### PR TITLE
Sync packages from computesdk-core

### DIFF
--- a/.changeset/add-kernel-browser-provider.md
+++ b/.changeset/add-kernel-browser-provider.md
@@ -1,0 +1,11 @@
+---
+"@computesdk/kernel": minor
+---
+
+Add Kernel browser provider package for cloud browser sessions powered by Kernel:
+
+- Full session lifecycle: create, retrieve, list, delete, and getConnectUrl via `@onkernel/sdk`
+- Profiles: create, get, list, delete via Kernel REST API
+- Extensions: upload (multipart), get, delete via Kernel REST API
+- Logs: list by consuming SSE stream from `/browsers/{id}/logs/stream`
+- Recordings: start replay via `/browsers/{id}/replays`


### PR DESCRIPTION
Automated sync of `packages/` and `.changeset/` from [computesdk-core](https://github.com/computesdk/computesdk-core).

**Source commit:** df2430e834609eb2f9e2a0d17ffc2d8caf69fe57
**Trigger:** changeset for kernel package (#378)

This PR will be automatically updated with new changes until merged.