### PR TITLE
fix: add npm authentication to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
             echo "has_changesets=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Create .npmrc
+        if: steps.check.outputs.has_changesets == 'true'
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
       - name: Version and Publish to NPM
         if: steps.check.outputs.has_changesets == 'true'
         run: |


### PR DESCRIPTION
Fixes ENEEDAUTH error by creating .npmrc with NPM_TOKEN before publishing packages.