### PR TITLE
Sync packages from computesdk-core

### DIFF
--- a/.changeset/vercel-runtime-translation-and-sandbox-bump.md
+++ b/.changeset/vercel-runtime-translation-and-sandbox-bump.md
@@ -1,0 +1,9 @@
+---
+"@computesdk/vercel": patch
+---
+
+Fix generic runtime name handling and improve `runCommand` performance:
+
+- Translate generic runtime names (`node`, `python`) to Vercel-supported versions (`node24`, `python3.13`) so the default provider runtime works end-to-end.
+- Use builtin `@vercel/sandbox` stdout/stderr pipes to avoid blocking `runCommand`.
+- Bump `@vercel/sandbox` to `^1.9.3`.

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "@computesdk/vercel",
-  "version": "1.7.21",
-  "description": "Vercel Sandbox provider for ComputeSDK - serverless code execution for Python and Node.js on Vercel's edge network",
+  "name": "@computesdk/kernel",
+  "version": "0.1.0",
+  "description": "Kernel browser provider for ComputeSDK - cloud browser sessions powered by Kernel",
   "author": "Garrison",
   "license": "MIT",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [
@@ -19,33 +20,31 @@
   ],
   "scripts": {
     "build": "tsup",
+    "clean": "rimraf dist",
     "dev": "tsup --watch",
     "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint"
   },
   "dependencies": {
+    "@onkernel/sdk": "^0.5.0",
     "@computesdk/provider": "workspace:*",
-    "@vercel/sandbox": "^1.9.3",
-    "computesdk": "workspace:*",
-    "ms": "^2.1.3"
+    "computesdk": "workspace:*"
   },
   "keywords": [
     "computesdk",
-    "vercel",
-    "sandbox",
-    "code-execution",
-    "nodejs",
-    "python",
-    "cloud",
-    "compute",
-    "provider",
-    "serverless"
+    "kernel",
+    "browser",
+    "headless",
+    "playwright",
+    "provider"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/computesdk/computesdk.git",
-    "directory": "packages/vercel"
+    "directory": "packages/kernel"
   },
   "homepage": "https://www.computesdk.com",
   "bugs": {
@@ -53,7 +52,6 @@
   },
   "devDependencies": {
     "@computesdk/test-utils": "workspace:*",
-    "@types/ms": "^0.7.34",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^1.0.0",
     "eslint": "^8.37.0",

--- a/packages/kernel/src/__tests__/index.test.ts
+++ b/packages/kernel/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { runBrowserProviderTestSuite } from '@computesdk/test-utils';
+import { kernel } from '../index';
+
+runBrowserProviderTestSuite({
+  name: 'kernel',
+  provider: kernel({}),
+  skipIntegration: !process.env.KERNEL_API_KEY,
+});

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,0 +1,337 @@
+/**
+ * Kernel Browser Provider - Factory-based Implementation
+ *
+ * Cloud browser sessions with stealth mode, GPU acceleration,
+ * profiles, and extensions via the Kernel platform.
+ */
+
+import Kernel from '@onkernel/sdk';
+import { defineBrowserProvider } from '@computesdk/provider';
+
+import type {
+  CreateBrowserSessionOptions,
+  CreateBrowserProfileOptions,
+  CreateBrowserExtensionOptions,
+  BrowserProfile,
+  BrowserExtension,
+  BrowserLog,
+  BrowserRecording,
+} from '@computesdk/provider';
+
+import type { BrowserCreateResponse } from '@onkernel/sdk/resources/browsers';
+
+/**
+ * Kernel-specific configuration options
+ */
+export interface KernelConfig {
+  /** Kernel API key — falls back to KERNEL_API_KEY env var */
+  apiKey?: string;
+  /** Invocation ID for the Kernel action context */
+  invocationId?: string;
+}
+
+/**
+ * Resolve config values from explicit config or environment variables
+ */
+function resolveConfig(config: KernelConfig) {
+  const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.KERNEL_API_KEY) || '';
+
+  if (!apiKey) {
+    throw new Error(
+      `Missing Kernel API key. Provide 'apiKey' in config or set KERNEL_API_KEY environment variable. ` +
+      `Get your API key from https://app.onkernel.com`
+    );
+  }
+
+  return { apiKey, invocationId: config.invocationId };
+}
+
+/**
+ * Create a Kernel SDK client from config
+ */
+function createClient(config: KernelConfig): Kernel {
+  const { apiKey } = resolveConfig(config);
+  return new Kernel({ apiKey });
+}
+
+const KERNEL_API_BASE = 'https://api.onkernel.com';
+
+/**
+ * Make a direct API call to Kernel for endpoints not yet in the SDK
+ */
+async function kernelFetch(config: KernelConfig, path: string, options: RequestInit = {}) {
+  const { apiKey } = resolveConfig(config);
+  const response = await fetch(`${KERNEL_API_BASE}${path}`, {
+    ...options,
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Kernel API ${options.method ?? 'GET'} ${path} failed (${response.status}): ${body}`);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+/**
+ * Map ComputeSDK session options to Kernel create browser params.
+ *
+ * The SDK types currently only require invocation_id, but the API
+ * accepts additional fields (stealth, viewport, etc.) so we pass
+ * them through via a type assertion.
+ */
+function mapSessionOptions(config: KernelConfig, options?: CreateBrowserSessionOptions) {
+  const { invocationId } = resolveConfig(config);
+  const params: Record<string, any> = {};
+
+  if (invocationId) params.invocation_id = invocationId;
+
+  if (!options) return params;
+
+  if (options.stealth !== undefined) params.stealth = options.stealth;
+  if (options.timeout !== undefined) params.timeout_seconds = options.timeout;
+
+  // Viewport
+  if (options.viewport) {
+    params.viewport = {
+      width: options.viewport.width,
+      height: options.viewport.height,
+    };
+  }
+
+  // Profile — map profileId to Kernel's profile object
+  if (options.profileId) {
+    params.profile = { id: options.profileId };
+  }
+
+  // Extensions — map extensionIds to Kernel's extensions array
+  if (options.extensionIds?.length) {
+    params.extensions = options.extensionIds.map((id: string) => ({ id }));
+  }
+
+  return params;
+}
+
+/**
+ * Normalize a Kernel browser response into our standard shape
+ */
+function normalizeSession(browser: BrowserCreateResponse) {
+  return {
+    session: browser,
+    sessionId: browser.session_id,
+    connectUrl: browser.cdp_ws_url,
+  };
+}
+
+/**
+ * Create a Kernel browser provider instance
+ *
+ * @example
+ * ```ts
+ * import { kernel } from '@computesdk/kernel';
+ *
+ * const k = kernel({ apiKey: 'k_...' });
+ *
+ * // Create a browser session
+ * const session = await k.session.create({ stealth: true });
+ * console.log(session.connectUrl);
+ *
+ * // Connect with Playwright
+ * const browser = await chromium.connectOverCDP(session.connectUrl);
+ * const page = browser.contexts()[0].pages()[0];
+ * await page.goto('https://example.com');
+ * ```
+ */
+export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>({
+  name: 'kernel',
+  methods: {
+    // ─── Session Lifecycle ─────────────────────────────────────────────
+    session: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const params = mapSessionOptions(config, options);
+        const browser = await client.browsers.create(params as any);
+        return normalizeSession(browser);
+      },
+
+      getById: async (config, sessionId) => {
+        const client = createClient(config);
+        try {
+          const browser = await client.browsers.retrieve(sessionId);
+          return {
+            session: browser as BrowserCreateResponse,
+            sessionId: browser.session_id,
+            connectUrl: browser.cdp_ws_url,
+          };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const client = createClient(config);
+        const browsers = await (client.browsers as any).list();
+        return (browsers as any[]).map((browser: any) => ({
+          session: browser as BrowserCreateResponse,
+          sessionId: browser.session_id,
+          connectUrl: browser.cdp_ws_url,
+        }));
+      },
+
+      destroy: async (config, sessionId) => {
+        const client = createClient(config);
+        await (client.browsers as any).deleteByID(sessionId);
+      },
+
+      getConnectUrl: async (config, sessionId) => {
+        const client = createClient(config);
+        const browser = await client.browsers.retrieve(sessionId);
+        return browser.cdp_ws_url;
+      },
+    },
+
+    // ─── Profiles ─────────────────────────────────────────────────────
+    profile: {
+      create: async (config, options) => {
+        const params: Record<string, any> = {};
+        if (options?.name) params.name = options.name;
+        const result = await kernelFetch(config, '/profiles', {
+          method: 'POST',
+          body: JSON.stringify(params),
+        });
+        return {
+          profileId: result.id,
+          name: result.name ?? options?.name,
+          createdAt: result.created_at ? new Date(result.created_at) : undefined,
+          metadata: options?.metadata as Record<string, unknown> | undefined,
+        } satisfies BrowserProfile;
+      },
+
+      get: async (config, profileId) => {
+        try {
+          const result = await kernelFetch(config, `/profiles/${profileId}`);
+          return {
+            profileId: result.id,
+            name: result.name,
+            createdAt: result.created_at ? new Date(result.created_at) : undefined,
+          } satisfies BrowserProfile;
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const results = await kernelFetch(config, '/profiles');
+        return (results as any[]).map((result) => ({
+          profileId: result.id,
+          name: result.name,
+          createdAt: result.created_at ? new Date(result.created_at) : undefined,
+        } satisfies BrowserProfile));
+      },
+
+      delete: async (config, profileId) => {
+        await kernelFetch(config, `/profiles/${profileId}`, { method: 'DELETE' });
+      },
+    },
+
+    // ─── Extensions ───────────────────────────────────────────────────
+    extension: {
+      create: async (config, options) => {
+        const { apiKey } = resolveConfig(config);
+        const blob = typeof options.file === 'string'
+          ? new Blob([options.file])
+          : new Blob([new Uint8Array(options.file).buffer as ArrayBuffer]);
+        const formData = new FormData();
+        formData.append('file', new File([blob], options.name ?? 'extension.zip'));
+        if (options.name) formData.append('name', options.name);
+        const response = await fetch(`${KERNEL_API_BASE}/extensions`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${apiKey}` },
+          body: formData,
+        });
+        if (!response.ok) {
+          const body = await response.text().catch(() => '');
+          throw new Error(`Failed to upload Kernel extension (${response.status}): ${body}`);
+        }
+        const result = await response.json();
+        return {
+          extensionId: result.id,
+          name: result.name ?? options.name,
+        } satisfies BrowserExtension;
+      },
+
+      get: async (config, extensionId) => {
+        try {
+          const result = await kernelFetch(config, `/extensions/${extensionId}`);
+          return {
+            extensionId: result.id,
+            name: result.name,
+          } satisfies BrowserExtension;
+        } catch {
+          return null;
+        }
+      },
+
+      delete: async (config, extensionId) => {
+        await kernelFetch(config, `/extensions/${extensionId}`, { method: 'DELETE' });
+      },
+    },
+
+    // ─── Logs ─────────────────────────────────────────────────────────
+    logs: {
+      list: async (config, sessionId) => {
+        const { apiKey } = resolveConfig(config);
+        const url = `${KERNEL_API_BASE}/browsers/${sessionId}/logs/stream?source=supervisor&follow=false`;
+        const response = await fetch(url, {
+          headers: { 'Authorization': `Bearer ${apiKey}`, 'Accept': 'text/event-stream' },
+        });
+        if (!response.ok) {
+          const body = await response.text().catch(() => '');
+          throw new Error(`Failed to fetch Kernel logs (${response.status}): ${body}`);
+        }
+        const text = await response.text();
+        const logs: BrowserLog[] = [];
+        for (const block of text.split(/\r?\n\r?\n/)) {
+          const lines = block.split(/\r?\n/).filter((l) => l.startsWith('data:'));
+          if (!lines.length) continue;
+          const data = lines.map((l) => l.slice(5).trim()).join('');
+          try {
+            const event = JSON.parse(data);
+            logs.push({
+              timestamp: new Date(event.timestamp),
+              level: 'info',
+              message: event.message ?? '',
+            });
+          } catch {
+            // skip malformed events
+          }
+        }
+        return logs;
+      },
+    },
+
+    // ─── Recordings (Replays) ─────────────────────────────────────────
+    recording: {
+      get: async (config, sessionId) => {
+        try {
+          const result = await kernelFetch(config, `/browsers/${sessionId}/replays`, {
+            method: 'POST',
+            body: JSON.stringify({}),
+          });
+          return {
+            recordingId: result.replay_id,
+            sessionId,
+            format: 'mp4',
+            url: result.replay_view_url,
+          } satisfies BrowserRecording;
+        } catch {
+          return null;
+        }
+      },
+    },
+  },
+});

--- a/packages/kernel/tsconfig.json
+++ b/packages/kernel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/workbench",
-  "version": "21.0.2",
+  "version": "21.0.1",
   "description": "Interactive REPL for testing ComputeSDK sandbox operations",
   "author": "Garrison",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,6 +891,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/kernel:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@onkernel/sdk':
+        specifier: ^0.5.0
+        version: 0.5.0
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/lambda:
     dependencies:
       computesdk:
@@ -3132,6 +3169,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@onkernel/sdk@0.5.0':
+    resolution: {integrity: sha512-n7gwc7rU0GY/XcDnEV0piHPd76bHTSfuTjQW4qFKUWQji0UK9YUVKDFklqAWbyGlXPUezWCfxh79ELv2cFYOBA==}
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -10401,6 +10441,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@onkernel/sdk@0.5.0': {}
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:


### PR DESCRIPTION
Automated sync of `packages/` and `.changeset/` from [computesdk-core](https://github.com/computesdk/computesdk-core).

**Source commit:** 6b12cb9053045282fa1fb7d5da5b880ed9ecb4d7
**Trigger:** feat: add kernel browser package (#375)

Adds a new @computesdk/kernel browser provider package that mirrors the existing browserbase provider method groups, using @onkernel/sdk plus direct REST calls for endpoints not covered by the SDK.

## Changes:

- Introduces the @computesdk/kernel package with build/test tooling (tsup/tsconfig/vitest).
- Implements Kernel-backed browser provider methods for sessions, profiles, extensions, logs, and recordings.
- Updates the lockfile to include @onkernel/sdk@0.5.0 and the new workspace package entry.

This PR will be automatically updated with new changes until merged.