### PR TITLE
feat: add getInstance() method to replace instance property

### DIFF
--- a/packages/codesandbox/src/index.ts
+++ b/packages/codesandbox/src/index.ts
@@ -312,7 +312,13 @@ export const codesandbox = createProvider<CodesandboxSandbox, CodesandboxConfig>
           const client = await sandbox.connect();
           await client.fs.remove(path);
         }
-      }
+      },
+
+      // Provider-specific typed getInstance method
+      getInstance: (sandbox: CodesandboxSandbox): CodesandboxSandbox => {
+        return sandbox;
+      },
+
     }
   }
 });

--- a/packages/computesdk/src/__tests__/test-utils.ts
+++ b/packages/computesdk/src/__tests__/test-utils.ts
@@ -13,7 +13,11 @@ import type { Provider, Sandbox, ExecutionResult, SandboxInfo, FileEntry } from 
 export class MockSandbox implements Sandbox {
   readonly sandboxId = `mock-sandbox-${Math.random().toString(36).substr(2, 9)}`
   readonly provider = 'mock'
-  readonly instance = {}  // Mock native instance
+  private _mockInstance = {}  // Mock native instance
+
+  getInstance<T = unknown>(): T {
+    return this._mockInstance as T
+  }
 
   async runCode(code: string): Promise<ExecutionResult> {
     return {

--- a/packages/computesdk/src/factory.ts
+++ b/packages/computesdk/src/factory.ts
@@ -227,7 +227,6 @@ class SupportedFileSystem<TSandbox> implements SandboxFileSystem {
 class GeneratedSandbox<TSandbox = any> implements Sandbox {
   readonly sandboxId: string;
   readonly provider: string;
-  readonly instance: TSandbox;
   readonly filesystem: SandboxFileSystem;
 
   constructor(
@@ -241,7 +240,6 @@ class GeneratedSandbox<TSandbox = any> implements Sandbox {
   ) {
     this.sandboxId = sandboxId;
     this.provider = providerName;
-    this.instance = sandbox;
 
     // Auto-detect filesystem support
     if (methods.filesystem) {
@@ -249,6 +247,10 @@ class GeneratedSandbox<TSandbox = any> implements Sandbox {
     } else {
       this.filesystem = new UnsupportedFileSystem(providerName);
     }
+  }
+
+  getInstance<T = TSandbox>(): T {
+    return this.sandbox as unknown as T;
   }
 
   async runCode(code: string, runtime?: Runtime): Promise<ExecutionResult> {

--- a/packages/computesdk/src/factory.ts
+++ b/packages/computesdk/src/factory.ts
@@ -33,6 +33,9 @@ export interface SandboxMethods<TSandbox = any, TConfig = any> {
   getInfo: (sandbox: TSandbox) => Promise<SandboxInfo>;
   getUrl: (sandbox: TSandbox, options: { port: number; protocol?: string }) => Promise<string>;
   
+  // Optional provider-specific typed getInstance method
+  getInstance?: (sandbox: TSandbox) => TSandbox;
+  
   // Optional filesystem methods
   filesystem?: {
     readFile: (sandbox: TSandbox, path: string, runCommand: (sandbox: TSandbox, command: string, args?: string[]) => Promise<ExecutionResult>) => Promise<string>;
@@ -250,6 +253,11 @@ class GeneratedSandbox<TSandbox = any> implements Sandbox {
   }
 
   getInstance<T = TSandbox>(): T {
+    // Use provider-specific typed getInstance if available
+    if (this.methods.getInstance) {
+      return this.methods.getInstance(this.sandbox) as unknown as T;
+    }
+    // Fallback to generic casting
     return this.sandbox as unknown as T;
   }
 

--- a/packages/computesdk/src/types/sandbox.ts
+++ b/packages/computesdk/src/types/sandbox.ts
@@ -152,8 +152,6 @@ export interface Sandbox {
   readonly sandboxId: string;
   /** Provider that created this sandbox */
   readonly provider: string;
-  /** Access to the native provider sandbox instance */
-  readonly instance: unknown;
 
   /** Execute code in the sandbox */
   runCode(code: string, runtime?: Runtime): Promise<ExecutionResult>;
@@ -165,6 +163,8 @@ export interface Sandbox {
   getUrl(options: { port: number; protocol?: string }): Promise<string>;
   /** Get the provider instance that created this sandbox */
   getProvider(): Provider;
+  /** Get the native provider sandbox instance with proper typing */
+  getInstance<T = unknown>(): T;
   /** Kill the sandbox */
   kill(): Promise<void>;
   /** Destroy the sandbox and clean up resources */

--- a/packages/daytona/src/index.ts
+++ b/packages/daytona/src/index.ts
@@ -364,9 +364,15 @@ export const daytona = createProvider<DaytonaSandbox, DaytonaConfig>({
             throw new Error(`Failed to remove ${path}: ${error instanceof Error ? error.message : String(error)}`);
           }
         }
-      }
+      },
+
+      // Provider-specific typed getInstance method
+      getInstance: (sandbox: DaytonaSandbox): DaytonaSandbox => {
+        return sandbox;
+      },
 
       // Terminal operations not implemented - Daytona session API needs verification
+
     }
   }
 });

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -7,9 +7,9 @@
 
 import { Sandbox as E2BSandbox } from '@e2b/code-interpreter';
 import { createProvider } from 'computesdk';
-import type { 
-  ExecutionResult, 
-  SandboxInfo, 
+import type {
+  ExecutionResult,
+  SandboxInfo,
   Runtime,
   CreateSandboxOptions,
   FileEntry
@@ -152,29 +152,29 @@ export const e2b = createProvider<E2BSandbox, E2BConfig>({
         const startTime = Date.now();
 
         try {
-          
+
           // Auto-detect runtime if not specified
           const effectiveRuntime = runtime || (
             // Strong Python indicators
-            code.includes('print(') || 
-            code.includes('import ') ||
-            code.includes('def ') ||
-            code.includes('sys.') ||
-            code.includes('json.') ||
-            code.includes('__') ||
-            code.includes('f"') ||
-            code.includes("f'")
+            code.includes('print(') ||
+              code.includes('import ') ||
+              code.includes('def ') ||
+              code.includes('sys.') ||
+              code.includes('json.') ||
+              code.includes('__') ||
+              code.includes('f"') ||
+              code.includes("f'")
               ? 'python'
               // Default to Node.js for all other cases (including ambiguous)
               : 'node'
           );
-          
+
           // Use runCommand for consistent execution across all providers
           let result;
-          
+
           // Use base64 encoding for both runtimes for reliability and consistency
           const encoded = Buffer.from(code).toString('base64');
-          
+
           if (effectiveRuntime === 'python') {
             result = await sandbox.commands.run(`echo "${encoded}" | base64 -d | python3`);
           } else {
@@ -184,10 +184,10 @@ export const e2b = createProvider<E2BSandbox, E2BConfig>({
           // Check for syntax errors and throw them (similar to Vercel behavior)
           if (result.exitCode !== 0 && result.stderr) {
             // Check for common syntax error patterns
-            if (result.stderr.includes('SyntaxError') || 
-                result.stderr.includes('invalid syntax') ||
-                result.stderr.includes('Unexpected token') ||
-                result.stderr.includes('Unexpected identifier')) {
+            if (result.stderr.includes('SyntaxError') ||
+              result.stderr.includes('invalid syntax') ||
+              result.stderr.includes('Unexpected token') ||
+              result.stderr.includes('Unexpected identifier')) {
               throw new Error(`Syntax error: ${result.stderr.trim()}`);
             }
           }
@@ -205,7 +205,7 @@ export const e2b = createProvider<E2BSandbox, E2BConfig>({
           if (error instanceof Error && error.message === 'exit status 1') {
             const actualStderr = (error as any)?.result?.stderr || '';
             const isSyntaxError = actualStderr.includes('SyntaxError');
-            
+
             if (isSyntaxError) {
               // For syntax errors, throw
               const syntaxErrorLine = actualStderr.split('\n').find((line: string) => line.includes('SyntaxError')) || 'SyntaxError: Invalid syntax in code';
@@ -222,7 +222,7 @@ export const e2b = createProvider<E2BSandbox, E2BConfig>({
               };
             }
           }
-          
+
           // Re-throw syntax errors
           if (error instanceof Error && error.message.includes('Syntax error')) {
             throw error;

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -326,6 +326,10 @@ export const e2b = createProvider<E2BSandbox, E2BConfig>({
         }
       },
 
+      // Provider-specific typed getInstance method
+      getInstance: (sandbox: E2BSandbox): E2BSandbox => {
+        return sandbox;
+      },
 
     }
   }

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -531,7 +531,13 @@ export const modal = createProvider<ModalSandbox, ModalConfig>({
             throw new Error(`Failed to remove ${path}: ${error instanceof Error ? error.message : String(error)}`);
           }
         }
-      }
+      },
+
+      // Provider-specific typed getInstance method
+      getInstance: (sandbox: ModalSandbox): ModalSandbox => {
+        return sandbox;
+      },
+
     }
   }
 });

--- a/packages/test-utils/src/provider-test-suite.ts
+++ b/packages/test-utils/src/provider-test-suite.ts
@@ -240,7 +240,7 @@ function createMockSandbox(config: ProviderTestConfig): Sandbox {
   return {
     sandboxId: 'mock-sandbox-123',
     provider: providerName,
-    instance: {}, // Mock native instance
+    getInstance: <T = any>(): T => ({} as T), // Mock native instance getter
     
     runCode: async (code: string, runtime?: string): Promise<ExecutionResult> => {
       // Simulate realistic code execution

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -328,6 +328,12 @@ export const vercel = createProvider<VercelSandbox, VercelConfig>({
           );
         }
       },
+
+      // Provider-specific typed getInstance method
+      getInstance: (sandbox: VercelSandbox): VercelSandbox => {
+        return sandbox;
+      },
+
     }
   }
 });


### PR DESCRIPTION
- Add getInstance<T>() method to Sandbox interface with proper type inference
- Remove readonly instance property to eliminate casting requirement
- Update factory implementation to provide type-safe native instance access
- Users no longer need to import provider-specific types or use casting
- Factory automatically infers correct provider instance type (E2BSandbox, etc.)
- All tests passing with cleaner, more intuitive API