### PR TITLE
fix: make timing test more resilient to CI variance

### DIFF
--- a/packages/computesdk/src/__tests__/utils.test.ts
+++ b/packages/computesdk/src/__tests__/utils.test.ts
@@ -104,7 +104,7 @@ describe('Utils', () => {
       const duration = Date.now() - start
       
       expect(result).toBe('success')
-      expect(duration).toBeGreaterThanOrEqual(50)
+      expect(duration).toBeGreaterThanOrEqual(45) // Allow for timing variance in CI
       expect(duration).toBeLessThan(150) // Should be around 50ms
     })
 


### PR DESCRIPTION
- Reduce timing assertion from 50ms to 45ms to account for CI timing variance
- Prevents flaky test failures in GitHub Actions environment