### PR TITLE
feat(create-compute): interactive sandbox REPL and PTY modes

### DIFF
--- a/packages/create-compute/README.md
+++ b/packages/create-compute/README.md
@@ -1,26 +1,136 @@
 # create-compute
 
-Create ComputeSDK projects with a single command.
+Spin up a cloud sandbox and start coding in an interactive REPL.
+
+## Quick Start
+
+```bash
+npx create-compute
+```
+
+This will:
+1. Auto-detect your provider credentials from environment variables
+2. Drop you into an interactive REPL
+3. Lazily create a sandbox on your first command
 
 ## Usage
 
 ```bash
-npx create-compute my-app
+# Auto-detect provider from env vars
+npx create-compute
+
+# Specify a provider
+npx create-compute --provider e2b
+
+# Skip the welcome banner
+npx create-compute --no-banner
+
+# Enable debug output
+npx create-compute --debug
 ```
 
-## Status
+## Environment Variables
 
-This CLI tool is under development. Check back soon for template support and project scaffolding features.
+Set your provider credentials before running:
+
+```bash
+# ComputeSDK Gateway (recommended)
+export COMPUTESDK_API_KEY=your_key
+
+# E2B
+export E2B_API_KEY=your_e2b_key
+
+# Modal
+export MODAL_TOKEN_ID=your_token_id
+export MODAL_TOKEN_SECRET=your_token_secret
+
+# Other providers...
+```
+
+## REPL Commands
+
+Once in the REPL, you can:
+
+### Run Shell Commands
+
+```javascript
+// Using $command syntax
+$ls -la
+$cat package.json
+
+// Using @computesdk/cmd functions
+ls('-la')
+npm.install('lodash')
+git.status()
+```
+
+### Execute Code
+
+```javascript
+// Run Python code
+runCode('print(1 + 1)', 'python')
+
+// Run Node.js code  
+runCode('console.log(1 + 1)', 'node')
+```
+
+### Manage Sandbox
+
+```javascript
+// Show sandbox info
+info
+
+// Get sandbox URL for a port
+await getUrl({ port: 3000 })
+
+// Restart sandbox
+restart
+
+// Destroy sandbox
+destroy
+```
+
+### Filesystem Operations
+
+```javascript
+// Read/write files
+await filesystem.writeFile('/tmp/test.txt', 'hello')
+await filesystem.readFile('/tmp/test.txt')
+
+// List directory
+await filesystem.readdir('/home')
+
+// Check if path exists
+await filesystem.exists('/tmp/test.txt')
+```
+
+### Session Commands
+
+```javascript
+help      // Show available commands
+info      // Show sandbox info
+verbose   // Toggle verbose output
+exit      // Exit and cleanup
+```
+
+## Features
+
+- **Lazy sandbox creation**: Sandbox is only created when you run your first command
+- **Auto-detection**: Automatically detects provider from environment variables
+- **Smart evaluation**: Command arrays from `@computesdk/cmd` are auto-executed
+- **Tab completion**: Autocomplete for commands and functions
+- **Command history**: History persisted across sessions
 
 ## Development
-
-This package is part of the ComputeSDK monorepo. To work on it locally:
 
 ```bash
 # From the monorepo root
 pnpm install
 pnpm build
 
-# Test the CLI
+# Run locally
 node packages/create-compute/dist/index.js
+
+# Or with pnpm
+pnpm --filter create-compute start
 ```

--- a/packages/create-compute/package.json
+++ b/packages/create-compute/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-compute",
   "version": "0.2.0",
-  "description": "Create ComputeSDK projects with a single command",
+  "description": "Spin up a cloud sandbox and start coding in an interactive REPL",
   "author": "Garrison",
   "license": "MIT",
   "type": "module",
@@ -16,18 +16,19 @@
     "build": "tsup",
     "clean": "rimraf dist",
     "dev": "tsup --watch",
-    "test": "echo 'nothing here'",
-    "test:watch": "echo 'nothing here'",
-    "test:coverage": "echo 'nothing here'",
-    "typecheck": "echo 'nothing here'",
-    "lint": "echo 'nothing here'"
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
   },
   "keywords": [
     "create",
-    "init",
-    "scaffold",
-    "computesdk",
     "sandbox",
+    "repl",
+    "computesdk",
+    "cloud",
     "cli"
   ],
   "repository": {
@@ -39,8 +40,11 @@
     "url": "https://github.com/computesdk/computesdk/issues"
   },
   "dependencies": {
+    "@clack/prompts": "^0.7.0",
     "commander": "^11.1.0",
-    "picocolors": "^1.0.0"
+    "computesdk": "workspace:*",
+    "picocolors": "^1.0.0",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/create-compute/src/__tests__/auth.test.ts
+++ b/packages/create-compute/src/__tests__/auth.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'os';
+import http from 'node:http';
+
+// Fixed test home path (vi.mock is hoisted, so we can't use variables)
+const TEST_HOME = path.join(os.tmpdir(), 'create-compute-test');
+
+// Mock os module so auth.ts uses our test home directory
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  const testHome = actual.tmpdir() + '/create-compute-test';
+  return { ...actual, default: actual, homedir: () => testHome };
+});
+
+// Mock @clack/prompts to avoid interactive output in tests
+vi.mock('@clack/prompts', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+  spinner: () => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import {
+  loadStoredCredentials,
+  storeCredentials,
+  clearStoredCredentials,
+  runBrowserAuthFlow,
+  resolveApiKey,
+} from '../auth.js';
+
+const CREDENTIALS_DIR = path.join(TEST_HOME, '.computesdk');
+const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials.json');
+
+function makeRequest(
+  port: number,
+  reqPath: string
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://127.0.0.1:${port}${reqPath}`, (res) => {
+      let body = '';
+      res.on('data', (chunk: string) => (body += chunk));
+      res.on('end', () =>
+        resolve({ statusCode: res.statusCode || 0, body })
+      );
+    });
+    req.on('error', reject);
+  });
+}
+
+beforeEach(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  fs.mkdirSync(TEST_HOME, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('loadStoredCredentials', () => {
+  it('returns null when file does not exist', () => {
+    expect(loadStoredCredentials()).toBeNull();
+  });
+
+  it('returns apiKey when valid credentials file exists', () => {
+    fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
+    fs.writeFileSync(
+      CREDENTIALS_FILE,
+      JSON.stringify({ apiKey: 'computesdk_live_test123' })
+    );
+    expect(loadStoredCredentials()).toBe('computesdk_live_test123');
+  });
+
+  it('returns null when JSON is malformed', () => {
+    fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
+    fs.writeFileSync(CREDENTIALS_FILE, 'not json');
+    expect(loadStoredCredentials()).toBeNull();
+  });
+
+  it('returns null when apiKey field is missing', () => {
+    fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
+    fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify({ other: 'field' }));
+    expect(loadStoredCredentials()).toBeNull();
+  });
+
+  it('returns null when apiKey is empty string', () => {
+    fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
+    fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify({ apiKey: '' }));
+    expect(loadStoredCredentials()).toBeNull();
+  });
+});
+
+describe('storeCredentials', () => {
+  it('creates directory and writes credentials file', () => {
+    storeCredentials('computesdk_live_abc');
+    const raw = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data.apiKey).toBe('computesdk_live_abc');
+  });
+
+  it('overwrites existing credentials', () => {
+    storeCredentials('computesdk_live_first');
+    storeCredentials('computesdk_live_second');
+    const raw = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data.apiKey).toBe('computesdk_live_second');
+  });
+});
+
+describe('clearStoredCredentials', () => {
+  it('deletes credentials file', () => {
+    storeCredentials('computesdk_live_abc');
+    expect(fs.existsSync(CREDENTIALS_FILE)).toBe(true);
+    clearStoredCredentials();
+    expect(fs.existsSync(CREDENTIALS_FILE)).toBe(false);
+  });
+
+  it('does not throw when file does not exist', () => {
+    expect(() => clearStoredCredentials()).not.toThrow();
+  });
+});
+
+describe('runBrowserAuthFlow', () => {
+  it('resolves with token on valid callback', async () => {
+    const result = runBrowserAuthFlow({
+      skipBrowserOpen: true,
+      timeoutMs: 5000,
+      onServerReady: (port, state) => {
+        makeRequest(port, `/callback?token=computesdk_live_test&state=${state}`);
+      },
+    });
+
+    await expect(result).resolves.toBe('computesdk_live_test');
+  });
+
+  it('rejects state mismatch with 403', async () => {
+    const result = runBrowserAuthFlow({
+      skipBrowserOpen: true,
+      timeoutMs: 1000,
+      onServerReady: async (port, _state) => {
+        const res = await makeRequest(
+          port,
+          '/callback?token=computesdk_live_test&state=wrong_state'
+        );
+        expect(res.statusCode).toBe(403);
+      },
+    });
+
+    // Wrong state doesn't close the server, so it times out
+    await expect(result).rejects.toThrow('timed out');
+  });
+
+  it('returns 404 for non-callback paths', async () => {
+    const result = runBrowserAuthFlow({
+      skipBrowserOpen: true,
+      timeoutMs: 5000,
+      onServerReady: async (port, state) => {
+        const res = await makeRequest(port, '/other-path');
+        expect(res.statusCode).toBe(404);
+
+        await makeRequest(
+          port,
+          `/callback?token=computesdk_live_test&state=${state}`
+        );
+      },
+    });
+
+    await expect(result).resolves.toBe('computesdk_live_test');
+  });
+
+  it('returns 400 when token is missing', async () => {
+    const result = runBrowserAuthFlow({
+      skipBrowserOpen: true,
+      timeoutMs: 5000,
+      onServerReady: async (port, state) => {
+        const res = await makeRequest(port, `/callback?state=${state}`);
+        expect(res.statusCode).toBe(400);
+
+        await makeRequest(
+          port,
+          `/callback?token=computesdk_live_test&state=${state}`
+        );
+      },
+    });
+
+    await expect(result).resolves.toBe('computesdk_live_test');
+  });
+
+  it('rejects on timeout', async () => {
+    const result = runBrowserAuthFlow({
+      skipBrowserOpen: true,
+      timeoutMs: 100,
+    });
+
+    await expect(result).rejects.toThrow('timed out');
+  });
+});
+
+describe('resolveApiKey', () => {
+  const originalEnv = process.env.COMPUTESDK_API_KEY;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.COMPUTESDK_API_KEY = originalEnv;
+    } else {
+      delete process.env.COMPUTESDK_API_KEY;
+    }
+  });
+
+  it('returns env var when COMPUTESDK_API_KEY is set', async () => {
+    process.env.COMPUTESDK_API_KEY = 'computesdk_live_from_env';
+    const key = await resolveApiKey();
+    expect(key).toBe('computesdk_live_from_env');
+  });
+
+  it('returns stored credentials when env var is not set', async () => {
+    delete process.env.COMPUTESDK_API_KEY;
+    storeCredentials('computesdk_live_stored');
+    const key = await resolveApiKey();
+    expect(key).toBe('computesdk_live_stored');
+  });
+
+  it('env var takes precedence over stored credentials', async () => {
+    storeCredentials('computesdk_live_stored');
+    process.env.COMPUTESDK_API_KEY = 'computesdk_live_from_env';
+    const key = await resolveApiKey();
+    expect(key).toBe('computesdk_live_from_env');
+  });
+});

--- a/packages/create-compute/src/auth.ts
+++ b/packages/create-compute/src/auth.ts
@@ -1,0 +1,245 @@
+/**
+ * Browser-based CLI authentication flow
+ *
+ * Precedence: env var > stored credentials > browser auth flow
+ */
+
+import * as http from 'node:http';
+import * as crypto from 'node:crypto';
+import { exec } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'os';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+function getCredentialsDir(): string {
+  return path.join(os.homedir(), '.computesdk');
+}
+
+function getCredentialsFile(): string {
+  return path.join(getCredentialsDir(), 'credentials.json');
+}
+
+const AUTH_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const CONSOLE_AUTH_URL = 'https://console.computesdk.com/cli/auth';
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html>
+<head><title>ComputeSDK CLI</title></head>
+<body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
+  <div style="text-align: center;">
+    <h1>Authenticated</h1>
+    <p>You can close this tab and return to the terminal.</p>
+  </div>
+</body>
+</html>`;
+
+/**
+ * Load stored credentials from ~/.computesdk/credentials.json.
+ * Returns the API key if found and valid, or null.
+ */
+export function loadStoredCredentials(): string | null {
+  try {
+    if (!fs.existsSync(getCredentialsFile())) {
+      return null;
+    }
+    const raw = fs.readFileSync(getCredentialsFile(), 'utf-8');
+    const data = JSON.parse(raw);
+    if (typeof data.apiKey === 'string' && data.apiKey.length > 0) {
+      return data.apiKey;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store credentials to ~/.computesdk/credentials.json.
+ * Creates ~/.computesdk/ directory if it doesn't exist.
+ */
+export function storeCredentials(apiKey: string): void {
+  if (!fs.existsSync(getCredentialsDir())) {
+    fs.mkdirSync(getCredentialsDir(), { recursive: true, mode: 0o700 });
+  }
+  fs.writeFileSync(
+    getCredentialsFile(),
+    JSON.stringify({ apiKey }, null, 2) + '\n',
+    { mode: 0o600 }
+  );
+}
+
+/**
+ * Delete stored credentials file.
+ */
+export function clearStoredCredentials(): void {
+  try {
+    if (fs.existsSync(getCredentialsFile())) {
+      fs.unlinkSync(getCredentialsFile());
+    }
+  } catch {
+    // Ignore - file may not exist or may not be writable
+  }
+}
+
+/**
+ * Open a URL in the user's default browser.
+ * Falls back to printing the URL if the browser fails to open.
+ */
+function openBrowser(url: string): void {
+  const command =
+    process.platform === 'darwin'
+      ? `open "${url}"`
+      : process.platform === 'win32'
+        ? `start "" "${url}"`
+        : `xdg-open "${url}"`;
+
+  exec(command, (err) => {
+    if (err) {
+      p.log.warn('Could not open browser automatically.');
+      p.log.info(`Open this URL manually:\n  ${pc.cyan(url)}`);
+    }
+  });
+}
+
+export interface AuthFlowOptions {
+  /** Override timeout for tests */
+  timeoutMs?: number;
+  /** Callback when server is listening (for tests) */
+  onServerReady?: (port: number, state: string) => void;
+  /** Skip opening browser (for tests) */
+  skipBrowserOpen?: boolean;
+}
+
+/**
+ * Run the browser-based authentication flow.
+ *
+ * 1. Start a local HTTP server on a random port
+ * 2. Open browser to console.computesdk.com/cli/auth
+ * 3. Wait for callback with token and validated state
+ * 4. Return the API key
+ */
+export function runBrowserAuthFlow(options?: AuthFlowOptions): Promise<string> {
+  const timeoutMs = options?.timeoutMs ?? AUTH_TIMEOUT_MS;
+  const state = crypto.randomBytes(32).toString('hex');
+
+  return new Promise<string>((resolve, reject) => {
+    const server = http.createServer();
+
+    const timeout = setTimeout(() => {
+      server.close();
+      reject(
+        new Error('Authentication timed out after 5 minutes. Please try again.')
+      );
+    }, timeoutMs);
+
+    server.on('request', (req, res) => {
+      const url = new URL(req.url || '/', 'http://localhost');
+
+      if (req.method !== 'GET' || url.pathname !== '/callback') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+        return;
+      }
+
+      const receivedState = url.searchParams.get('state');
+      const token = url.searchParams.get('token');
+
+      if (receivedState !== state) {
+        res.writeHead(403, { 'Content-Type': 'text/plain' });
+        res.end('Error: State mismatch. Please try authenticating again.');
+        return;
+      }
+
+      if (!token) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('Error: No token received.');
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(SUCCESS_HTML);
+
+      clearTimeout(timeout);
+      server.close();
+      resolve(token);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        clearTimeout(timeout);
+        server.close();
+        reject(new Error('Failed to start auth server'));
+        return;
+      }
+
+      const port = addr.port;
+      const authUrl = `${CONSOLE_AUTH_URL}?port=${port}&state=${state}`;
+
+      if (options?.onServerReady) {
+        options.onServerReady(port, state);
+      }
+
+      if (!options?.skipBrowserOpen) {
+        openBrowser(authUrl);
+      }
+    });
+
+    server.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(new Error(`Auth server error: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Resolve an API key through the precedence chain:
+ *   env var > stored credentials > browser auth flow
+ */
+export async function resolveApiKey(options?: {
+  forceLogin?: boolean;
+}): Promise<string> {
+  // 1. Check environment variable (highest precedence)
+  if (process.env.COMPUTESDK_API_KEY) {
+    return process.env.COMPUTESDK_API_KEY;
+  }
+
+  // 2. Check stored credentials (skip if forcing re-auth)
+  if (!options?.forceLogin) {
+    const stored = loadStoredCredentials();
+    if (stored) {
+      p.log.info(
+        `Using stored credentials from ${pc.dim('~/.computesdk/credentials.json')}`
+      );
+      return stored;
+    }
+  }
+
+  // 3. Run browser auth flow
+  p.log.info('No API key found. Starting browser authentication...');
+
+  const spinner = p.spinner();
+  spinner.start('Waiting for browser authentication...');
+
+  try {
+    const apiKey = await runBrowserAuthFlow();
+    spinner.stop('Authentication successful');
+
+    // Store for next time
+    try {
+      storeCredentials(apiKey);
+      p.log.success(
+        `Credentials saved to ${pc.dim('~/.computesdk/credentials.json')}`
+      );
+    } catch {
+      p.log.warn('Could not save credentials to disk. You may need to authenticate again next time.');
+    }
+
+    return apiKey;
+  } catch (error) {
+    spinner.stop(pc.red('Authentication failed'));
+    throw error;
+  }
+}

--- a/packages/create-compute/src/index.ts
+++ b/packages/create-compute/src/index.ts
@@ -16,7 +16,6 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { compute, type Sandbox } from 'computesdk';
 import { detectAvailableProviders, getProviderStatus, buildProviderConfig, type ProviderStatus } from './providers.js';
-import { startPTY } from './pty.js';
 import { startREPL } from './repl.js';
 import { resolveApiKey, clearStoredCredentials } from './auth.js';
 
@@ -84,26 +83,6 @@ async function main() {
     process.exit(0);
   }
 
-  // Select mode
-  const mode = await p.select({
-    message: 'Select mode',
-    options: [
-      { 
-        value: 'repl', 
-        label: 'REPL',
-      },
-      { 
-        value: 'pty', 
-        label: 'Shell (PTY)',
-      },
-    ],
-  });
-
-  if (p.isCancel(mode)) {
-    p.cancel('Cancelled');
-    process.exit(0);
-  }
-
   // Create sandbox
   const spinner = p.spinner();
   spinner.start('Creating sandbox...');
@@ -122,16 +101,10 @@ async function main() {
     process.exit(1);
   }
 
-  // Start selected mode
-  if (mode === 'pty') {
-    p.log.info('Connecting to shell... ' + pc.gray('(.exit or Ctrl+D to quit)'));
-    console.log();
-    await startPTY(sandbox);
-  } else {
-    p.log.info('Starting REPL... ' + pc.gray('(.exit or Ctrl+D to quit)'));
-    console.log();
-    await startREPL(sandbox, provider as string);
-  }
+  // Start REPL (use /shell to drop into PTY when needed)
+  p.log.info('Starting REPL... ' + pc.gray('(/shell for interactive PTY, /exit to quit)'));
+  console.log();
+  await startREPL(sandbox, provider as string);
 
   // Cleanup
   const cleanupSpinner = p.spinner();

--- a/packages/create-compute/src/index.ts
+++ b/packages/create-compute/src/index.ts
@@ -1,37 +1,138 @@
-import { Command } from 'commander'
-import pc from 'picocolors'
-import { readFileSync } from 'fs'
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
+/**
+ * create-compute
+ *
+ * Spin up a cloud sandbox and start coding.
+ *
+ * Usage:
+ *   npx create-compute
+ *   npm create compute
+ */
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+import 'dotenv/config';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { compute, type Sandbox } from 'computesdk';
+import { detectAvailableProviders, getProviderStatus, buildProviderConfig, type ProviderStatus } from './providers.js';
+import { startPTY } from './pty.js';
+import { startREPL } from './repl.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Read package.json to get version
 const packageJson = JSON.parse(
   readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')
-)
+);
 
-const program = new Command()
+async function main() {
+  console.log();
+  p.intro(pc.cyan(`create-compute v${packageJson.version}`));
 
-program
-  .name('create-compute')
-  .description('Create ComputeSDK projects with a single command')
-  .version(packageJson.version)
-  .argument('[project-name]', 'Name of your project')
-  .option('-t, --template <template>', 'Template to use', 'basic')
-  .action((projectName, options) => {
-    console.log(pc.bold(pc.cyan('\n📦 Welcome to create-compute!\n')))
-    
-    if (projectName) {
-      console.log(`Creating a new ComputeSDK project: ${pc.green(projectName)}`)
-      console.log(`Using template: ${pc.yellow(options.template)}`)
-    } else {
-      console.log('No project name provided. Run with a project name:')
-      console.log(pc.gray('  npx create-compute my-app'))
-    }
-    
-    console.log(pc.gray('\nThis CLI is under development. Check back soon!'))
-  })
+  // Check for gateway API key
+  if (!process.env.COMPUTESDK_API_KEY) {
+    p.log.error('COMPUTESDK_API_KEY not set');
+    p.log.info('Get your API key at https://computesdk.com');
+    p.outro(pc.red('Setup incomplete'));
+    process.exit(1);
+  }
 
-program.parse()
+  // Detect available providers
+  const available = detectAvailableProviders();
+  const providerStatus = getProviderStatus();
+
+  if (available.length === 0) {
+    p.log.error('No provider credentials detected');
+    p.log.info('Set one of: E2B_API_KEY, MODAL_TOKEN_ID, RAILWAY_API_KEY, etc.');
+    p.outro(pc.red('Setup incomplete'));
+    process.exit(1);
+  }
+
+  // Build provider options for select
+  const providerOptions = providerStatus
+    .filter((status: ProviderStatus) => status.ready)
+    .map((status: ProviderStatus) => ({
+      value: status.name,
+      label: status.name,
+    }));
+
+  // Select provider
+  const provider = await p.select({
+    message: 'Select provider',
+    options: providerOptions,
+  });
+
+  if (p.isCancel(provider)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+
+  // Select mode
+  const mode = await p.select({
+    message: 'Select mode',
+    options: [
+      { 
+        value: 'repl', 
+        label: 'REPL',
+      },
+      { 
+        value: 'pty', 
+        label: 'Shell (PTY)',
+      },
+    ],
+  });
+
+  if (p.isCancel(mode)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+
+  // Create sandbox
+  const spinner = p.spinner();
+  spinner.start('Creating sandbox...');
+
+  let sandbox: Sandbox;
+  try {
+    // Configure compute with provider and credentials from env
+    const config = buildProviderConfig(provider as string);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    compute.setConfig(config as any);
+    sandbox = await compute.sandbox.create();
+    spinner.stop(`Sandbox ready: ${pc.cyan(sandbox.sandboxId)}`);
+  } catch (error) {
+    spinner.stop(pc.red('Failed to create sandbox'));
+    p.log.error((error as Error).message);
+    process.exit(1);
+  }
+
+  // Start selected mode
+  if (mode === 'pty') {
+    p.log.info('Connecting to shell... ' + pc.gray('(.exit or Ctrl+D to quit)'));
+    console.log();
+    await startPTY(sandbox);
+  } else {
+    p.log.info('Starting REPL... ' + pc.gray('(.exit or Ctrl+D to quit)'));
+    console.log();
+    await startREPL(sandbox, provider as string);
+  }
+
+  // Cleanup
+  const cleanupSpinner = p.spinner();
+  cleanupSpinner.start('Cleaning up...');
+  
+  try {
+    await sandbox.destroy();
+    cleanupSpinner.stop('Sandbox destroyed');
+  } catch {
+    cleanupSpinner.stop(pc.yellow('Cleanup warning'));
+  }
+
+  p.outro(pc.green('Done!'));
+}
+
+main().catch((error) => {
+  console.error(pc.red(`\nError: ${error.message}`));
+  process.exit(1);
+});

--- a/packages/create-compute/src/providers.ts
+++ b/packages/create-compute/src/providers.ts
@@ -1,0 +1,71 @@
+/**
+ * Provider detection and validation
+ */
+
+import {
+  PROVIDER_NAMES,
+  isProviderAuthComplete,
+  getMissingEnvVars,
+  getProviderConfigFromEnv,
+  type ProviderName,
+} from 'computesdk';
+
+/**
+ * Provider status info
+ */
+export interface ProviderStatus {
+  name: string;
+  ready: boolean;
+  missing: string[];
+}
+
+/**
+ * Detect all available providers from environment variables
+ */
+export function detectAvailableProviders(): string[] {
+  const available: string[] = [];
+
+  for (const provider of PROVIDER_NAMES) {
+    if (isProviderAuthComplete(provider)) {
+      available.push(provider);
+    }
+  }
+
+  return available;
+}
+
+/**
+ * Get status of all providers
+ */
+export function getProviderStatus(): ProviderStatus[] {
+  return PROVIDER_NAMES.map((provider) => ({
+    name: provider,
+    ready: isProviderAuthComplete(provider),
+    missing: getMissingEnvVars(provider),
+  }));
+}
+
+/**
+ * Check if gateway mode is available
+ */
+export function isGatewayAvailable(): boolean {
+  return !!process.env.COMPUTESDK_API_KEY;
+}
+
+/**
+ * Build the full compute config for a provider from env vars
+ */
+export function buildProviderConfig(provider: string): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    provider,
+    computesdkApiKey: process.env.COMPUTESDK_API_KEY,
+  };
+
+  // Add provider-specific config from env vars
+  const providerConfig = getProviderConfigFromEnv(provider as ProviderName);
+  if (Object.keys(providerConfig).length > 0) {
+    config[provider] = providerConfig;
+  }
+
+  return config;
+}

--- a/packages/create-compute/src/pty.ts
+++ b/packages/create-compute/src/pty.ts
@@ -1,0 +1,125 @@
+/**
+ * PTY Mode - Full interactive shell session
+ *
+ * Connects stdin/stdout directly to a remote PTY terminal.
+ * Like SSH, but to a cloud sandbox.
+ */
+
+import type { Sandbox } from 'computesdk';
+
+// Control characters
+const CTRL_D = 0x04;
+
+/**
+ * Start PTY mode - interactive shell session
+ */
+export async function startPTY(sandbox: Sandbox): Promise<void> {
+  // Create PTY terminal
+  const terminal = await sandbox.terminal.create({ pty: true });
+
+  // Set up stdin in raw mode for passthrough
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+  }
+  process.stdin.resume();
+
+  // Buffer to detect ".exit" command
+  let inputBuffer = '';
+
+  // Pipe terminal output to stdout
+  terminal.on('output', (data: string) => {
+    process.stdout.write(data);
+  });
+
+  terminal.on('error', (error: string) => {
+    process.stderr.write(`\r\nTerminal error: ${error}\r\n`);
+  });
+
+  // Pipe stdin to terminal, with .exit and Ctrl+D detection
+  const onData = (data: Buffer) => {
+    const str = data.toString();
+    
+    // Check for Ctrl+D
+    if (data.length === 1 && data[0] === CTRL_D) {
+      doExit();
+      return;
+    }
+    
+    // Add to buffer
+    inputBuffer += str;
+    
+    // Check for .exit at end of buffer (after Enter)
+    if (inputBuffer.endsWith('.exit\r') || inputBuffer.endsWith('.exit\n')) {
+      doExit();
+      return;
+    }
+    
+    // Keep buffer small - only track last 10 chars
+    if (inputBuffer.length > 10) {
+      inputBuffer = inputBuffer.slice(-10);
+    }
+    
+    // Pass through to terminal
+    terminal.write(str);
+  };
+  process.stdin.on('data', onData);
+
+  // Handle terminal resize
+  const onResize = () => {
+    if (process.stdout.columns && process.stdout.rows) {
+      try {
+        terminal.resize(process.stdout.columns, process.stdout.rows);
+      } catch {
+        // Ignore resize errors
+      }
+    }
+  };
+  process.stdout.on('resize', onResize);
+
+  // Initial resize
+  onResize();
+
+  let exiting = false;
+
+  async function doExit() {
+    if (exiting) return;
+    exiting = true;
+    
+    cleanup();
+    try {
+      await terminal.destroy();
+    } catch {
+      // Ignore
+    }
+    resolvePromise();
+  }
+
+  function cleanup() {
+    process.stdin.removeListener('data', onData);
+    process.stdout.removeListener('resize', onResize);
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+    process.stdin.pause();
+    console.log(); // New line after PTY
+  }
+
+  let resolvePromise: () => void;
+
+  // Wait for terminal to close
+  return new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+
+    terminal.on('destroyed', () => {
+      if (!exiting) {
+        cleanup();
+        resolve();
+      }
+    });
+
+    // Handle stdin end
+    process.stdin.on('end', () => {
+      doExit();
+    });
+  });
+}

--- a/packages/create-compute/src/repl.ts
+++ b/packages/create-compute/src/repl.ts
@@ -1,0 +1,228 @@
+/**
+ * REPL Mode - Run commands one at a time
+ *
+ * Shell-like interface where each line is executed as a command.
+ * Special commands prefixed with /.
+ */
+
+import * as readline from 'readline';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import pc from 'picocolors';
+import type { Sandbox } from 'computesdk';
+
+/**
+ * Start REPL mode
+ */
+export async function startREPL(sandbox: Sandbox, provider: string): Promise<void> {
+  const sandboxId = sandbox.sandboxId;
+  
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: pc.cyan(`[${sandboxId}] `) + pc.bold('$ '),
+    terminal: true,
+    historySize: 1000,
+  });
+
+  // Load history
+  loadHistory(rl);
+
+  return new Promise<void>((resolve) => {
+    // Handle Ctrl+C and Ctrl+D
+    rl.on('SIGINT', () => {
+      // Ctrl+C - just show new prompt
+      console.log();
+      rl.prompt();
+    });
+    
+    rl.on('close', () => {
+      // Ctrl+D or .exit
+      resolve();
+    });
+
+    rl.on('line', async (line) => {
+      const trimmed = line.trim();
+
+      // Skip empty lines
+      if (!trimmed) {
+        rl.prompt();
+        return;
+      }
+
+      // Handle .exit
+      if (trimmed === '.exit') {
+        rl.close();
+        resolve();
+        return;
+      }
+
+      // Save to history
+      saveToHistory(trimmed);
+
+      try {
+        // Check for special commands (start with /)
+        if (trimmed.startsWith('/')) {
+          const shouldExit = await handleSpecialCommand(sandbox, trimmed, rl);
+          if (shouldExit) {
+            rl.close();
+            resolve();
+            return;
+          }
+        } else {
+          // Execute as shell command
+          await executeCommand(sandbox, trimmed);
+        }
+      } catch (error) {
+        console.log(pc.red(`✗ ${(error as Error).message}`));
+      }
+
+      rl.prompt();
+    });
+
+    rl.on('close', () => {
+      resolve();
+    });
+
+    // Start prompting
+    rl.prompt();
+  });
+}
+
+/**
+ * Execute a shell command in the sandbox
+ */
+async function executeCommand(sandbox: Sandbox, command: string): Promise<void> {
+  const result = await sandbox.runCommand(command);
+
+  // Print stdout
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+    if (!result.stdout.endsWith('\n')) {
+      console.log();
+    }
+  }
+
+  // Print stderr in red
+  if (result.stderr) {
+    process.stderr.write(pc.red(result.stderr));
+    if (!result.stderr.endsWith('\n')) {
+      console.log();
+    }
+  }
+
+  // Show exit code if non-zero
+  if (result.exitCode !== 0) {
+    console.log(pc.gray(`exit code: ${result.exitCode}`));
+  }
+}
+
+/**
+ * Handle special commands (prefixed with /)
+ * Returns true if should exit
+ */
+async function handleSpecialCommand(
+  sandbox: Sandbox,
+  input: string,
+  rl: readline.Interface
+): Promise<boolean> {
+  const [cmd, ...args] = input.slice(1).split(/\s+/);
+
+  switch (cmd.toLowerCase()) {
+    case 'help':
+    case 'h':
+    case '?':
+      showHelp();
+      return false;
+
+    case 'info':
+    case 'i':
+      console.log();
+      console.log(pc.bold('  Sandbox Info'));
+      console.log(`  ID: ${pc.cyan(sandbox.sandboxId)}`);
+      console.log();
+      return false;
+
+    case 'url':
+    case 'u':
+      if (args.length === 0) {
+        console.log(pc.gray('Usage: /url <port>'));
+      } else {
+        const port = parseInt(args[0], 10);
+        if (isNaN(port)) {
+          console.log(pc.red('Invalid port number'));
+        } else {
+          const url = await sandbox.getUrl({ port });
+          console.log(pc.cyan(url));
+        }
+      }
+      return false;
+
+    case 'exit':
+    case 'quit':
+    case 'q':
+      return true;
+
+    default:
+      console.log(pc.yellow(`Unknown command: /${cmd}`));
+      console.log(pc.gray('Type /help for available commands'));
+      return false;
+  }
+}
+
+/**
+ * Show help message
+ */
+function showHelp(): void {
+  console.log();
+  console.log(pc.bold('  Shell Mode'));
+  console.log(pc.gray('  Just type commands - they run in the sandbox'));
+  console.log();
+  console.log(pc.white('    ls -la'));
+  console.log(pc.white('    cat /etc/os-release'));
+  console.log(pc.white('    npm install lodash'));
+  console.log();
+  console.log(pc.bold('  Special Commands') + pc.gray(' (prefix with /)'));
+  console.log();
+  console.log(pc.cyan('    /help') + pc.gray('        Show this help'));
+  console.log(pc.cyan('    /info') + pc.gray('        Show sandbox info'));
+  console.log(pc.cyan('    /url 3000') + pc.gray('    Get public URL for port'));
+  console.log(pc.cyan('    /exit') + pc.gray('        Exit and cleanup'));
+  console.log(pc.cyan('    .exit') + pc.gray('        Exit and cleanup'));
+  console.log();
+}
+
+// History file path
+const HISTORY_FILE = path.join(os.homedir(), '.create_compute_history');
+
+/**
+ * Load history from file
+ */
+function loadHistory(rl: readline.Interface): void {
+  try {
+    if (fs.existsSync(HISTORY_FILE)) {
+      const history = fs.readFileSync(HISTORY_FILE, 'utf-8')
+        .split('\n')
+        .filter(line => line.trim())
+        .reverse();
+      
+      for (const line of history.slice(0, 1000)) {
+        (rl as unknown as { history: string[] }).history?.push(line);
+      }
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+/**
+ * Save a line to history
+ */
+function saveToHistory(line: string): void {
+  try {
+    fs.appendFileSync(HISTORY_FILE, line + '\n');
+  } catch {
+    // Ignore
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,9 +370,18 @@ importers:
 
   packages/create-compute:
     dependencies:
+      '@clack/prompts':
+        specifier: ^0.7.0
+        version: 0.7.0
       commander:
         specifier: ^11.1.0
         version: 11.1.0
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
@@ -1453,6 +1462,14 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@0.3.5':
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+
+  '@clack/prompts@0.7.0':
+    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
+    bundledDependencies:
+      - is-unicode-supported
 
   '@cloudflare/containers@0.0.25':
     resolution: {integrity: sha512-41sCUwGPhMMQI/kwksEZXNWe/GZdQoIy8QlgO4NAF68M4y4NN41IXeQ4n2jn4iJ7tHaV4noe7RI75b7T6h2JGg==}
@@ -5546,6 +5563,9 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -7589,6 +7609,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@0.3.5':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.7.0':
+    dependencies:
+      '@clack/core': 0.3.5
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@cloudflare/containers@0.0.25': {}
 
@@ -12182,6 +12213,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
     optional: true
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Transforms `create-compute` from a scaffolding placeholder into an interactive sandbox CLI tool.

### What's in this PR

- **Interactive setup**: Provider and mode selection using @clack/prompts
- **REPL mode**: Run shell commands with `/` meta-commands for control
- **PTY mode**: Full interactive shell session (like SSH to the sandbox)
- **Auto-detection**: Discovers provider credentials from environment variables
- **Clean exit**: Support `.exit` and `Ctrl+D` in both modes

### Usage

```bash
npx create-compute
```

```
┌  create-compute v0.2.0
│
◇  Select provider
│  e2b
│
◇  Select mode
│  REPL
│
◐  Creating sandbox...
◇  Sandbox ready: positive-boa
│
ℹ  Starting REPL... (.exit or Ctrl+D to quit)

[positive-boa] $ ls -la
total 8
drwxr-xr-x 2 user user 4096 ...

[positive-boa] $ python --version
Python 3.11.6

[positive-boa] $ /help

  Shell Mode
  Just type commands - they run in the sandbox

    ls -la
    cat /etc/os-release
    npm install lodash
    python -c "print(1+1)"

  Special Commands (prefix with /)

    /help        Show this help
    /info        Show sandbox info
    /url 3000    Get public URL for port
    /exit        Exit and cleanup
    .exit        Exit and cleanup

[positive-boa] $ .exit

◐  Cleaning up...
◇  Sandbox destroyed
│
└  Done!
```

---

## Future Vision

This PR is the foundation. Here's where we're headed:

### REPL-First Design

Remove mode selection prompt. Always start in REPL (session manager), with `/shell` as escape hatch for PTY when needed (vim, htop, etc.):

```
[my-project] $ /info
Sandbox: my-project-abc
Provider: e2b
Volume: vol-xyz

[my-project] $ /url 3000
https://my-project-abc-3000.preview.computesdk.com

[my-project] $ /shell
user@sandbox:~$ vim app.js
user@sandbox:~$ exit

[my-project] $ .exit
```

Like psql/mysql have SQL + meta-commands (`\dt`, `\q`), we have shell + meta-commands (`/info`, `/shell`).

### OAuth Flow

No API keys needed. Browser-based login:

```
◇  No credentials found
│  Opening browser to login...

◇  Logged in as garrison@example.com
```

Token stored in `~/.compute/credentials.json`

### Directory Sync

Sync your local project to the sandbox:

```
◇  Sync local directory?
│  ● Yes - current directory (/Users/me/my-project)
│  ○ No

◇  Syncing files... (respecting .gitignore)
│  47 files uploaded

◇  Found .env file
│  ● Sync to sandbox
│  ○ Skip

◇  Detected: package.json
│  ● Run npm install
│  ○ Skip
```

Uses tar for speed (1 upload vs 500 HTTP requests), or `git clone` + PAT for private repos.

### Git Integration

For private repos:

```
◇  Private repo detected
│  Enter GitHub PAT: ghp_xxxx
│  
◇  Save PAT locally? (~/.compute/credentials.json)
│  ● Yes
│  ○ No
```

PAT also saved to sandbox's `~/.git-credentials`, so `git pull`/`git push` just work.

### Persistent Volumes

Sandboxes are ephemeral, but volumes persist:

```
◇  Sandbox expired, but volume still exists
│  Creating new sandbox with existing volume...

[new-sandbox-xyz] $ ls
# all your stuff is still there - node_modules, .env, code
```

### Config Files

**Local registry** (`~/.compute/`):
```
~/.compute/
├── credentials.json          # ComputeSDK token, GitHub PAT (chmod 600)
├── config.json               # sandbox registry
└── sandboxes/<id>/
    └── config.json           # provider, sync settings, install_cmd
```

**Per-project** (`./compute.json`) - optional:
```json
{
  "provider": "e2b",
  "sync": true,
  "env_file": ".env",
  "install_cmd": "npm install"
}
```

### Reconnect Flow

First time: full prompts → save settings

Next time:
```
◇  Found existing sandbox: my-project-abc
│  Reconnecting... ✓

[my-project-abc] $ 
```

One second and you're back in, everything still there.

---

## REPL Commands (Future)

```
/help       - show commands
/info       - sandbox info  
/url 3000   - get preview URL
/shell      - enter PTY mode
/sync       - re-sync local files
/env        - manage env vars
/destroy    - tear down sandbox
.exit       - quit
```