### PR TITLE
Add Prime Intellect sandbox provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ npm install @computesdk/modal      # Modal provider
 npm install @computesdk/railway    # Railway provider
 npm install @computesdk/daytona    # Daytona provider
 npm install @computesdk/vercel     # Vercel provider
+npm install @computesdk/prime      # Prime Intellect Sandboxes provider
 npm install @computesdk/just-bash  # Local bash sandbox (no auth needed)
 ```
 
@@ -275,6 +276,7 @@ See individual provider READMEs for details:
 - **[@computesdk/railway](./packages/railway)** - Full-stack deployments
 - **[@computesdk/daytona](./packages/daytona)** - Development workspaces
 - **[@computesdk/vercel](./packages/vercel)** - Serverless functions
+- **[@computesdk/prime](./packages/prime)** - Prime Intellect Docker sandboxes with gateway command execution
 - **[@computesdk/just-bash](./packages/just-bash)** - Local bash sandbox with virtual filesystem (no auth required)
 
 ## Building Custom Providers

--- a/packages/prime/CHANGELOG.md
+++ b/packages/prime/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @computesdk/prime
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release of the Prime Intellect Sandboxes provider for ComputeSDK.

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -1,0 +1,54 @@
+# @computesdk/prime
+
+Prime Intellect Sandboxes provider for ComputeSDK.
+
+## Installation
+
+```bash
+npm install @computesdk/prime
+```
+
+## Setup
+
+Set your Prime API key:
+
+```bash
+export PRIME_API_KEY=your_prime_api_key
+```
+
+Optional:
+
+```bash
+export PRIME_TEAM_ID=team_id
+export PRIME_API_BASE_URL=https://api.primeintellect.ai
+export PRIME_SANDBOX_IMAGE=node:22
+export PRIME_SANDBOX_CPU_CORES=1
+export PRIME_SANDBOX_MEMORY_GB=2
+export PRIME_SANDBOX_DISK_SIZE_GB=5
+export PRIME_SANDBOX_TIMEOUT_MINUTES=15
+```
+
+## Usage
+
+```typescript
+import { prime } from '@computesdk/prime';
+
+const compute = prime({
+  apiKey: process.env.PRIME_API_KEY,
+  teamId: process.env.PRIME_TEAM_ID,
+});
+
+const sandbox = await compute.sandbox.create({ runtime: 'node' });
+const result = await sandbox.runCommand('node -v');
+
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+## Notes
+
+- Sandboxes are created through Prime's `/api/v1/sandbox` API.
+- Command execution uses Prime's `/sandbox/{id}/auth` endpoint plus the gateway `/exec` endpoint.
+- `getUrl()` uses Prime's port exposure API and reuses existing exposures when possible.
+- Filesystem methods are not implemented in this provider.

--- a/packages/prime/package.json
+++ b/packages/prime/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@computesdk/prime",
+  "version": "0.1.0",
+  "description": "Prime Intellect Sandboxes provider for ComputeSDK - disposable Docker sandboxes with gateway command execution",
+  "author": "ComputeSDK Team",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "prime",
+    "prime-intellect",
+    "sandbox",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider",
+    "containers"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/prime"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/prime/src/__tests__/crud.test.ts
+++ b/packages/prime/src/__tests__/crud.test.ts
@@ -1,0 +1,8 @@
+import { runProviderCrudTest } from '@computesdk/test-utils';
+import { prime } from '../index';
+
+runProviderCrudTest({
+  name: 'prime',
+  provider: prime({}),
+  skipIntegration: !process.env.PRIME_API_KEY,
+});

--- a/packages/prime/src/__tests__/index.test.ts
+++ b/packages/prime/src/__tests__/index.test.ts
@@ -1,0 +1,9 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { prime } from '../index';
+
+runProviderTestSuite({
+  name: 'prime',
+  provider: prime({}),
+  supportsFilesystem: false,
+  skipIntegration: !process.env.PRIME_API_KEY,
+});

--- a/packages/prime/src/index.ts
+++ b/packages/prime/src/index.ts
@@ -1,0 +1,808 @@
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+
+import type {
+  CodeResult,
+  CommandResult,
+  CreateSandboxOptions,
+  RunCommandOptions,
+  Runtime,
+  SandboxInfo,
+} from '@computesdk/provider';
+
+const DEFAULT_BASE_URL = 'https://api.primeintellect.ai';
+const DEFAULT_NODE_IMAGE = 'node:22';
+const DEFAULT_PYTHON_IMAGE = 'python:3.12-slim';
+const DEFAULT_TIMEOUT_MS = 300_000;
+const PRIME_FAILED_STATUSES = new Set(['ERROR', 'TERMINATED', 'TIMEOUT']);
+
+interface PrimeCreateResponse {
+  id: string;
+  name?: string;
+  status?: string;
+  dockerImage?: string;
+  docker_image?: string;
+  createdAt?: string;
+  created_at?: string;
+  startedAt?: string | null;
+  started_at?: string | null;
+  terminatedAt?: string | null;
+  terminated_at?: string | null;
+  errorType?: string;
+  error_type?: string;
+  errorMessage?: string;
+  error_message?: string;
+  cpuCores?: number;
+  cpu_cores?: number;
+  memoryGB?: number;
+  memory_gb?: number;
+  diskSizeGB?: number;
+  disk_size_gb?: number;
+  networkAccess?: boolean;
+  network_access?: boolean;
+  teamId?: string;
+  team_id?: string;
+}
+
+interface PrimeAuthResponse {
+  token: string;
+  gateway_url?: string;
+  gatewayUrl?: string;
+  user_ns?: string;
+  userNs?: string;
+  job_id?: string;
+  jobId?: string;
+}
+
+interface PrimeCommandResponse {
+  stdout?: string;
+  stderr?: string;
+  exit_code?: number;
+  exitCode?: number;
+}
+
+interface PrimeExposure {
+  exposure_id?: string;
+  exposureId?: string;
+  sandbox_id?: string;
+  sandboxId?: string;
+  port: number;
+  protocol?: string;
+  url?: string;
+  external_endpoint?: string;
+  externalEndpoint?: string;
+}
+
+interface PrimeExposureListResponse {
+  exposures?: PrimeExposure[];
+}
+
+interface PrimeSandbox extends PrimeCreateResponse {
+  apiKey: string;
+  baseUrl: string;
+  timeoutMs: number;
+  runtime: Runtime;
+}
+
+export interface PrimeConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  teamId?: string;
+  image?: string;
+  cpuCores?: number;
+  memoryGb?: number;
+  diskSizeGb?: number;
+  timeout?: number;
+  timeoutMinutes?: number;
+  runtime?: Runtime;
+}
+
+interface ResolvedPrimeConfig {
+  apiKey: string;
+  baseUrl: string;
+  teamId?: string;
+  image?: string;
+  cpuCores?: number;
+  memoryGb?: number;
+  diskSizeGb?: number;
+  timeoutMs: number;
+  timeoutMinutes?: number;
+  runtime?: Runtime;
+}
+
+export const prime = defineProvider<PrimeSandbox, PrimeConfig>({
+  name: 'prime',
+  methods: {
+    sandbox: {
+      create: async (config: PrimeConfig, options?: CreateSandboxOptions) => {
+        const resolved = resolveConfig(config);
+
+        if (options?.sandboxId) {
+          const existing = await getPrimeSandbox(resolved, options.sandboxId);
+          return {
+            sandbox: existing,
+            sandboxId: existing.id,
+          };
+        }
+
+        const {
+          runtime: optRuntime,
+          timeout: optTimeout,
+          envs,
+          name,
+          metadata,
+          templateId: _templateId,
+          snapshotId: _snapshotId,
+          sandboxId: _sandboxId,
+          namespace: _namespace,
+          directory: _directory,
+          overlays: _overlays,
+          servers: _servers,
+          ...providerOptions
+        } = options || {};
+
+        const runtime = optRuntime || resolved.runtime || 'node';
+        const providerRecord = providerOptions as Record<string, unknown>;
+        const timeoutMs = parsePositiveNumber(optTimeout) ?? resolved.timeoutMs;
+        const timeoutMinutes =
+          parsePositiveInt(providerRecord.timeoutMinutes) ??
+          parsePositiveInt(providerRecord.timeout_minutes) ??
+          resolved.timeoutMinutes ??
+          Math.max(1, Math.ceil(timeoutMs / 60_000));
+
+        const image =
+          asNonEmptyString(providerRecord.image) ||
+          resolved.image ||
+          defaultImageForRuntime(runtime);
+
+        const cpuCores =
+          parsePositiveNumber(providerRecord.cpuCores) ??
+          parsePositiveNumber(providerRecord.cpu_cores) ??
+          resolved.cpuCores ??
+          1;
+
+        const memoryGb =
+          parsePositiveNumber(providerRecord.memoryGb) ??
+          parsePositiveNumber(providerRecord.memory_gb) ??
+          resolved.memoryGb ??
+          2;
+
+        const diskSizeGb =
+          parsePositiveNumber(providerRecord.diskSizeGb) ??
+          parsePositiveNumber(providerRecord.disk_size_gb) ??
+          resolved.diskSizeGb ??
+          5;
+
+        const payload: Record<string, unknown> = {
+          name: name || createSandboxName(),
+          docker_image: image,
+          start_command:
+            asNonEmptyString(providerRecord.startCommand) ||
+            asNonEmptyString(providerRecord.start_command) ||
+            'tail -f /dev/null',
+          cpu_cores: cpuCores,
+          memory_gb: memoryGb,
+          disk_size_gb: diskSizeGb,
+          gpu_count: 0,
+          vm: false,
+          network_access: true,
+          timeout_minutes: timeoutMinutes,
+        };
+
+        if (resolved.teamId) {
+          payload.team_id = resolved.teamId;
+        }
+
+        if (envs && Object.keys(envs).length > 0) {
+          payload.environment_vars = envs;
+        }
+
+        if (metadata && typeof metadata === 'object') {
+          payload.labels = Object.entries(metadata).map(([key, value]) => {
+            const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+            return `${key}:${rendered}`;
+          });
+        }
+
+        const created = await fetchJson<PrimeCreateResponse>(
+          `${resolved.baseUrl}/api/v1/sandbox`,
+          {
+            method: 'POST',
+            headers: withJsonHeaders(apiHeaders(resolved.apiKey)),
+            body: JSON.stringify(payload),
+          }
+        );
+
+        return {
+          sandbox: createSandboxState(created, resolved, runtime, timeoutMs),
+          sandboxId: created.id,
+        };
+      },
+
+      getById: async (config: PrimeConfig, sandboxId: string) => {
+        const resolved = resolveConfig(config);
+
+        try {
+          const sandbox = await getPrimeSandbox(resolved, sandboxId);
+          return {
+            sandbox,
+            sandboxId: sandbox.id,
+          };
+        } catch (error) {
+          if (error instanceof Error && error.message.includes('(404)')) {
+            return null;
+          }
+          throw error;
+        }
+      },
+
+      list: async (config: PrimeConfig) => {
+        const resolved = resolveConfig(config);
+        const search = new URLSearchParams({
+          page: '1',
+          per_page: '100',
+        });
+
+        if (resolved.teamId) {
+          search.set('team_id', resolved.teamId);
+        }
+
+        try {
+          const response = await fetchJson<PrimeExposureListResponse & { sandboxes?: PrimeCreateResponse[] }>(
+            `${resolved.baseUrl}/api/v1/sandbox?${search.toString()}`,
+            {
+              method: 'GET',
+              headers: apiHeaders(resolved.apiKey),
+            }
+          );
+
+          return (response.sandboxes || []).map(sandbox => {
+            const runtime = inferRuntimeFromImage(
+              sandbox.dockerImage || sandbox.docker_image || resolved.image || DEFAULT_NODE_IMAGE
+            );
+            const state = createSandboxState(sandbox, resolved, runtime, resolved.timeoutMs);
+            return {
+              sandbox: state,
+              sandboxId: state.id,
+            };
+          });
+        } catch (_error) {
+          return [];
+        }
+      },
+
+      destroy: async (config: PrimeConfig, sandboxId: string) => {
+        const resolved = resolveConfig(config);
+        const response = await fetch(`${resolved.baseUrl}/api/v1/sandbox/${sandboxId}`, {
+          method: 'DELETE',
+          headers: apiHeaders(resolved.apiKey),
+        });
+
+        if (response.status === 404 || response.status === 410) {
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to delete Prime sandbox '${sandboxId}' (${response.status}): ${await safeReadText(response)}`
+          );
+        }
+      },
+
+      runCode: async (sandbox: PrimeSandbox, code: string, runtime?: Runtime): Promise<CodeResult> => {
+        const effectiveRuntime = runtime || detectRuntime(code, sandbox.runtime);
+        const command = buildRuntimeCommand(code, effectiveRuntime);
+        const result = await runPrimeCommand(sandbox, command, {
+          timeoutMs: sandbox.timeoutMs,
+        });
+        const output = combineOutput(result.stdout, result.stderr);
+
+        if (result.exitCode !== 0 && isSyntaxError(output, effectiveRuntime)) {
+          throw new Error(`Syntax error: ${firstNonEmptyLine(output)}`);
+        }
+
+        return {
+          output,
+          exitCode: result.exitCode,
+          language: effectiveRuntime,
+        };
+      },
+
+      runCommand: async (
+        sandbox: PrimeSandbox,
+        command: string,
+        options?: RunCommandOptions
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+        const timeoutMs = parsePositiveNumber(options?.timeout) ?? sandbox.timeoutMs;
+        const background = Boolean((options as { background?: boolean } | undefined)?.background);
+
+        try {
+          const result = await runPrimeCommand(
+            sandbox,
+            background ? wrapBackgroundCommand(command) : command,
+            {
+              cwd: options?.cwd,
+              env: options?.env,
+              timeoutMs,
+            }
+          );
+
+          return {
+            stdout: result.stdout,
+            stderr: result.stderr,
+            exitCode: result.exitCode,
+            durationMs: Date.now() - startTime,
+          };
+        } catch (error) {
+          return {
+            stdout: '',
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: 127,
+            durationMs: Date.now() - startTime,
+          };
+        }
+      },
+
+      getInfo: async (sandbox: PrimeSandbox): Promise<SandboxInfo> => {
+        const refreshed = await getPrimeSandbox(
+          {
+            apiKey: sandbox.apiKey,
+            baseUrl: sandbox.baseUrl,
+            timeoutMs: sandbox.timeoutMs,
+          },
+          sandbox.id,
+          sandbox.runtime
+        );
+
+        return {
+          id: refreshed.id,
+          provider: 'prime',
+          runtime: refreshed.runtime,
+          status: mapPrimeStatus(refreshed.status || 'RUNNING'),
+          createdAt: parseDate(refreshed.createdAt || refreshed.created_at),
+          timeout: refreshed.timeoutMs,
+          metadata: {
+            name: refreshed.name,
+            image: refreshed.dockerImage || refreshed.docker_image,
+            cpuCores: refreshed.cpuCores || refreshed.cpu_cores,
+            memoryGb: refreshed.memoryGB || refreshed.memory_gb,
+            diskSizeGb: refreshed.diskSizeGB || refreshed.disk_size_gb,
+            teamId: refreshed.teamId || refreshed.team_id,
+          },
+        };
+      },
+
+      getUrl: async (sandbox: PrimeSandbox, options: { port: number; protocol?: string }): Promise<string> => {
+        const protocol = (options.protocol || 'https').toUpperCase() === 'TCP' ? 'TCP' : 'HTTP';
+        const headers = withJsonHeaders(apiHeaders(sandbox.apiKey));
+        const list = await fetchJson<PrimeExposureListResponse>(
+          `${sandbox.baseUrl}/api/v1/sandbox/${sandbox.id}/expose`,
+          {
+            method: 'GET',
+            headers: apiHeaders(sandbox.apiKey),
+          }
+        );
+
+        const existing = (list.exposures || []).find(exposure =>
+          exposure.port === options.port &&
+          (exposure.protocol || 'HTTP').toUpperCase() === protocol
+        );
+
+        const exposure = existing || await fetchJson<PrimeExposure>(
+          `${sandbox.baseUrl}/api/v1/sandbox/${sandbox.id}/expose`,
+          {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+              port: options.port,
+              protocol,
+            }),
+          }
+        );
+
+        if (exposure.url) {
+          return exposure.url;
+        }
+
+        const externalEndpoint = exposure.external_endpoint || exposure.externalEndpoint;
+        if (externalEndpoint) {
+          if (externalEndpoint.startsWith('http://') || externalEndpoint.startsWith('https://')) {
+            return externalEndpoint;
+          }
+          return protocol === 'TCP' ? externalEndpoint : `https://${externalEndpoint}`;
+        }
+
+        throw new Error(`Prime did not return an exposed URL for sandbox ${sandbox.id} port ${options.port}`);
+      },
+    },
+  },
+});
+
+function resolveConfig(config: PrimeConfig): ResolvedPrimeConfig {
+  const apiKey = asNonEmptyString(config.apiKey) || asNonEmptyString(process.env.PRIME_API_KEY) || '';
+  if (!apiKey) {
+    throw new Error('Missing Prime API key. Set PRIME_API_KEY or pass apiKey in the provider config.');
+  }
+
+  const timeoutMs =
+    parsePositiveNumber(config.timeout) ??
+    parsePositiveNumber(process.env.PRIME_TIMEOUT_MS) ??
+    DEFAULT_TIMEOUT_MS;
+
+  return {
+    apiKey,
+    baseUrl: normalizeBaseUrl(config.baseUrl || process.env.PRIME_API_BASE_URL || process.env.PRIME_BASE_URL || DEFAULT_BASE_URL),
+    teamId: asNonEmptyString(config.teamId) || asNonEmptyString(process.env.PRIME_TEAM_ID),
+    image: asNonEmptyString(config.image) || asNonEmptyString(process.env.PRIME_SANDBOX_IMAGE),
+    cpuCores:
+      parsePositiveNumber(config.cpuCores) ??
+      parsePositiveNumber(process.env.PRIME_SANDBOX_CPU_CORES),
+    memoryGb:
+      parsePositiveNumber(config.memoryGb) ??
+      parsePositiveNumber(process.env.PRIME_SANDBOX_MEMORY_GB),
+    diskSizeGb:
+      parsePositiveNumber(config.diskSizeGb) ??
+      parsePositiveNumber(process.env.PRIME_SANDBOX_DISK_SIZE_GB),
+    timeoutMs,
+    timeoutMinutes:
+      parsePositiveInt(config.timeoutMinutes) ??
+      parsePositiveInt(process.env.PRIME_SANDBOX_TIMEOUT_MINUTES),
+    runtime: config.runtime,
+  };
+}
+
+function createSandboxState(
+  source: PrimeCreateResponse,
+  config: ResolvedPrimeConfig,
+  runtime: Runtime,
+  timeoutMs: number
+): PrimeSandbox {
+  return {
+    ...source,
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+    timeoutMs,
+    runtime,
+  };
+}
+
+async function getPrimeSandbox(
+  config: ResolvedPrimeConfig,
+  sandboxId: string,
+  runtime?: Runtime
+): Promise<PrimeSandbox> {
+  const data = await fetchJson<PrimeCreateResponse>(
+    `${config.baseUrl}/api/v1/sandbox/${sandboxId}`,
+    {
+      method: 'GET',
+      headers: apiHeaders(config.apiKey),
+    }
+  );
+
+  const inferredRuntime = runtime || inferRuntimeFromImage(
+    data.dockerImage || data.docker_image || config.image || DEFAULT_NODE_IMAGE
+  );
+
+  return createSandboxState(data, config, inferredRuntime, config.timeoutMs);
+}
+
+async function runPrimeCommand(
+  sandbox: PrimeSandbox,
+  command: string,
+  options: { cwd?: string; env?: Record<string, string>; timeoutMs: number }
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const deadline = Date.now() + options.timeoutMs;
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    const current = await getPrimeSandbox(
+      {
+        apiKey: sandbox.apiKey,
+        baseUrl: sandbox.baseUrl,
+        timeoutMs: sandbox.timeoutMs,
+      },
+      sandbox.id,
+      sandbox.runtime
+    );
+
+    sandbox.status = current.status;
+    sandbox.errorType = current.errorType;
+    sandbox.error_type = current.error_type;
+    sandbox.errorMessage = current.errorMessage;
+    sandbox.error_message = current.error_message;
+
+    if (PRIME_FAILED_STATUSES.has(current.status || '')) {
+      throw new Error(formatPrimeError(current));
+    }
+
+    if ((current.status || '') === 'RUNNING') {
+      try {
+        const remainingMs = Math.max(1_000, deadline - Date.now());
+        return await execPrimeCommand(current, command, {
+          cwd: options.cwd,
+          env: options.env,
+          timeoutMs: remainingMs,
+        });
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    await sleep(attempt < 5 ? 1_000 : 2_000);
+    attempt += 1;
+  }
+
+  const reason = lastError instanceof Error ? lastError.message : 'sandbox never became command-ready';
+  throw new Error(`Prime sandbox ${sandbox.id} was not ready in time: ${reason}`);
+}
+
+async function execPrimeCommand(
+  sandbox: PrimeSandbox,
+  command: string,
+  options: { cwd?: string; env?: Record<string, string>; timeoutMs: number }
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const auth = await fetchJson<PrimeAuthResponse>(
+    `${sandbox.baseUrl}/api/v1/sandbox/${sandbox.id}/auth`,
+    {
+      method: 'POST',
+      headers: apiHeaders(sandbox.apiKey),
+    }
+  );
+
+  const gatewayUrl = normalizeBaseUrl(auth.gateway_url || auth.gatewayUrl || '');
+  const userNs = auth.user_ns || auth.userNs;
+  const jobId = auth.job_id || auth.jobId;
+
+  if (!gatewayUrl || !userNs || !jobId || !auth.token) {
+    throw new Error(`Prime auth response was missing gateway details for sandbox ${sandbox.id}`);
+  }
+
+  const payload = {
+    command,
+    working_dir: options.cwd,
+    env: validateEnv(options.env),
+    sandbox_id: sandbox.id,
+    timeout: Math.max(1, Math.ceil(options.timeoutMs / 1000)),
+  };
+
+  const result = await fetchJson<PrimeCommandResponse>(
+    `${gatewayUrl}/${userNs}/${jobId}/exec`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    },
+    options.timeoutMs + 5_000
+  );
+
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.exit_code ?? result.exitCode ?? 1,
+  };
+}
+
+function validateEnv(env?: Record<string, string>): Record<string, string> {
+  if (!env) return {};
+
+  const validated: Record<string, string> = {};
+  const safeKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+  for (const [key, value] of Object.entries(env)) {
+    if (!safeKeyPattern.test(key)) {
+      throw new Error(`Invalid environment variable name: ${key}`);
+    }
+    validated[key] = value;
+  }
+
+  return validated;
+}
+
+function apiHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+function withJsonHeaders(headers: Record<string, string>): Record<string, string> {
+  return {
+    ...headers,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function fetchJson<T>(url: string, init: RequestInit, timeoutMs = 30_000): Promise<T> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) as unknown : {};
+
+    if (!response.ok) {
+      const detail = typeof data === 'object' && data !== null && 'detail' in data
+        ? String((data as { detail?: unknown }).detail)
+        : text || response.statusText;
+      throw new Error(`Prime request failed (${response.status}) ${response.url}: ${detail}`);
+    }
+
+    return data as T;
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error(`Prime request timed out after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    const text = (await response.text()).trim();
+    return text || '<empty response>';
+  } catch {
+    return '<failed to read response>';
+  }
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '').replace(/\/api\/v1$/, '');
+}
+
+function detectRuntime(code: string, fallback: Runtime = 'node'): Runtime {
+  if (
+    code.includes('print(') ||
+    code.includes('import ') ||
+    code.includes('def ') ||
+    code.includes('raise ')
+  ) {
+    return 'python';
+  }
+
+  return fallback;
+}
+
+function inferRuntimeFromImage(image: string): Runtime {
+  const normalized = image.toLowerCase();
+  if (normalized.includes('python')) return 'python';
+  if (normalized.includes('bun')) return 'bun';
+  if (normalized.includes('deno')) return 'deno';
+  return 'node';
+}
+
+function defaultImageForRuntime(runtime: Runtime): string {
+  return runtime === 'python' ? DEFAULT_PYTHON_IMAGE : DEFAULT_NODE_IMAGE;
+}
+
+function buildRuntimeCommand(code: string, runtime: Runtime): string {
+  const encoded = Buffer.from(code, 'utf8').toString('base64');
+
+  if (runtime === 'python') {
+    return `echo "${encoded}" | base64 -d | (if command -v python3 >/dev/null 2>&1; then python3; else python; fi)`;
+  }
+
+  if (runtime === 'deno') {
+    return `echo "${encoded}" | base64 -d | deno run -`;
+  }
+
+  if (runtime === 'bun') {
+    return `echo "${encoded}" | base64 -d | bun`;
+  }
+
+  return `echo "${encoded}" | base64 -d | node`;
+}
+
+function wrapBackgroundCommand(command: string): string {
+  return `nohup sh -lc ${escapeShellArg(command)} < /dev/null > /dev/null 2>&1 &`;
+}
+
+function combineOutput(stdout: string, stderr: string): string {
+  if (stdout && stderr) {
+    const needsSeparator = !stdout.endsWith('\n') && !stderr.startsWith('\n');
+    return needsSeparator ? `${stdout}\n${stderr}` : `${stdout}${stderr}`;
+  }
+  return stdout || stderr;
+}
+
+function mapPrimeStatus(status: string): SandboxInfo['status'] {
+  switch (status) {
+    case 'PENDING':
+    case 'PROVISIONING':
+    case 'RUNNING':
+      return 'running';
+    case 'PAUSED':
+    case 'TERMINATED':
+      return 'stopped';
+    default:
+      return 'error';
+  }
+}
+
+function formatPrimeError(sandbox: PrimeCreateResponse): string {
+  const errorType = sandbox.errorType || sandbox.error_type;
+  const errorMessage = sandbox.errorMessage || sandbox.error_message;
+  const detail = [errorType, errorMessage].filter(Boolean).join(': ');
+  return detail ? `Sandbox ${sandbox.id} ${sandbox.status}: ${detail}` : `Sandbox ${sandbox.id} ${sandbox.status}`;
+}
+
+function isSyntaxError(output: string, runtime: Runtime): boolean {
+  const normalized = output.toLowerCase();
+
+  if (runtime === 'python') {
+    return (
+      normalized.includes('syntaxerror') ||
+      normalized.includes('invalid syntax') ||
+      normalized.includes('indentationerror') ||
+      normalized.includes('taberror')
+    );
+  }
+
+  return (
+    normalized.includes('syntaxerror') ||
+    normalized.includes('unexpected token') ||
+    normalized.includes('unexpected identifier') ||
+    normalized.includes('parse error')
+  );
+}
+
+function firstNonEmptyLine(text: string): string {
+  const line = text
+    .split('\n')
+    .map(value => value.trim())
+    .find(value => value.length > 0);
+
+  return line || 'Invalid code.';
+}
+
+function parseDate(value?: string): Date {
+  if (!value) return new Date();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+function parsePositiveNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+
+  if (typeof value === 'string') {
+    if (!value.trim()) return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function parsePositiveInt(value: unknown): number | undefined {
+  const parsed = parsePositiveNumber(value);
+  return parsed === undefined ? undefined : Math.floor(parsed);
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function createSandboxName(): string {
+  return `prime-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/packages/prime/src/index.ts
+++ b/packages/prime/src/index.ts
@@ -496,40 +496,40 @@ async function runPrimeCommand(
   let lastError: unknown;
 
   while (Date.now() < deadline) {
-    const current = await getPrimeSandbox(
-      {
-        apiKey: sandbox.apiKey,
-        baseUrl: sandbox.baseUrl,
-        timeoutMs: sandbox.timeoutMs,
-      },
-      sandbox.id,
-      sandbox.runtime
-    );
-
-    sandbox.status = current.status;
-    sandbox.errorType = current.errorType;
-    sandbox.error_type = current.error_type;
-    sandbox.errorMessage = current.errorMessage;
-    sandbox.error_message = current.error_message;
-
-    if (PRIME_FAILED_STATUSES.has(current.status || '')) {
-      throw new Error(formatPrimeError(current));
+    try {
+      const remainingMs = Math.max(1_000, deadline - Date.now());
+      return await execPrimeCommand(sandbox, command, {
+        cwd: options.cwd,
+        env: options.env,
+        timeoutMs: remainingMs,
+      });
+    } catch (error) {
+      lastError = error;
     }
 
-    if ((current.status || '') === 'RUNNING') {
-      try {
-        const remainingMs = Math.max(1_000, deadline - Date.now());
-        return await execPrimeCommand(current, command, {
-          cwd: options.cwd,
-          env: options.env,
-          timeoutMs: remainingMs,
-        });
-      } catch (error) {
-        lastError = error;
+    if (attempt < 5 || attempt % 4 === 0) {
+      const current = await getPrimeSandbox(
+        {
+          apiKey: sandbox.apiKey,
+          baseUrl: sandbox.baseUrl,
+          timeoutMs: sandbox.timeoutMs,
+        },
+        sandbox.id,
+        sandbox.runtime
+      );
+
+      sandbox.status = current.status;
+      sandbox.errorType = current.errorType;
+      sandbox.error_type = current.error_type;
+      sandbox.errorMessage = current.errorMessage;
+      sandbox.error_message = current.error_message;
+
+      if (PRIME_FAILED_STATUSES.has(current.status || '')) {
+        throw new Error(formatPrimeError(current));
       }
     }
 
-    await sleep(attempt < 5 ? 1_000 : 2_000);
+    await sleep(attempt < 10 ? 100 : 250);
     attempt += 1;
   }
 

--- a/packages/prime/tsconfig.json
+++ b/packages/prime/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "paths": {
+      "@computesdk/provider": ["../provider/dist/index.d.ts"],
+      "@computesdk/test-utils": ["../test-utils/dist/index.d.ts"],
+      "computesdk": ["../computesdk/dist/index.d.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/prime/tsup.config.ts
+++ b/packages/prime/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/prime/vitest.config.ts
+++ b/packages/prime/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,6 +996,40 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/prime:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/provider:
     dependencies:
       '@computesdk/cmd':


### PR DESCRIPTION
## Summary
- add a first-party `@computesdk/prime` provider package for Prime Intellect Sandboxes
- implement sandbox lifecycle, command/code execution, info, and port exposure support
- add package docs, tests, build config, and register the provider in the root README

## Validation
- `corepack pnpm --filter @computesdk/prime typecheck`
- `corepack pnpm --filter @computesdk/prime build`
- `corepack pnpm --filter @computesdk/prime test`
- live smoke test against Prime: create sandbox, run `node -v`, destroy

## Follow-up
- a benchmark repo PR is being opened separately with the Prime benchmark adapter and current results