### PR TITLE
feat: add @computesdk/webcontainer package

### DIFF
--- a/packages/webcontainer/package.json
+++ b/packages/webcontainer/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@computesdk/webcontainer",
+  "version": "1.0.0",
+  "description": "WebContainer-compatible API for remote computesdk sandboxes - drop-in replacement that runs on remote infrastructure",
+  "author": "Garrison",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "keywords": [
+    "computesdk",
+    "webcontainer",
+    "webcontainers",
+    "sandbox",
+    "code-execution",
+    "nodejs",
+    "browser",
+    "cloud",
+    "compute",
+    "remote-execution"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/webcontainer"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  }
+}

--- a/packages/webcontainer/src/filesystem.ts
+++ b/packages/webcontainer/src/filesystem.ts
@@ -1,0 +1,224 @@
+/**
+ * FileSystemAPI adapter for computesdk
+ * 
+ * Provides a WebContainer-compatible filesystem interface that wraps
+ * the computesdk Sandbox filesystem operations.
+ */
+
+import type { Sandbox } from 'computesdk';
+import type {
+  FileSystemAPI,
+  FileSystemTree,
+  FileNode,
+  SymlinkNode,
+  DirectoryNode,
+  DirEnt,
+  MkdirOptions,
+  ReaddirOptions,
+  RmOptions,
+  WatchOptions,
+  WatchListener,
+  Watcher,
+  BufferEncoding,
+} from './types';
+
+/**
+ * Implementation of DirEnt for readdir with withFileTypes
+ */
+class DirEntImpl implements DirEnt<string> {
+  constructor(
+    public readonly name: string,
+    private readonly _isDirectory: boolean
+  ) {}
+
+  isDirectory(): boolean {
+    return this._isDirectory;
+  }
+
+  isFile(): boolean {
+    return !this._isDirectory;
+  }
+}
+
+/**
+ * Creates a FileSystemAPI implementation that wraps a computesdk Sandbox
+ */
+export function createFileSystemAPI(sandbox: Sandbox, workdir: string): FileSystemAPI {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  // Track active watchers for cleanup
+  const watchers = new Map<string, { destroy: () => void }>();
+
+  /**
+   * Resolve path relative to workdir
+   */
+  function resolvePath(path: string): string {
+    if (path.startsWith('/')) {
+      return path;
+    }
+    return `${workdir}/${path}`.replace(/\/+/g, '/');
+  }
+
+  /**
+   * Recursively mount a FileSystemTree
+   */
+  async function mountTree(tree: FileSystemTree, basePath: string): Promise<void> {
+    for (const [name, node] of Object.entries(tree)) {
+      const fullPath = `${basePath}/${name}`.replace(/\/+/g, '/');
+
+      if ('file' in node) {
+        const fileNode = node as FileNode | SymlinkNode;
+        if ('contents' in fileNode.file) {
+          // Regular file
+          const contents = fileNode.file.contents;
+          const content = typeof contents === 'string' 
+            ? contents 
+            : decoder.decode(contents);
+          await sandbox.filesystem.writeFile(fullPath, content);
+        } else if ('symlink' in fileNode.file) {
+          // Symlink - create via command since filesystem API doesn't have symlink
+          const target = (fileNode as SymlinkNode).file.symlink;
+          await sandbox.runCommand(`ln -s "${target}" "${fullPath}"`);
+        }
+      } else if ('directory' in node) {
+        // Directory
+        const dirNode = node as DirectoryNode;
+        await sandbox.filesystem.mkdir(fullPath);
+        await mountTree(dirNode.directory, fullPath);
+      }
+    }
+  }
+
+  const fs: FileSystemAPI = {
+    async mkdir(path: string, options?: MkdirOptions): Promise<void> {
+      const resolvedPath = resolvePath(path);
+      if (options?.recursive) {
+        await sandbox.runCommand(`mkdir -p "${resolvedPath}"`);
+      } else {
+        await sandbox.filesystem.mkdir(resolvedPath);
+      }
+    },
+
+    async readdir(path: string, options?: ReaddirOptions): Promise<string[] | DirEnt<string>[]> {
+      const resolvedPath = resolvePath(path);
+      const entries = await sandbox.filesystem.readdir(resolvedPath);
+
+      if (options?.withFileTypes) {
+        return entries.map(entry => new DirEntImpl(entry.name, entry.type === 'directory'));
+      }
+
+      // Just return names
+      return entries.map(entry => entry.name);
+    },
+
+    async readFile(path: string, encoding?: BufferEncoding | null): Promise<Uint8Array | string> {
+      const resolvedPath = resolvePath(path);
+      const content = await sandbox.filesystem.readFile(resolvedPath);
+
+      if (encoding === null || encoding === undefined) {
+        // Return as Uint8Array
+        return encoder.encode(content);
+      }
+
+      // Return as string (content is already a string from sandbox)
+      return content;
+    },
+
+    async rename(oldPath: string, newPath: string): Promise<void> {
+      const resolvedOldPath = resolvePath(oldPath);
+      const resolvedNewPath = resolvePath(newPath);
+      await sandbox.runCommand(`mv "${resolvedOldPath}" "${resolvedNewPath}"`);
+    },
+
+    async rm(path: string, options?: RmOptions): Promise<void> {
+      const resolvedPath = resolvePath(path);
+      let cmd = 'rm';
+      
+      if (options?.force) {
+        cmd += ' -f';
+      }
+      if (options?.recursive) {
+        cmd += ' -r';
+      }
+      
+      await sandbox.runCommand(`${cmd} "${resolvedPath}"`);
+    },
+
+    async writeFile(
+      path: string, 
+      data: string | Uint8Array, 
+      options?: string | { encoding?: BufferEncoding | null } | null
+    ): Promise<void> {
+      const resolvedPath = resolvePath(path);
+      const content = typeof data === 'string' ? data : decoder.decode(data);
+      await sandbox.filesystem.writeFile(resolvedPath, content);
+    },
+
+    watch(
+      path: string, 
+      optionsOrListener?: WatchOptions | WatchListener, 
+      maybeListener?: WatchListener
+    ): Watcher {
+      const resolvedPath = resolvePath(path);
+      let options: WatchOptions = {};
+      let listener: WatchListener;
+
+      if (typeof optionsOrListener === 'function') {
+        listener = optionsOrListener;
+      } else {
+        options = optionsOrListener || {};
+        listener = maybeListener!;
+      }
+
+      // Create watcher using computesdk watcher API
+      let watcherInstance: { destroy: () => void } | null = null;
+      let closed = false;
+
+      // Start the watcher asynchronously
+      (async () => {
+        try {
+          const ignored = options.recursive ? [] : ['*/**']; // If not recursive, ignore subdirs
+          const watcher = await sandbox.watcher.create(resolvedPath, { 
+            ignored,
+            includeContent: false 
+          });
+
+          if (closed) {
+            await watcher.destroy();
+            return;
+          }
+
+          watcherInstance = watcher;
+          watchers.set(resolvedPath, watcher);
+
+          // Set up event listener
+          watcher.on('change', (event) => {
+            // Map computesdk events to WebContainer events
+            const wcEvent = event.event === 'create' || event.event === 'delete' 
+              ? 'rename' 
+              : 'change';
+            listener(wcEvent, event.path);
+          });
+        } catch (error) {
+          console.error('Failed to create watcher:', error);
+        }
+      })();
+
+      return {
+        close() {
+          closed = true;
+          if (watcherInstance) {
+            watcherInstance.destroy();
+            watchers.delete(resolvedPath);
+          }
+        }
+      };
+    }
+  };
+
+  // Add internal mount function for use by WebContainer class
+  (fs as any)._mount = mountTree;
+
+  return fs;
+}

--- a/packages/webcontainer/src/index.ts
+++ b/packages/webcontainer/src/index.ts
@@ -100,7 +100,7 @@ export type {
 
 export { PreviewMessageType } from './types';
 
-// Utility for iframe preview reloading (no-op for remote)
+// Utility for iframe preview reloading
 export async function reloadPreview(
   preview: HTMLIFrameElement, 
   hardRefreshTimeout?: number
@@ -112,17 +112,8 @@ export async function reloadPreview(
   preview.src = src;
 }
 
-// API key configuration (no-op for remote - auth is handled differently)
-export function configureAPIKey(key: string): void {
-  // No-op for remote sandboxes
-  // Auth is handled via the ConnectOptions.token
-  console.warn(
-    'configureAPIKey is not used for remote sandboxes. ' +
-    'Pass your token via ConnectOptions.token in WebContainer.connect()'
-  );
-}
-
-// Note: WebContainer's `auth` namespace is not exported.
-// It's specific to StackBlitz OAuth for private npm packages.
+// Note: WebContainer's `auth` namespace and `configureAPIKey` are not exported.
+// - `auth` is specific to StackBlitz OAuth for private npm packages
+// - `configureAPIKey` is for WebContainer commercial licensing
 // For computesdk, authentication is handled via the `token` option in boot().
 // Private npm packages should be configured via .npmrc or env vars on the sandbox.

--- a/packages/webcontainer/src/index.ts
+++ b/packages/webcontainer/src/index.ts
@@ -1,0 +1,155 @@
+/**
+ * @computesdk/webcontainer
+ * 
+ * A WebContainer-compatible API for remote computesdk sandboxes.
+ * 
+ * This package provides a drop-in replacement for the WebContainer API that works
+ * with remote sandboxes instead of in-browser execution. This allows existing
+ * WebContainer-based applications to run on more powerful remote infrastructure.
+ * 
+ * The API is designed to be as close to the original WebContainer API as possible,
+ * so existing code should work with minimal changes.
+ * 
+ * @example
+ * ```typescript
+ * import { WebContainer } from '@computesdk/webcontainer';
+ * 
+ * // Boot connects to a remote sandbox (auto-detects URL from query params or localStorage)
+ * const container = await WebContainer.boot();
+ * 
+ * // Or with explicit connection info
+ * const container = await WebContainer.boot({
+ *   sandboxUrl: 'https://sandbox-123.sandbox.computesdk.com',
+ *   token: 'your-session-token',
+ * });
+ * 
+ * // Use the familiar WebContainer API
+ * await container.mount({
+ *   'package.json': { file: { contents: '{"name": "my-app"}' } },
+ *   'index.js': { file: { contents: 'console.log("Hello!")' } },
+ * });
+ * 
+ * const process = await container.spawn('node', ['index.js']);
+ * process.output.pipeTo(new WritableStream({
+ *   write(data) { console.log(data); }
+ * }));
+ * 
+ * await process.exit;
+ * container.teardown();
+ * ```
+ * 
+ * ## Connection Methods
+ * 
+ * The sandbox URL and token can be provided in several ways:
+ * 
+ * 1. **Explicit options**: Pass `sandboxUrl` and `token` to `boot()`
+ * 2. **URL parameters**: Include `?sandbox_url=...&session_token=...` in the page URL
+ * 3. **localStorage**: Set `sandbox_url` and `session_token` keys
+ * 
+ * URL parameters are automatically cleaned from the URL and stored in localStorage.
+ * 
+ * @packageDocumentation
+ */
+
+// Main class
+export { WebContainer } from './webcontainer';
+
+// Types
+export type {
+  // File system types
+  FileSystemAPI,
+  FileSystemTree,
+  FileNode,
+  SymlinkNode,
+  DirectoryNode,
+  DirEnt,
+  BufferEncoding,
+  MkdirOptions,
+  ReaddirOptions,
+  RmOptions,
+  WatchOptions,
+  WatchListener,
+  Watcher,
+  
+  // Process types
+  WebContainerProcess,
+  SpawnOptions,
+  
+  // Export types
+  ExportOptions,
+  
+  // Preview types
+  PreviewMessage,
+  PreviewScriptOptions,
+  BasePreviewMessage,
+  UncaughtExceptionMessage,
+  UnhandledRejectionMessage,
+  ConsoleErrorMessage,
+  
+  // Event listeners
+  PortListener,
+  ErrorListener,
+  ServerReadyListener,
+  PreviewMessageListener,
+  
+  // Boot/Connect options
+  BootOptions,
+  ConnectOptions,
+  MountOptions,
+  
+  // Auth types
+  AuthInitOptions,
+  AuthFailedError,
+  AuthInitResult,
+} from './types';
+
+export { PreviewMessageType } from './types';
+
+// Utility for iframe preview reloading (no-op for remote)
+export async function reloadPreview(
+  preview: HTMLIFrameElement, 
+  hardRefreshTimeout?: number
+): Promise<void> {
+  // For remote sandboxes, we just reload the iframe src
+  const src = preview.src;
+  preview.src = '';
+  await new Promise(resolve => setTimeout(resolve, hardRefreshTimeout || 200));
+  preview.src = src;
+}
+
+// API key configuration (no-op for remote - auth is handled differently)
+export function configureAPIKey(key: string): void {
+  // No-op for remote sandboxes
+  // Auth is handled via the ConnectOptions.token
+  console.warn(
+    'configureAPIKey is not used for remote sandboxes. ' +
+    'Pass your token via ConnectOptions.token in WebContainer.connect()'
+  );
+}
+
+// Auth namespace (not fully supported for remote sandboxes)
+export const auth = {
+  init(options: { clientId: string; scope: string; editorOrigin?: string }) {
+    console.warn('auth.init is not supported for remote sandboxes');
+    return { status: 'authorized' as const };
+  },
+  
+  startAuthFlow(options?: { popup?: boolean }) {
+    throw new Error('auth.startAuthFlow is not supported for remote sandboxes');
+  },
+  
+  async loggedIn(): Promise<void> {
+    // Always resolves immediately for remote sandboxes
+    return Promise.resolve();
+  },
+  
+  async logout(options?: { ignoreRevokeError?: boolean }): Promise<void> {
+    // No-op for remote sandboxes
+    console.warn('auth.logout is not supported for remote sandboxes');
+  },
+  
+  on(event: 'logged-out' | 'auth-failed', listener: () => void): () => void {
+    // Return no-op unsubscribe
+    return () => {};
+  }
+};

--- a/packages/webcontainer/src/index.ts
+++ b/packages/webcontainer/src/index.ts
@@ -96,11 +96,6 @@ export type {
   BootOptions,
   ConnectOptions,
   MountOptions,
-  
-  // Auth types
-  AuthInitOptions,
-  AuthFailedError,
-  AuthInitResult,
 } from './types';
 
 export { PreviewMessageType } from './types';
@@ -127,29 +122,7 @@ export function configureAPIKey(key: string): void {
   );
 }
 
-// Auth namespace (not fully supported for remote sandboxes)
-export const auth = {
-  init(options: { clientId: string; scope: string; editorOrigin?: string }) {
-    console.warn('auth.init is not supported for remote sandboxes');
-    return { status: 'authorized' as const };
-  },
-  
-  startAuthFlow(options?: { popup?: boolean }) {
-    throw new Error('auth.startAuthFlow is not supported for remote sandboxes');
-  },
-  
-  async loggedIn(): Promise<void> {
-    // Always resolves immediately for remote sandboxes
-    return Promise.resolve();
-  },
-  
-  async logout(options?: { ignoreRevokeError?: boolean }): Promise<void> {
-    // No-op for remote sandboxes
-    console.warn('auth.logout is not supported for remote sandboxes');
-  },
-  
-  on(event: 'logged-out' | 'auth-failed', listener: () => void): () => void {
-    // Return no-op unsubscribe
-    return () => {};
-  }
-};
+// Note: WebContainer's `auth` namespace is not exported.
+// It's specific to StackBlitz OAuth for private npm packages.
+// For computesdk, authentication is handled via the `token` option in boot().
+// Private npm packages should be configured via .npmrc or env vars on the sandbox.

--- a/packages/webcontainer/src/process.ts
+++ b/packages/webcontainer/src/process.ts
@@ -1,0 +1,137 @@
+/**
+ * WebContainerProcess adapter for computesdk
+ * 
+ * Provides a WebContainer-compatible process interface that wraps
+ * computesdk terminal sessions.
+ */
+
+import type { Sandbox, TerminalInstance } from 'computesdk';
+import type { WebContainerProcess, SpawnOptions } from './types';
+
+/**
+ * Creates a WebContainerProcess from a computesdk terminal
+ */
+export function createWebContainerProcess(
+  terminal: TerminalInstance,
+  sandbox: Sandbox,
+  options?: SpawnOptions
+): WebContainerProcess {
+  let exitResolve: (code: number) => void;
+  let exitReject: (error: Error) => void;
+  
+  const exitPromise = new Promise<number>((resolve, reject) => {
+    exitResolve = resolve;
+    exitReject = reject;
+  });
+
+  // Create output stream
+  let outputController: ReadableStreamDefaultController<string> | null = null;
+  const outputStream = new ReadableStream<string>({
+    start(controller) {
+      outputController = controller;
+    },
+    cancel() {
+      outputController = null;
+    }
+  });
+
+  // Create input stream
+  const inputStream = new WritableStream<string>({
+    write(chunk) {
+      terminal.write(chunk);
+    }
+  });
+
+  // Set up terminal output handler if output is enabled (default: true)
+  if (options?.output !== false) {
+    terminal.on('output', (data: string) => {
+      if (outputController) {
+        outputController.enqueue(data);
+      }
+    });
+  }
+
+  // Track exit status
+  let killed = false;
+
+  // Handle terminal close/exit
+  terminal.on('exit', (code: number) => {
+    if (outputController) {
+      outputController.close();
+    }
+    exitResolve(code);
+  });
+
+  return {
+    exit: exitPromise,
+    input: inputStream,
+    output: outputStream,
+
+    kill() {
+      if (!killed) {
+        killed = true;
+        terminal.destroy().catch(() => {});
+        if (outputController) {
+          outputController.close();
+        }
+        exitResolve(137); // SIGKILL
+      }
+    },
+
+    resize(dimensions: { cols: number; rows: number }) {
+      terminal.resize(dimensions.cols, dimensions.rows);
+    }
+  };
+}
+
+/**
+ * Spawns a process in the sandbox and returns a WebContainerProcess
+ */
+export async function spawnProcess(
+  sandbox: Sandbox,
+  command: string,
+  args: string[] = [],
+  options?: SpawnOptions
+): Promise<WebContainerProcess> {
+  // Build the full command
+  const fullCommand = args.length > 0 
+    ? `${command} ${args.map(arg => {
+        // Quote arguments that contain spaces or special characters
+        if (/[\s"'\\$`!]/.test(arg)) {
+          return `"${arg.replace(/["\\$`!]/g, '\\$&')}"`;
+        }
+        return arg;
+      }).join(' ')}`
+    : command;
+
+  // Create a PTY terminal for the process
+  const terminal = await sandbox.terminal.create({
+    pty: true,
+    shell: '/bin/sh',
+    encoding: 'raw',
+  });
+
+  // Set terminal size if specified
+  if (options?.terminal) {
+    terminal.resize(options.terminal.cols, options.terminal.rows);
+  }
+
+  // Create the process wrapper
+  const process = createWebContainerProcess(terminal, sandbox, options);
+
+  // Execute the command
+  // We need to handle the command execution and capture the exit code
+  const envVars = options?.env 
+    ? Object.entries(options.env)
+        .map(([k, v]) => `export ${k}="${String(v).replace(/"/g, '\\"')}"`)
+        .join('; ') + '; '
+    : '';
+  
+  const cwdPrefix = options?.cwd ? `cd "${options.cwd}" && ` : '';
+  
+  // Write the command to execute and capture exit code
+  // Use a special exit handler to capture the exit code
+  terminal.write(`${envVars}${cwdPrefix}${fullCommand}; exit $?\n`);
+
+  return process;
+}

--- a/packages/webcontainer/src/types.ts
+++ b/packages/webcontainer/src/types.ts
@@ -1,0 +1,335 @@
+/**
+ * WebContainer-compatible types for computesdk
+ * 
+ * This module provides type definitions that mirror the WebContainer API,
+ * allowing code written for WebContainers to work with remote computesdk sandboxes.
+ * 
+ * @see https://webcontainers.io/api
+ */
+
+// ============================================================================
+// Buffer Encoding
+// ============================================================================
+
+export type BufferEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf-8'
+  | 'utf16le'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+
+// ============================================================================
+// File System Types
+// ============================================================================
+
+/**
+ * File node in the filesystem tree
+ */
+export interface FileNode {
+  file: {
+    contents: string | Uint8Array;
+  };
+}
+
+/**
+ * Symlink node in the filesystem tree
+ */
+export interface SymlinkNode {
+  file: {
+    symlink: string;
+  };
+}
+
+/**
+ * Directory node in the filesystem tree
+ */
+export interface DirectoryNode {
+  directory: FileSystemTree;
+}
+
+/**
+ * Tree structure representing files and directories
+ */
+export interface FileSystemTree {
+  [name: string]: FileNode | SymlinkNode | DirectoryNode;
+}
+
+/**
+ * Directory entry returned by readdir
+ */
+export interface DirEnt<T = string> {
+  name: T;
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+/**
+ * Options for mkdir
+ */
+export interface MkdirOptions {
+  recursive?: boolean;
+}
+
+/**
+ * Options for readdir
+ */
+export interface ReaddirOptions {
+  encoding?: BufferEncoding;
+  withFileTypes?: boolean;
+}
+
+/**
+ * Options for rm
+ */
+export interface RmOptions {
+  force?: boolean;
+  recursive?: boolean;
+}
+
+/**
+ * Options for watch
+ */
+export interface WatchOptions {
+  encoding?: BufferEncoding | null;
+  recursive?: boolean;
+}
+
+/**
+ * Watch listener callback
+ */
+export type WatchListener = (event: 'rename' | 'change', filename: string | Buffer) => void;
+
+/**
+ * File system watcher
+ */
+export interface Watcher {
+  close(): void;
+}
+
+/**
+ * File system API matching WebContainer's fs interface
+ */
+export interface FileSystemAPI {
+  mkdir(path: string, options?: MkdirOptions): Promise<void>;
+  readdir(path: string, options?: ReaddirOptions): Promise<string[] | DirEnt<string>[]>;
+  readFile(path: string, encoding?: BufferEncoding | null): Promise<Uint8Array | string>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  rm(path: string, options?: RmOptions): Promise<void>;
+  writeFile(path: string, data: string | Uint8Array, options?: string | { encoding?: BufferEncoding | null } | null): Promise<void>;
+  watch(path: string, options: WatchOptions, listener: WatchListener): Watcher;
+  watch(path: string, listener: WatchListener): Watcher;
+}
+
+// ============================================================================
+// Process Types
+// ============================================================================
+
+/**
+ * Options for spawning a process
+ */
+export interface SpawnOptions {
+  /** Current working directory for the process */
+  cwd?: string;
+  /** Environment variables for the process */
+  env?: Record<string, string | number | boolean>;
+  /** Whether to receive output (default: true) */
+  output?: boolean;
+  /** Terminal size for PTY mode */
+  terminal?: { cols: number; rows: number };
+}
+
+/**
+ * A running process in the WebContainer
+ */
+export interface WebContainerProcess {
+  /** Promise that resolves with the exit code */
+  exit: Promise<number>;
+  /** Writable stream for process input */
+  input: WritableStream<string>;
+  /** Readable stream for process output */
+  output: ReadableStream<string>;
+  /** Kill the process */
+  kill(): void;
+  /** Resize the terminal */
+  resize(dimensions: { cols: number; rows: number }): void;
+}
+
+// ============================================================================
+// Export Types
+// ============================================================================
+
+/**
+ * Options for exporting the filesystem
+ */
+export interface ExportOptions {
+  /** Export format */
+  format?: 'json' | 'binary' | 'zip';
+  /** Glob patterns to include from excluded folders */
+  includes?: string[];
+  /** Glob patterns to exclude */
+  excludes?: string[];
+}
+
+// ============================================================================
+// Preview Types
+// ============================================================================
+
+export enum PreviewMessageType {
+  UncaughtException = 'uncaught-exception',
+  UnhandledRejection = 'unhandled-rejection',
+  ConsoleError = 'console-error',
+}
+
+export interface BasePreviewMessage {
+  previewId: string;
+  port: number;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export interface UncaughtExceptionMessage {
+  type: PreviewMessageType.UncaughtException;
+  message: string;
+  stack: string | undefined;
+}
+
+export interface UnhandledRejectionMessage {
+  type: PreviewMessageType.UnhandledRejection;
+  message: string;
+  stack: string | undefined;
+}
+
+export interface ConsoleErrorMessage {
+  type: PreviewMessageType.ConsoleError;
+  args: any[];
+  stack: string;
+}
+
+export type PreviewMessage = (UncaughtExceptionMessage | UnhandledRejectionMessage | ConsoleErrorMessage) & BasePreviewMessage;
+
+/**
+ * Options for preview scripts
+ */
+export interface PreviewScriptOptions {
+  type?: 'module' | 'importmap';
+  defer?: boolean;
+  async?: boolean;
+}
+
+// ============================================================================
+// Event Listeners
+// ============================================================================
+
+/**
+ * Listener for port events
+ */
+export type PortListener = (port: number, type: 'open' | 'close', url: string) => void;
+
+/**
+ * Listener for error events
+ */
+export type ErrorListener = (error: { message: string }) => void;
+
+/**
+ * Listener for server-ready events
+ */
+export type ServerReadyListener = (port: number, url: string) => void;
+
+/**
+ * Listener for preview message events
+ */
+export type PreviewMessageListener = (message: PreviewMessage) => void;
+
+// ============================================================================
+// Boot/Connect Options
+// ============================================================================
+
+/**
+ * Options for booting a WebContainer
+ * 
+ * For remote sandboxes, extends the standard WebContainer BootOptions
+ * with connection information. The sandbox URL and token can be provided
+ * explicitly or auto-detected from URL parameters / localStorage.
+ * 
+ * @see https://webcontainers.io/api#boot-options
+ */
+export interface BootOptions {
+  /** COEP header configuration (ignored for remote sandboxes) */
+  coep?: 'require-corp' | 'credentialless' | 'none';
+  /** Working directory name */
+  workdirName?: string;
+  /** Forward preview errors (ignored for remote sandboxes) */
+  forwardPreviewErrors?: boolean | 'exceptions-only';
+  
+  // Remote sandbox connection options (computesdk extension)
+  /** Sandbox URL - auto-detected from URL params or localStorage if not provided */
+  sandboxUrl?: string;
+  /** Authentication token - auto-detected from URL params or localStorage if not provided */
+  token?: string;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** WebSocket protocol */
+  protocol?: 'json' | 'binary';
+}
+
+/**
+ * Options for connecting to a remote sandbox (computesdk extension)
+ */
+export interface ConnectOptions {
+  /** Sandbox URL (e.g., https://sandbox-123.sandbox.computesdk.com) */
+  sandboxUrl: string;
+  /** Sandbox ID */
+  sandboxId: string;
+  /** Provider name (e.g., 'e2b', 'gateway') */
+  provider: string;
+  /** Authentication token */
+  token?: string;
+  /** Additional headers */
+  headers?: Record<string, string>;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** WebSocket implementation (for Node.js) */
+  WebSocket?: new (url: string) => WebSocket;
+  /** WebSocket protocol */
+  protocol?: 'json' | 'binary';
+  /** Working directory name */
+  workdirName?: string;
+}
+
+/**
+ * Options that can be passed to mount()
+ */
+export interface MountOptions {
+  /** Mount point path */
+  mountPoint?: string;
+}
+
+// ============================================================================
+// Auth Types (for private package support)
+// ============================================================================
+
+export interface AuthInitOptions {
+  /** StackBlitz origin (default: https://stackblitz.com) */
+  editorOrigin?: string;
+  /** OAuth client ID */
+  clientId: string;
+  /** OAuth scope */
+  scope: string;
+}
+
+export interface AuthFailedError {
+  status: 'auth-failed';
+  error: string;
+  description: string;
+}
+
+export type AuthInitResult = 
+  | { status: 'need-auth' | 'authorized' }
+  | AuthFailedError;

--- a/packages/webcontainer/src/webcontainer.ts
+++ b/packages/webcontainer/src/webcontainer.ts
@@ -1,0 +1,626 @@
+/**
+ * WebContainer adapter for computesdk
+ * 
+ * Provides a WebContainer-compatible API that works with remote computesdk sandboxes.
+ * This allows existing WebContainer code to run on remote sandboxes with minimal changes.
+ * 
+ * Key differences from local WebContainers:
+ * - `boot()` is replaced by `connect()` for remote sandboxes
+ * - The boot happens on a remote machine, so `connect()` just establishes the connection
+ * - All operations are performed via HTTP/WebSocket to the remote sandbox
+ * 
+ * @example
+ * ```typescript
+ * import { WebContainer } from '@computesdk/webcontainer';
+ * 
+ * // Connect to a remote sandbox (instead of boot)
+ * const container = await WebContainer.connect({
+ *   sandboxUrl: 'https://sandbox-123.sandbox.computesdk.com',
+ *   sandboxId: 'sandbox-123',
+ *   provider: 'gateway',
+ *   token: 'your-token',
+ * });
+ * 
+ * // Use the same API as WebContainers
+ * await container.mount({
+ *   'index.js': { file: { contents: 'console.log("Hello!")' } },
+ * });
+ * 
+ * const process = await container.spawn('node', ['index.js']);
+ * process.output.pipeTo(new WritableStream({
+ *   write(data) { console.log(data); }
+ * }));
+ * 
+ * const exitCode = await process.exit;
+ * ```
+ */
+
+import { Sandbox } from 'computesdk';
+import { createFileSystemAPI } from './filesystem';
+import { spawnProcess } from './process';
+import type {
+  FileSystemAPI,
+  FileSystemTree,
+  WebContainerProcess,
+  SpawnOptions,
+  BootOptions,
+  ConnectOptions,
+  MountOptions,
+  ExportOptions,
+  PortListener,
+  ErrorListener,
+  ServerReadyListener,
+  PreviewMessageListener,
+  PreviewScriptOptions,
+} from './types';
+
+type EventType = 'port' | 'error' | 'server-ready' | 'preview-message';
+type EventListener = PortListener | ErrorListener | ServerReadyListener | PreviewMessageListener;
+
+/**
+ * WebContainer-compatible interface for remote computesdk sandboxes
+ */
+export class WebContainer {
+  private _sandbox: Sandbox;
+  private _fs: FileSystemAPI;
+  private _workdir: string;
+  private _path: string;
+  private _eventListeners: Map<EventType, Set<EventListener>> = new Map();
+  private _signalService: any = null;
+  private _isDestroyed = false;
+
+  /**
+   * Private constructor - use WebContainer.connect() to create instances
+   */
+  private constructor(sandbox: Sandbox, workdir: string) {
+    this._sandbox = sandbox;
+    this._workdir = workdir;
+    this._path = '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
+    this._fs = createFileSystemAPI(sandbox, workdir);
+
+    // Initialize event listener maps
+    this._eventListeners.set('port', new Set());
+    this._eventListeners.set('error', new Set());
+    this._eventListeners.set('server-ready', new Set());
+    this._eventListeners.set('preview-message', new Set());
+  }
+
+  /**
+   * File system interface
+   */
+  get fs(): FileSystemAPI {
+    return this._fs;
+  }
+
+  /**
+   * Default PATH for spawned processes
+   */
+  get path(): string {
+    return this._path;
+  }
+
+  /**
+   * Working directory path
+   */
+  get workdir(): string {
+    return this._workdir;
+  }
+
+  /**
+   * Access to the underlying computesdk Sandbox (for advanced use cases)
+   */
+  get sandbox(): Sandbox {
+    return this._sandbox;
+  }
+
+  // ============================================================================
+  // Static Factory Methods
+  // ============================================================================
+
+  /** Singleton instance - only one WebContainer can be active at a time */
+  private static _instance: WebContainer | null = null;
+
+  /**
+   * Boot a WebContainer
+   * 
+   * For remote sandboxes, this connects to an existing sandbox rather than
+   * booting a new one. The sandbox URL and token can be:
+   * 1. Passed explicitly in options
+   * 2. Auto-detected from URL query parameters (?sandbox_url=...&session_token=...)
+   * 3. Read from localStorage (sandbox_url, session_token)
+   * 
+   * Only one WebContainer instance can be active at a time. Call `teardown()`
+   * before booting a new instance.
+   * 
+   * @param options - Boot options including optional connection details
+   * @returns A WebContainer instance connected to the remote sandbox
+   * 
+   * @example
+   * ```typescript
+   * // Auto-detect from URL/localStorage
+   * const container = await WebContainer.boot();
+   * 
+   * // Or explicit connection info
+   * const container = await WebContainer.boot({
+   *   sandboxUrl: 'https://sandbox-123.sandbox.computesdk.com',
+   *   token: 'your-session-token',
+   *   workdirName: 'my-project',
+   * });
+   * ```
+   */
+  static async boot(options: BootOptions = {}): Promise<WebContainer> {
+    if (WebContainer._instance) {
+      throw new Error(
+        'A WebContainer instance is already running. ' +
+        'Call teardown() before booting a new instance.'
+      );
+    }
+
+    // Auto-detect sandbox URL and token from URL params or localStorage
+    let sandboxUrl = options.sandboxUrl;
+    let token = options.token;
+
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      
+      // Check URL parameters first
+      const urlToken = params.get('session_token');
+      const urlSandboxUrl = params.get('sandbox_url');
+      
+      // Clean up URL if params were found
+      if (urlToken || urlSandboxUrl) {
+        if (urlToken) {
+          params.delete('session_token');
+          localStorage.setItem('session_token', urlToken);
+          token = token || urlToken;
+        }
+        if (urlSandboxUrl) {
+          params.delete('sandbox_url');
+          localStorage.setItem('sandbox_url', urlSandboxUrl);
+          sandboxUrl = sandboxUrl || urlSandboxUrl;
+        }
+        
+        // Update URL without the params
+        const search = params.toString() ? `?${params.toString()}` : '';
+        const newUrl = `${window.location.pathname}${search}${window.location.hash}`;
+        window.history.replaceState({}, '', newUrl);
+      }
+      
+      // Fall back to localStorage
+      sandboxUrl = sandboxUrl || localStorage.getItem('sandbox_url') || undefined;
+      token = token || localStorage.getItem('session_token') || undefined;
+    }
+
+    if (!sandboxUrl) {
+      throw new Error(
+        'No sandbox URL provided. Either:\n' +
+        '1. Pass sandboxUrl in boot options\n' +
+        '2. Include ?sandbox_url=... in the page URL\n' +
+        '3. Set sandbox_url in localStorage'
+      );
+    }
+
+    // Extract sandbox ID from URL (e.g., https://sandbox-123.sandbox.computesdk.com)
+    const sandboxId = sandboxUrl.match(/\/\/([\w-]+)\./)?.[1] || 'unknown';
+
+    const sandbox = new Sandbox({
+      sandboxUrl: sandboxUrl.replace(/\/$/, ''),
+      sandboxId,
+      provider: 'gateway',
+      token,
+      timeout: options.timeout,
+      protocol: options.protocol,
+    });
+
+    // Verify connection by checking health
+    await sandbox.health();
+
+    // Determine working directory
+    const workdir = options.workdirName 
+      ? `/home/${options.workdirName}`
+      : '/home/project';
+
+    // Ensure workdir exists
+    try {
+      await sandbox.runCommand(`mkdir -p "${workdir}"`);
+    } catch {
+      // Directory might already exist
+    }
+
+    const container = new WebContainer(sandbox, workdir);
+
+    // Start signal service to handle port/error events
+    await container._startSignalService();
+
+    WebContainer._instance = container;
+    return container;
+  }
+
+  /**
+   * Connect to a remote computesdk sandbox (explicit configuration)
+   * 
+   * Use this method when you have explicit sandbox details. For simpler
+   * usage with auto-detection, use `boot()` instead.
+   * 
+   * @param options - Connection options including sandbox URL, ID, and credentials
+   * @returns A WebContainer instance connected to the remote sandbox
+   * 
+   * @example
+   * ```typescript
+   * const container = await WebContainer.connect({
+   *   sandboxUrl: 'https://sandbox-123.sandbox.computesdk.com',
+   *   sandboxId: 'sandbox-123',
+   *   provider: 'gateway',
+   *   token: 'your-session-token',
+   * });
+   * ```
+   */
+  static async connect(options: ConnectOptions): Promise<WebContainer> {
+    if (WebContainer._instance) {
+      throw new Error(
+        'A WebContainer instance is already running. ' +
+        'Call teardown() before connecting to a new instance.'
+      );
+    }
+
+    const sandbox = new Sandbox({
+      sandboxUrl: options.sandboxUrl,
+      sandboxId: options.sandboxId,
+      provider: options.provider,
+      token: options.token,
+      headers: options.headers,
+      timeout: options.timeout,
+      WebSocket: options.WebSocket,
+      protocol: options.protocol,
+    });
+
+    // Verify connection by checking health
+    await sandbox.health();
+
+    // Determine working directory
+    const workdir = options.workdirName 
+      ? `/home/${options.workdirName}`
+      : '/home/project';
+
+    // Ensure workdir exists
+    try {
+      await sandbox.runCommand(`mkdir -p "${workdir}"`);
+    } catch {
+      // Directory might already exist
+    }
+
+    const container = new WebContainer(sandbox, workdir);
+
+    // Start signal service to handle port/error events
+    await container._startSignalService();
+
+    WebContainer._instance = container;
+    return container;
+  }
+
+  // ============================================================================
+  // File System Operations
+  // ============================================================================
+
+  /**
+   * Mount a file system tree into the container
+   * 
+   * @param tree - File system tree or binary snapshot
+   * @param options - Mount options including mount point
+   * 
+   * @example
+   * ```typescript
+   * await container.mount({
+   *   'src': {
+   *     directory: {
+   *       'index.js': { file: { contents: 'console.log("Hello!")' } },
+   *       'utils.js': { file: { contents: 'export const add = (a, b) => a + b;' } },
+   *     }
+   *   },
+   *   'package.json': { file: { contents: JSON.stringify({ name: 'my-app' }) } },
+   * });
+   * ```
+   */
+  async mount(
+    tree: FileSystemTree | Uint8Array | ArrayBuffer,
+    options?: MountOptions
+  ): Promise<void> {
+    this._ensureNotDestroyed();
+
+    const mountPoint = options?.mountPoint || this._workdir;
+
+    if (tree instanceof Uint8Array || tree instanceof ArrayBuffer) {
+      // Binary snapshot - not yet supported
+      throw new Error(
+        'Binary snapshots are not yet supported. Please use FileSystemTree format.'
+      );
+    }
+
+    // Mount the file system tree
+    const mountFn = (this._fs as any)._mount;
+    if (mountFn) {
+      await mountFn(tree, mountPoint);
+    }
+  }
+
+  // ============================================================================
+  // Process Management
+  // ============================================================================
+
+  /**
+   * Spawn a process in the container
+   * 
+   * @param command - Command to execute
+   * @param args - Command arguments (optional)
+   * @param options - Spawn options
+   * @returns WebContainerProcess for interacting with the process
+   * 
+   * @example
+   * ```typescript
+   * // With arguments
+   * const install = await container.spawn('npm', ['install']);
+   * await install.exit;
+   * 
+   * // Without arguments
+   * const shell = await container.spawn('bash');
+   * shell.input.getWriter().write('echo "Hello"\n');
+   * ```
+   */
+  async spawn(command: string, args?: string[], options?: SpawnOptions): Promise<WebContainerProcess>;
+  async spawn(command: string, options?: SpawnOptions): Promise<WebContainerProcess>;
+  async spawn(
+    command: string, 
+    argsOrOptions?: string[] | SpawnOptions, 
+    maybeOptions?: SpawnOptions
+  ): Promise<WebContainerProcess> {
+    this._ensureNotDestroyed();
+
+    let args: string[] = [];
+    let options: SpawnOptions | undefined;
+
+    if (Array.isArray(argsOrOptions)) {
+      args = argsOrOptions;
+      options = maybeOptions;
+    } else {
+      options = argsOrOptions;
+    }
+
+    // Set default cwd to workdir
+    const spawnOptions: SpawnOptions = {
+      ...options,
+      cwd: options?.cwd || this._workdir,
+    };
+
+    return spawnProcess(this._sandbox, command, args, spawnOptions);
+  }
+
+  // ============================================================================
+  // Event Handling
+  // ============================================================================
+
+  /**
+   * Listen for events
+   * 
+   * @param event - Event type: 'port', 'error', 'server-ready', or 'preview-message'
+   * @param listener - Event listener function
+   * @returns Unsubscribe function
+   * 
+   * @example
+   * ```typescript
+   * // Listen for port events
+   * const unsubscribe = container.on('port', (port, type, url) => {
+   *   console.log(`Port ${port} ${type}: ${url}`);
+   * });
+   * 
+   * // Listen for server-ready events
+   * container.on('server-ready', (port, url) => {
+   *   console.log(`Server ready at ${url}`);
+   * });
+   * 
+   * // Unsubscribe later
+   * unsubscribe();
+   * ```
+   */
+  on(event: 'port', listener: PortListener): () => void;
+  on(event: 'error', listener: ErrorListener): () => void;
+  on(event: 'server-ready', listener: ServerReadyListener): () => void;
+  on(event: 'preview-message', listener: PreviewMessageListener): () => void;
+  on(event: EventType, listener: EventListener): () => void {
+    const listeners = this._eventListeners.get(event);
+    if (listeners) {
+      listeners.add(listener);
+    }
+
+    return () => {
+      listeners?.delete(listener);
+    };
+  }
+
+  // ============================================================================
+  // Export and Lifecycle
+  // ============================================================================
+
+  /**
+   * Export the filesystem
+   * 
+   * @param path - Path to export
+   * @param options - Export options
+   * @returns FileSystemTree (json) or Uint8Array (binary/zip)
+   * 
+   * @example
+   * ```typescript
+   * // Export as JSON tree
+   * const tree = await container.export('src', { format: 'json' });
+   * 
+   * // Export as zip
+   * const zipData = await container.export('dist', { format: 'zip' });
+   * const blob = new Blob([zipData], { type: 'application/zip' });
+   * ```
+   */
+  async export(path: string, options?: ExportOptions): Promise<Uint8Array | FileSystemTree> {
+    this._ensureNotDestroyed();
+
+    const resolvedPath = path.startsWith('/') ? path : `${this._workdir}/${path}`;
+    const format = options?.format || 'json';
+
+    if (format === 'json') {
+      // Build a FileSystemTree by reading the directory
+      return this._exportAsTree(resolvedPath, options);
+    } else {
+      // Export as binary (zip or binary snapshot)
+      // Use tar/zip command to create archive
+      const tempFile = `/tmp/export-${Date.now()}.${format === 'zip' ? 'zip' : 'tar'}`;
+      
+      if (format === 'zip') {
+        await this._sandbox.runCommand(`cd "${resolvedPath}" && zip -r "${tempFile}" .`);
+      } else {
+        await this._sandbox.runCommand(`tar -cf "${tempFile}" -C "${resolvedPath}" .`);
+      }
+
+      // Read the archive
+      const content = await this._sandbox.filesystem.readFile(tempFile);
+      
+      // Clean up
+      await this._sandbox.runCommand(`rm "${tempFile}"`);
+
+      // Convert to Uint8Array
+      return new TextEncoder().encode(content);
+    }
+  }
+
+  /**
+   * Configure a script to be injected into previews
+   * 
+   * Note: This is a no-op for remote sandboxes as preview injection
+   * is handled differently.
+   */
+  async setPreviewScript(scriptSrc: string, options?: PreviewScriptOptions): Promise<void> {
+    // No-op for remote sandboxes
+    console.warn('setPreviewScript is not supported for remote sandboxes');
+  }
+
+  /**
+   * Destroy the WebContainer instance and release resources
+   * 
+   * After calling this method, the instance becomes unusable.
+   * Unlike local WebContainers, this does not terminate the remote sandbox -
+   * it only disconnects from it. A new instance can be created by calling
+   * `boot()` again.
+   */
+  teardown(): void {
+    if (this._isDestroyed) {
+      return;
+    }
+
+    this._isDestroyed = true;
+
+    // Clear singleton reference
+    WebContainer._instance = null;
+
+    // Stop signal service
+    if (this._signalService) {
+      this._signalService.stop().catch(() => {});
+      this._signalService = null;
+    }
+
+    // Clear event listeners
+    this._eventListeners.forEach(listeners => listeners.clear());
+
+    // Disconnect from sandbox
+    this._sandbox.disconnect();
+  }
+
+  // ============================================================================
+  // Private Methods
+  // ============================================================================
+
+  /**
+   * Start the signal service to receive port/error events
+   */
+  private async _startSignalService(): Promise<void> {
+    try {
+      this._signalService = await this._sandbox.signal.start();
+
+      this._signalService.on('port', (event: { port: number; type: 'open' | 'close'; url: string }) => {
+        const listeners = this._eventListeners.get('port');
+        listeners?.forEach((listener) => {
+          (listener as PortListener)(event.port, event.type, event.url);
+        });
+
+        // Also emit server-ready for port open events
+        if (event.type === 'open') {
+          const serverReadyListeners = this._eventListeners.get('server-ready');
+          serverReadyListeners?.forEach((listener) => {
+            (listener as ServerReadyListener)(event.port, event.url);
+          });
+        }
+      });
+
+      this._signalService.on('error', (event: { message: string }) => {
+        const listeners = this._eventListeners.get('error');
+        listeners?.forEach((listener) => {
+          (listener as ErrorListener)({ message: event.message });
+        });
+      });
+    } catch (error) {
+      // Signal service might not be available
+      console.warn('Failed to start signal service:', error);
+    }
+  }
+
+  /**
+   * Export a directory as a FileSystemTree
+   */
+  private async _exportAsTree(
+    path: string, 
+    options?: ExportOptions
+  ): Promise<FileSystemTree> {
+    const tree: FileSystemTree = {};
+    const entries = await this._sandbox.filesystem.readdir(path);
+
+    for (const entry of entries) {
+      const fullPath = `${path}/${entry.name}`;
+      
+      // Check excludes
+      if (options?.excludes?.some(pattern => this._matchGlob(entry.name, pattern))) {
+        // Check includes to see if it should be included anyway
+        if (!options?.includes?.some(pattern => this._matchGlob(entry.name, pattern))) {
+          continue;
+        }
+      }
+
+      if (entry.type === 'directory') {
+        tree[entry.name] = {
+          directory: await this._exportAsTree(fullPath, options)
+        };
+      } else {
+        const content = await this._sandbox.filesystem.readFile(fullPath);
+        tree[entry.name] = {
+          file: { contents: content }
+        };
+      }
+    }
+
+    return tree;
+  }
+
+  /**
+   * Simple glob matching (supports * and **)
+   */
+  private _matchGlob(name: string, pattern: string): boolean {
+    const regex = pattern
+      .replace(/\*\*/g, '.*')
+      .replace(/\*/g, '[^/]*')
+      .replace(/\?/g, '.');
+    return new RegExp(`^${regex}$`).test(name);
+  }
+
+  /**
+   * Ensure the container is not destroyed
+   */
+  private _ensureNotDestroyed(): void {
+    if (this._isDestroyed) {
+      throw new Error('WebContainer has been destroyed');
+    }
+  }
+}

--- a/packages/webcontainer/tsconfig.json
+++ b/packages/webcontainer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/webcontainer/tsup.config.ts
+++ b/packages/webcontainer/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ['computesdk'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,6 +945,37 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0)(terser@5.43.1)
 
+  packages/webcontainer:
+    dependencies:
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0)(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0)(terser@5.43.1)
+
   packages/workbench:
     dependencies:
       '@computesdk/blaxel':
@@ -4265,7 +4296,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -8233,7 +8264,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -8251,7 +8282,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:


### PR DESCRIPTION
## Summary

Adds `@computesdk/webcontainer` - a WebContainer-compatible API for remote computesdk sandboxes.

This package provides a drop-in replacement for the [WebContainer API](https://webcontainers.io/api) that works with remote sandboxes instead of in-browser execution, allowing existing WebContainer-based applications to run on remote infrastructure.

## Usage

```typescript
import { WebContainer } from '@computesdk/webcontainer';

// Boot connects to a remote sandbox
// Auto-detects URL from query params (?sandbox_url=...) or localStorage
const container = await WebContainer.boot();

// Or with explicit connection info
const container = await WebContainer.boot({
  sandboxUrl: 'https://sandbox-123.sandbox.computesdk.com',
  token: 'your-session-token',
});

// Use the familiar WebContainer API
await container.mount({
  'index.js': { file: { contents: 'console.log("Hello!")' } },
});

const process = await container.spawn('node', ['index.js']);
process.output.pipeTo(new WritableStream({
  write(data) { console.log(data); }
}));

await process.exit;
container.teardown();
```

## API Compatibility

| WebContainer API | Status | Notes |
|-----------------|--------|-------|
| `WebContainer.boot()` | ✅ | Connects to remote sandbox |
| `container.fs.*` | ✅ | Full FileSystemAPI |
| `container.spawn()` | ✅ | Returns WebContainerProcess |
| `container.mount()` | ✅ | FileSystemTree support |
| `container.export()` | ✅ | JSON and zip formats |
| `container.on()` | ✅ | port, error, server-ready events |
| `container.teardown()` | ✅ | Cleanup and disconnect |
| `setPreviewScript()` | ⚠️ | No-op (browser-specific) |
| `auth.*` | ⚠️ | Stubs (different auth model) |

## Connection Methods

The sandbox URL and token can be provided via:
1. **Explicit options**: Pass `sandboxUrl` and `token` to `boot()`
2. **URL parameters**: `?sandbox_url=...&session_token=...`
3. **localStorage**: `sandbox_url` and `session_token` keys

URL parameters are automatically cleaned from the URL and stored in localStorage.