### PR TITLE
chore(changeset): downgrade direct-provider bump from major to minor

### DIFF
--- a/.changeset/direct-provider-breaks.md
+++ b/.changeset/direct-provider-breaks.md
@@ -1,9 +1,9 @@
 ---
-"computesdk": major
-"@computesdk/provider": major
-"@computesdk/railway": major
-"@computesdk/render": major
-"@computesdk/workbench": major
+"computesdk": minor
+"@computesdk/provider": minor
+"@computesdk/railway": minor
+"@computesdk/render": minor
+"@computesdk/workbench": minor
 ---
 
 Remove hosted control-plane assumptions from `computesdk` and move to direct provider mode.


### PR DESCRIPTION
## Summary
- Update `.changeset/direct-provider-breaks.md` release levels from `major` to `minor` for:
  - `computesdk`
  - `@computesdk/provider`
  - `@computesdk/railway`
  - `@computesdk/render`
  - `@computesdk/workbench`

## Why
- We do not want to cut a major release for this set of changes.
- This keeps release bot output aligned with current release policy and avoids reintroducing `3.0.0` / `2.0.0` bumps on future release-branch regenerations.