### PR TITLE
Sync packages from computesdk-core

### DIFF
--- a/.changeset/vercel-runtime-translation-and-sandbox-bump.md
+++ b/.changeset/vercel-runtime-translation-and-sandbox-bump.md
@@ -1,0 +1,9 @@
+---
+"@computesdk/vercel": patch
+---
+
+Fix generic runtime name handling and improve `runCommand` performance:
+
+- Translate generic runtime names (`node`, `python`) to Vercel-supported versions (`node24`, `python3.13`) so the default provider runtime works end-to-end.
+- Use builtin `@vercel/sandbox` stdout/stderr pipes to avoid blocking `runCommand`.
+- Bump `@vercel/sandbox` to `^1.9.3`.

--- a/packages/avm/package.json
+++ b/packages/avm/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/packages/aws-ecs/package.json
+++ b/packages/aws-ecs/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-ecs": "^3.943.0",
+    "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.948.0",
+    "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*",
     "jszip": "^3.10.1"
   },

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/docker",
-  "version": "1.2.41",
+  "version": "1.2.40",
   "description": "Docker provider for ComputeSDK - local containerized sandboxes for development and testing",
   "author": "IberAI",
   "license": "MIT",

--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -22,7 +22,7 @@ import type {
 const PROVIDER = 'docker' as const;
 const LABEL_KEY = 'com.computesdk.sandbox';
 const LABEL_RUNTIME = 'com.computesdk.runtime';
-const KEEPALIVE_CMD = ['/bin/sh', '-c', 'exec sleep infinity'];
+const KEEPALIVE_CMD = ['/bin/sh', '-c', 'while :; do sleep 3600; done'];
 
 function pick<T>(val: T | undefined, fallback: T): T {
   return typeof val === 'undefined' ? fallback : val;
@@ -300,8 +300,8 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
         const docker = new Docker((config || defaultDockerConfig).connection as any);
         try {
           const c = docker.getContainer(sandboxId);
-          try { await c.kill(); } catch { /* already stopped */ }
-          try { await c.remove(); } catch { /* already removed */ }
+          try { await c.stop({ t: 5 } as any); } catch { /* stopped */ }
+          await c.remove({ force: true });
         } catch {
           // ok if already gone
         }
@@ -356,18 +356,7 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
       ): Promise<CommandResult> => {
         const start = Date.now();
 
-        let shell = command;
-        if (options?.cwd) {
-          shell = `cd ${JSON.stringify(options.cwd)} && ${shell}`;
-        }
-        if (options?.env) {
-          const prefix = Object.entries(options.env)
-            .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-            .join(' ');
-          shell = `${prefix} ${shell}`;
-        }
-
-        const { stdout, stderr, exitCode } = await runExec(handle, shell);
+        const { stdout, stderr, exitCode } = await runExec(handle, command);
 
         return {
           stdout,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -29,8 +29,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@onkernel/sdk": "^0.5.0",
     "@computesdk/provider": "workspace:*",
+    "@onkernel/sdk": "^0.49.0",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -26,8 +26,6 @@ import type { BrowserCreateResponse } from '@onkernel/sdk/resources/browsers';
 export interface KernelConfig {
   /** Kernel API key — falls back to KERNEL_API_KEY env var */
   apiKey?: string;
-  /** Invocation ID for the Kernel action context */
-  invocationId?: string;
 }
 
 /**
@@ -43,7 +41,7 @@ function resolveConfig(config: KernelConfig) {
     );
   }
 
-  return { apiKey, invocationId: config.invocationId };
+  return { apiKey };
 }
 
 /**
@@ -54,41 +52,11 @@ function createClient(config: KernelConfig): Kernel {
   return new Kernel({ apiKey });
 }
 
-const KERNEL_API_BASE = 'https://api.onkernel.com';
-
-/**
- * Make a direct API call to Kernel for endpoints not yet in the SDK
- */
-async function kernelFetch(config: KernelConfig, path: string, options: RequestInit = {}) {
-  const { apiKey } = resolveConfig(config);
-  const response = await fetch(`${KERNEL_API_BASE}${path}`, {
-    ...options,
-    headers: {
-      'Authorization': `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`Kernel API ${options.method ?? 'GET'} ${path} failed (${response.status}): ${body}`);
-  }
-  if (response.status === 204) return null;
-  return response.json();
-}
-
 /**
  * Map ComputeSDK session options to Kernel create browser params.
- *
- * The SDK types currently only require invocation_id, but the API
- * accepts additional fields (stealth, viewport, etc.) so we pass
- * them through via a type assertion.
  */
-function mapSessionOptions(config: KernelConfig, options?: CreateBrowserSessionOptions) {
-  const { invocationId } = resolveConfig(config);
+function mapSessionOptions(options?: CreateBrowserSessionOptions) {
   const params: Record<string, any> = {};
-
-  if (invocationId) params.invocation_id = invocationId;
 
   if (!options) return params;
 
@@ -153,7 +121,7 @@ export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>
     session: {
       create: async (config, options) => {
         const client = createClient(config);
-        const params = mapSessionOptions(config, options);
+        const params = mapSessionOptions(options);
         const browser = await client.browsers.create(params as any);
         return normalizeSession(browser);
       },
@@ -174,12 +142,15 @@ export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>
 
       list: async (config) => {
         const client = createClient(config);
-        const browsers = await (client.browsers as any).list();
-        return (browsers as any[]).map((browser: any) => ({
-          session: browser as BrowserCreateResponse,
-          sessionId: browser.session_id,
-          connectUrl: browser.cdp_ws_url,
-        }));
+        const sessions: { session: BrowserCreateResponse; sessionId: string; connectUrl: string }[] = [];
+        for await (const browser of client.browsers.list()) {
+          sessions.push({
+            session: browser as BrowserCreateResponse,
+            sessionId: browser.session_id,
+            connectUrl: browser.cdp_ws_url,
+          });
+        }
+        return sessions;
       },
 
       destroy: async (config, sessionId) => {
@@ -197,12 +168,10 @@ export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>
     // ─── Profiles ─────────────────────────────────────────────────────
     profile: {
       create: async (config, options) => {
-        const params: Record<string, any> = {};
+        const client = createClient(config);
+        const params: { name?: string } = {};
         if (options?.name) params.name = options.name;
-        const result = await kernelFetch(config, '/profiles', {
-          method: 'POST',
-          body: JSON.stringify(params),
-        });
+        const result = await client.profiles.create(params);
         return {
           profileId: result.id,
           name: result.name ?? options?.name,
@@ -212,11 +181,12 @@ export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>
       },
 
       get: async (config, profileId) => {
+        const client = createClient(config);
         try {
-          const result = await kernelFetch(config, `/profiles/${profileId}`);
+          const result = await client.profiles.retrieve(profileId);
           return {
             profileId: result.id,
-            name: result.name,
+            name: result.name ?? undefined,
             createdAt: result.created_at ? new Date(result.created_at) : undefined,
           } satisfies BrowserProfile;
         } catch {
@@ -225,39 +195,36 @@ export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>
       },
 
       list: async (config) => {
-        const results = await kernelFetch(config, '/profiles');
-        return (results as any[]).map((result) => ({
-          profileId: result.id,
-          name: result.name,
-          createdAt: result.created_at ? new Date(result.created_at) : undefined,
-        } satisfies BrowserProfile));
+        const client = createClient(config);
+        const profiles: BrowserProfile[] = [];
+        for await (const result of client.profiles.list()) {
+          profiles.push({
+            profileId: result.id,
+            name: result.name ?? undefined,
+            createdAt: result.created_at ? new Date(result.created_at) : undefined,
+          } satisfies BrowserProfile);
+        }
+        return profiles;
       },
 
       delete: async (config, profileId) => {
-        await kernelFetch(config, `/profiles/${profileId}`, { method: 'DELETE' });
+        const client = createClient(config);
+        await client.profiles.delete(profileId);
       },
     },
 
     // ─── Extensions ───────────────────────────────────────────────────
     extension: {
       create: async (config, options) => {
-        const { apiKey } = resolveConfig(config);
+        const client = createClient(config);
         const blob = typeof options.file === 'string'
           ? new Blob([options.file])
           : new Blob([new Uint8Array(options.file).buffer as ArrayBuffer]);
-        const formData = new FormData();
-        formData.append('file', new File([blob], options.name ?? 'extension.zip'));
-        if (options.name) formData.append('name', options.name);
-        const response = await fetch(`${KERNEL_API_BASE}/extensions`, {
-          method: 'POST',
-          headers: { 'Authorization': `Bearer ${apiKey}` },
-          body: formData,
+        const file = new File([blob], options.name ?? 'extension.zip');
+        const result = await client.extensions.upload({
+          file,
+          name: options.name,
         });
-        if (!response.ok) {
-          const body = await response.text().catch(() => '');
-          throw new Error(`Failed to upload Kernel extension (${response.status}): ${body}`);
-        }
-        const result = await response.json();
         return {
           extensionId: result.id,
           name: result.name ?? options.name,
@@ -265,72 +232,39 @@ export const kernel = defineBrowserProvider<BrowserCreateResponse, KernelConfig>
       },
 
       get: async (config, extensionId) => {
-        try {
-          const result = await kernelFetch(config, `/extensions/${extensionId}`);
-          return {
-            extensionId: result.id,
-            name: result.name,
-          } satisfies BrowserExtension;
-        } catch {
-          return null;
-        }
+        const client = createClient(config);
+        const extensions = await client.extensions.list();
+        const result = extensions.find((ext) => ext.id === extensionId);
+        if (!result) return null;
+        return {
+          extensionId: result.id,
+          name: result.name ?? undefined,
+        } satisfies BrowserExtension;
       },
 
       delete: async (config, extensionId) => {
-        await kernelFetch(config, `/extensions/${extensionId}`, { method: 'DELETE' });
+        const client = createClient(config);
+        await client.extensions.delete(extensionId);
       },
     },
 
     // ─── Logs ─────────────────────────────────────────────────────────
     logs: {
       list: async (config, sessionId) => {
-        const { apiKey } = resolveConfig(config);
-        const url = `${KERNEL_API_BASE}/browsers/${sessionId}/logs/stream?source=supervisor&follow=false`;
-        const response = await fetch(url, {
-          headers: { 'Authorization': `Bearer ${apiKey}`, 'Accept': 'text/event-stream' },
+        const client = createClient(config);
+        const stream = await client.browsers.logs.stream(sessionId, {
+          source: 'supervisor',
+          follow: false,
         });
-        if (!response.ok) {
-          const body = await response.text().catch(() => '');
-          throw new Error(`Failed to fetch Kernel logs (${response.status}): ${body}`);
-        }
-        const text = await response.text();
         const logs: BrowserLog[] = [];
-        for (const block of text.split(/\r?\n\r?\n/)) {
-          const lines = block.split(/\r?\n/).filter((l) => l.startsWith('data:'));
-          if (!lines.length) continue;
-          const data = lines.map((l) => l.slice(5).trim()).join('');
-          try {
-            const event = JSON.parse(data);
-            logs.push({
-              timestamp: new Date(event.timestamp),
-              level: 'info',
-              message: event.message ?? '',
-            });
-          } catch {
-            // skip malformed events
-          }
+        for await (const event of stream) {
+          logs.push({
+            timestamp: new Date(event.timestamp),
+            level: 'info',
+            message: event.message ?? '',
+          });
         }
         return logs;
-      },
-    },
-
-    // ─── Recordings (Replays) ─────────────────────────────────────────
-    recording: {
-      get: async (config, sessionId) => {
-        try {
-          const result = await kernelFetch(config, `/browsers/${sessionId}/replays`, {
-            method: 'POST',
-            body: JSON.stringify({}),
-          });
-          return {
-            recordingId: result.replay_id,
-            sessionId,
-            format: 'mp4',
-            url: result.replay_view_url,
-          } satisfies BrowserRecording;
-        } catch {
-          return null;
-        }
       },
     },
   },

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -26,6 +26,7 @@
     "vitest": "^1.0.0"
   },
   "devDependencies": {
+    "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/test-utils/src/provider-test-suite.ts
+++ b/packages/test-utils/src/provider-test-suite.ts
@@ -39,7 +39,7 @@ export function defineProviderTests(config: ProviderTestConfig) {
     const supportedRuntimes = provider.getSupportedRuntimes();
     
     // Helper function to create and cleanup sandboxes for each runtime
-    const createRuntimeSandbox = async (runtime: 'node' | 'python') => {
+    const createRuntimeSandbox = async (runtime: Runtime) => {
       if (skipIntegration) {
         return createMockSandbox(config);
       } else {

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/vercel",
-  "version": "1.7.22",
+  "version": "1.7.21",
   "description": "Vercel Sandbox provider for ComputeSDK - serverless code execution for Python and Node.js on Vercel's edge network",
   "author": "Garrison",
   "license": "MIT",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/workbench",
-  "version": "21.0.2",
+  "version": "21.0.1",
   "description": "Interactive REPL for testing ComputeSDK sandbox operations",
   "author": "Garrison",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
 
   packages/avm:
     dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -161,6 +164,9 @@ importers:
       '@aws-sdk/client-ecs':
         specifier: ^3.943.0
         version: 3.943.0
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -195,6 +201,9 @@ importers:
       '@aws-sdk/client-lambda':
         specifier: ^3.948.0
         version: 3.948.0
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -900,8 +909,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@onkernel/sdk':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.49.0
+        version: 0.49.0
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -933,6 +942,9 @@ importers:
 
   packages/lambda:
     dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -1323,6 +1335,9 @@ importers:
         specifier: ^17.2.1
         version: 17.2.1
     devDependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -3173,8 +3188,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@onkernel/sdk@0.5.0':
-    resolution: {integrity: sha512-n7gwc7rU0GY/XcDnEV0piHPd76bHTSfuTjQW4qFKUWQji0UK9YUVKDFklqAWbyGlXPUezWCfxh79ELv2cFYOBA==}
+  '@onkernel/sdk@0.49.0':
+    resolution: {integrity: sha512-nsq5OfkaNKxRTCdXQF8BSTj/Wl0iBIqyWoI/ATgQt15pV+59E22MsZ+IHPiVwwb33tXLtnOqUe5ffOxm7l3GHg==}
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -10445,7 +10460,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@onkernel/sdk@0.5.0': {}
+  '@onkernel/sdk@0.49.0': {}
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:


### PR DESCRIPTION
Automated sync of `packages/` and `.changeset/` from [computesdk-core](https://github.com/computesdk/computesdk-core).

**Source commit:** af7777a27e308e64b9571bcad321952c5e9ba8ae
**Trigger:** Migrate kernel provider from raw API calls to @onkernel/sdk (#376)

Migrates the Kernel browser provider implementation away from ad-hoc fetch calls to the official @onkernel/sdk client, aligning provider behavior with SDK-supported APIs and adding async iteration for paginated list endpoints.

## Changes:

- Bumped  dependency from  to  and updated .
- Replaced direct HTTP calls with SDK methods for sessions, profiles, extensions, logs, and recordings.
- Updated  (and ) to use async iteration over paginated results; removed the raw  helper and .

This PR will be automatically updated with new changes until merged.