### PR TITLE
fix(railway): use proper UUID-based templateId and templateServiceId

### DIFF
--- a/.changeset/railway-template-fix.md
+++ b/.changeset/railway-template-fix.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/gateway": patch
+---
+
+fix(railway): use proper UUID-based templateId and templateServiceId for service creation

--- a/packages/gateway/src/railway.ts
+++ b/packages/gateway/src/railway.ts
@@ -65,6 +65,16 @@ const GRAPHQL_QUERIES = {
   DELETE_SERVICE: `mutation ServiceDelete($id: String!) { serviceDelete(id: $id) }`
 };
 
+/**
+ * ComputeSDK Sandbox template configuration from Railway
+ * Template code: "sandbox"
+ * Queried via: query template($code: String!) { template(code: $code) { id serializedConfig } }
+ */
+const COMPUTESDK_TEMPLATE = {
+  templateId: 'b6293629-5a34-496b-860f-4d4ab4251e0d',
+  serviceId: '41cf086b-2117-4dd7-bd65-7fd12a1fd551',
+};
+
 const handleGraphQLErrors = (data: any) => {
   if (data.errors) {
     throw new Error(`Railway GraphQL error: ${data.errors.map((e: any) => e.message).join(', ')}`);
@@ -130,7 +140,8 @@ export const railway = defineInfraProvider<RailwayInstance, RailwayConfig>({
           variables: {
             input: {
               projectId,
-              environmentId,
+              templateId: COMPUTESDK_TEMPLATE.templateId,
+              templateServiceId: COMPUTESDK_TEMPLATE.serviceId,
               source: {
                 image: options?.image ?? 'computesdk/compute:latest',
               },


### PR DESCRIPTION
## Summary

- Add `COMPUTESDK_TEMPLATE` constant with proper UUID values for `templateId` and `templateServiceId`
- Use these UUIDs in the `ServiceCreate` mutation to preserve template association

## Context

Railway API changed after OAuth updates - the string `'sandbox'` for `templateServiceId` was being ignored/is no longer valid. Per Railway support, the proper approach is to use the actual UUID values:

- `templateId`: `b6293629-5a34-496b-860f-4d4ab4251e0d`
- `templateServiceId`: `41cf086b-2117-4dd7-bd65-7fd12a1fd551`

These were obtained by querying:
```graphql
query template($code: String!) {
  template(code: $code) {
    id
    serializedConfig
  }
}
```

This ensures ComputeSDK gets credit for template deployments while still allowing custom image overrides.