### PR TITLE
perf(vercel): use builtin stdout/stderr pipes to avoid blocking `runCommand`

### DIFF
--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@vercel/sandbox": "^1.6.0",
+    "@vercel/sandbox": "^1.9.3",
     "computesdk": "workspace:*",
     "ms": "^2.1.3"
   },

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -7,6 +7,7 @@
 
 import { Sandbox as VercelSandbox, Snapshot as VercelSnapshot } from '@vercel/sandbox';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
+import { Writable } from 'node:stream';
 
 export type { VercelSandbox, VercelSnapshot };
 
@@ -98,6 +99,21 @@ function validateCredentials(creds: ResolvedCredentials): void {
   }
 }
 
+/**
+ * Get a writable stream that collects UTF-8 string data and buffers it
+ * in memory, returning the full concatenated string when done.
+ */
+function getUtf8Sink() {
+  const chunks: string[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") :
+        String(chunk));
+      cb();
+    },
+  });
+  return { sink, value: () => chunks.join("") };
+}
 
 
 
@@ -337,26 +353,24 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
               .join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
-          
-          // Handle working directory
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-          
-          // Handle background execution
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
 
-          const result = await sandbox.runCommand('sh', ['-c', fullCommand]);
-          // Call stdout/stderr sequentially to avoid "Multiple consumers for logs" warning
-          const stdout = await result.stdout();
-          const stderr = await result.stderr();
+          // If running in the background, don't capture stdout/stderr
+          const stdout = options?.background ? undefined : getUtf8Sink();
+          const stderr = options?.background ? undefined : getUtf8Sink();
+
+          const result = await sandbox.runCommand({
+            cmd: 'sh',
+            args: ['-c', fullCommand],
+            cwd: options?.cwd,
+            detached: options?.background,
+            stdout: stdout?.sink,
+            stderr: stderr?.sink,
+          });
 
           return {
-            stdout,
-            stderr,
-            exitCode: result.exitCode,
+            stdout: stdout?.value() ?? '',
+            stderr: stderr?.value() ?? '',
+            exitCode: result.exitCode ?? 0,
             durationMs: Date.now() - startTime,
           };
         } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1373,8 +1373,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@vercel/sandbox':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.9.3
+        version: 1.9.3
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -4313,12 +4313,12 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vercel/sandbox@1.6.0':
-    resolution: {integrity: sha512-T204S3RZIdo+BCR5gpErTQBYz+ruXjTMRiZyf+HV/UQeKjPKAVKWu27T65kahDvVvJrbadHhxR2Cds28rXXF/Q==}
+  '@vercel/sandbox@1.9.3':
+    resolution: {integrity: sha512-G6ef1izdlYftkmv2xxBfks76gm2oxIH3LgiASe8WMw7xoge6zFzyFjY91/dPMT0Pkd4UNX9nsaOedj98ywdk8Q==}
 
   '@vitest/coverage-v8@1.6.1':
     resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
@@ -4339,6 +4339,9 @@ packages:
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
   '@xterm/addon-serialize@0.13.0':
     resolution: {integrity: sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==}
@@ -12085,11 +12088,12 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
-  '@vercel/sandbox@1.6.0':
+  '@vercel/sandbox@1.9.3':
     dependencies:
-      '@vercel/oidc': 3.1.0
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
       async-retry: 1.3.3
       jsonlines: 0.1.1
       ms: 2.1.3
@@ -12146,6 +12150,8 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@workflow/serde@4.1.0-beta.2': {}
 
   '@xterm/addon-serialize@0.13.0(@xterm/xterm@5.5.0)':
     dependencies:


### PR DESCRIPTION
Currently, the `@computesdk/vercel` package uses sequential `sandbox.runCommand()` and `command.stdout()` / `command.stderr()`: https://github.com/computesdk/computesdk/blob/dbeefe209b52be3a1ea279275c5637ab9f9c3333/packages/vercel/src/index.ts#L351

In the [Time-To-Interactive benchmarks](https://github.com/computesdk/benchmarks), this increases the measured TTI artifically, as it waits for the command to exit first, then performes another call to retrieve the logs sequentially.

The `@vercel/sandbox` SDK supports passing in `stdout` and `stderr` fields to `sandbox.runCommand()`, when the command isn't running it `detached` mode (aka, not in the background). When present, the two calls to 1) run the command and wait for it to exit 2) get the logs happen in parallel: https://github.com/vercel/sandbox/blob/9dc0ac96d1d531b5a44786c92d6ddc2ce4890791/packages/vercel-sandbox/src/sandbox.ts#L538

This PR also updates the logic for the `cwd` and `background` options, as they are supported natively by the `@vercel/sandbox` SDK, and updates to the latest version

---

Running the ComputeSDK benchmarks from London (`lhr1`), creating 10 sandboxes sequentially in `iad1`:

Before:
- p50: 0.63s
- p95/p99: 0.81s
<img width="666" height="132" alt="Screenshot 2026-04-10 at 11 24 43" src="https://github.com/user-attachments/assets/72950cb0-0834-4799-aa82-1abaa97b49c3" />

After:
- p50: 0.50s
- p95/p99: 0.57s
<img width="669" height="135" alt="Screenshot 2026-04-10 at 11 23 11" src="https://github.com/user-attachments/assets/37ff6c4f-dcee-40de-a44b-757f737a5be9" />