### PR TITLE
refactor(archil): require diskId on create and make getById ID-only

### DIFF
--- a/.changeset/archil-id-only-getbyid.md
+++ b/.changeset/archil-id-only-getbyid.md
@@ -1,0 +1,10 @@
+---
+"@computesdk/archil": minor
+---
+
+Refine Archil sandbox lookup semantics to be ID-only.
+
+- `create()` now requires an existing disk id in `metadata.diskId` and no longer provisions/deletes disks.
+- `getById()` now resolves disks strictly by disk ID.
+- Removed fallback behavior that treated `getById()` input as a disk name.
+- Updated docs and tests to reflect the stricter contract.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,13 @@ jobs:
       env:
         ARCHIL_API_KEY: ${{ secrets.ARCHIL_API_KEY }}
         ARCHIL_REGION: ${{ secrets.ARCHIL_REGION }}
+        ARCHIL_DISK_ID: ${{ secrets.ARCHIL_DISK_ID }}
       run: |
-         if [ -n "$ARCHIL_API_KEY" ] && [ -n "$ARCHIL_REGION" ]; then
+         if [ -n "$ARCHIL_API_KEY" ] && [ -n "$ARCHIL_REGION" ] && [ -n "$ARCHIL_DISK_ID" ]; then
            echo "Running Archil integration tests with real API..."
            pnpm --filter @computesdk/archil test
          else
-           echo "Skipping Archil integration tests - missing required secrets"
+           echo "Skipping Archil integration tests - missing required secrets (ARCHIL_API_KEY, ARCHIL_REGION, ARCHIL_DISK_ID)"
          fi
 
   computesdk-integration-tests:
@@ -215,6 +216,7 @@ jobs:
         MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         ARCHIL_API_KEY: ${{ secrets.ARCHIL_API_KEY }}
         ARCHIL_REGION: ${{ secrets.ARCHIL_REGION }}
+        ARCHIL_DISK_ID: ${{ secrets.ARCHIL_DISK_ID }}
       run: |
         case "$TEST_PROVIDER" in
           e2b)
@@ -242,8 +244,8 @@ jobs:
             fi
             ;;
           archil)
-            if [ -z "$ARCHIL_API_KEY" ] || [ -z "$ARCHIL_REGION" ]; then
-              echo "Skipping computesdk integration for archil - missing Archil credentials"
+            if [ -z "$ARCHIL_API_KEY" ] || [ -z "$ARCHIL_REGION" ] || [ -z "$ARCHIL_DISK_ID" ]; then
+              echo "Skipping computesdk integration for archil - missing Archil credentials (ARCHIL_API_KEY, ARCHIL_REGION, ARCHIL_DISK_ID)"
               exit 0
             fi
             ;;

--- a/packages/archil/README.md
+++ b/packages/archil/README.md
@@ -2,10 +2,10 @@
 
 [Archil](https://archil.com) provider for [ComputeSDK](https://www.computesdk.com).
 
-`create` provisions a new Archil disk (no mounts — archil-managed storage)
-and `runCommand` executes shell commands in a managed container with that
-disk attached via the control-plane `exec` endpoint. `destroy` deletes the
-disk. `getById` accepts either a disk id or a disk name.
+`create` resolves a handle to an existing Archil disk id, and `runCommand`
+executes shell commands in a managed container with that disk attached via the
+control-plane `exec` endpoint. `destroy` is a no-op because disk lifecycle is
+managed by Archil. `getById` requires a disk id.
 
 ## Install
 
@@ -31,29 +31,30 @@ import { archil } from '@computesdk/archil';
 
 const provider = archil();
 
-// Create a fresh disk. Pass a name to control it; omit for auto-generated.
-const { sandbox } = await provider.sandbox.create({ name: 'my-workspace' });
+// Attach to an existing disk by id.
+const { sandbox } = await provider.sandbox.create({
+  metadata: { diskId: 'disk_abc123' },
+});
 
 const result = await provider.sandbox.runCommand(sandbox, 'echo hello > /mnt/note && cat /mnt/note');
 console.log(result.stdout); // "hello"
 
-// Look up later by name or by id:
-const byName = await provider.sandbox.getById('my-workspace');
+// Look up later by disk id:
 const byId = await provider.sandbox.getById(sandbox.sandboxId);
 
 await provider.sandbox.destroy(sandbox.sandboxId);
 ```
 
-Disk names must match `^[a-zA-Z0-9_-]+$` and be 1–100 characters.
+`create()` requires `metadata.diskId` as the target disk id.
 
 ## Supported operations
 
 | Method        | Supported | Notes                                                       |
 | ------------- | --------- | ----------------------------------------------------------- |
-| `create`      | ✅        | Creates a new disk with archil-managed storage (no mounts). |
-| `getById`     | ✅        | Accepts either the disk id or the disk name.                |
+| `create`      | ✅        | Resolves an existing disk from `metadata.diskId`.           |
+| `getById`     | ✅        | Requires the disk id.                                        |
 | `list`        | ✅        | Lists all disks visible to the API key.                     |
-| `destroy`     | ✅        | Deletes the disk.                                           |
+| `destroy`     | no-op     | Disk lifecycle is managed by Archil.                        |
 | `runCommand`  | ✅        | Calls Archil's HTTP `exec` endpoint and waits for completion. |
 | `runCode`     | ✅        | Wraps code in `node -e` or `python3 -c`. Requires explicit `runtime`. |
 | `getInfo`     | ✅        |                                                             |

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -129,11 +129,9 @@ runProviderTestSuite({
     });
 
     // The generic provider test suite always calls create() without metadata.
-    // Archil create() requires an explicit disk id, so for integration tests we
-    // resolve one here (prefer ARCHIL_DISK_ID, else first visible disk) and
-    // inject it into create() calls made by the shared suite.
+    // Archil create() requires an explicit disk id, so inject ARCHIL_DISK_ID.
     const originalCreate = provider.sandbox.create.bind(provider.sandbox);
-    let resolvedDiskId: string | undefined = process.env.ARCHIL_DISK_ID;
+    const configuredDiskId = process.env.ARCHIL_DISK_ID;
 
     provider.sandbox.create = async (options?: any) => {
       const requested = options?.metadata?.diskId as string | undefined;
@@ -141,22 +139,15 @@ runProviderTestSuite({
         return originalCreate(options);
       }
 
-      if (!resolvedDiskId) {
-        const disks = await provider.sandbox.list();
-        if (disks.length === 0) {
-          throw new Error(
-            'Archil integration tests require at least one existing disk. ' +
-              'Set ARCHIL_DISK_ID or create a disk in the Archil account.'
-          );
-        }
-        resolvedDiskId = disks[0].sandboxId;
+      if (!configuredDiskId) {
+        throw new Error('Archil integration tests require ARCHIL_DISK_ID.');
       }
 
       return originalCreate({
         ...options,
         metadata: {
           ...(options?.metadata || {}),
-          diskId: resolvedDiskId,
+          diskId: configuredDiskId,
         },
       });
     };
@@ -168,5 +159,6 @@ runProviderTestSuite({
   // Keep command/runtime integration coverage on, and add dedicated filesystem
   // integration once mount-path behavior is standardized.
   supportsFilesystem: false,
-  skipIntegration: !process.env.ARCHIL_API_KEY || !process.env.ARCHIL_REGION,
+  skipIntegration:
+    !process.env.ARCHIL_API_KEY || !process.env.ARCHIL_REGION || !process.env.ARCHIL_DISK_ID,
 });

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 import * as indexExports from '../index';
 import { archil } from '../index';
@@ -14,6 +14,109 @@ describe('archil export shape', () => {
   it('uses the correct provider name', () => {
     const provider = archil({ apiKey: 'test', region: 'aws-us-east-1' });
     expect(provider.name).toBe('archil');
+  });
+});
+
+describe('archil getById semantics', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('resolves an existing disk by id', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            id: 'disk_123',
+            name: 'my-workspace',
+            organization: 'org',
+            status: 'ready',
+            provider: 'archil',
+            region: 'aws-us-east-1',
+            createdAt: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.getById('disk_123');
+
+    expect(sandbox?.sandboxId).toBe('disk_123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstUrl = String((fetchMock.mock.calls as any[][])[0][0]);
+    expect(firstUrl).toContain('/api/disks/disk_123');
+  });
+
+  it('does not fall back to name lookup when id lookup fails', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ success: false, error: 'not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.getById('my-workspace');
+
+    expect(sandbox).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstUrl = String((fetchMock.mock.calls as any[][])[0][0]);
+    expect(firstUrl).toContain('/api/disks/my-workspace');
+    expect((fetchMock.mock.calls as any[][]).some((call) => String(call[0]).endsWith('/api/disks'))).toBe(false);
+  });
+});
+
+describe('archil create semantics', () => {
+  it('requires disk id in metadata', async () => {
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    await expect(provider.sandbox.create()).rejects.toThrow(/requires an existing disk id/i);
+  });
+
+  it('resolves existing disk id without creating a new disk', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'GET') {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              id: 'disk_abc123',
+              name: 'existing-disk',
+              organization: 'org',
+              status: 'ready',
+              provider: 'archil',
+              region: 'aws-us-east-1',
+              createdAt: new Date().toISOString(),
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      return new Response(JSON.stringify({ success: false, error: 'unexpected method' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const created = await provider.sandbox.create({ metadata: { diskId: 'disk_abc123' } });
+
+    expect(created.sandboxId).toBe('disk_abc123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const method = ((fetchMock.mock.calls as any[][])[0][1] as RequestInit | undefined)?.method;
+    expect(method).toBe('GET');
   });
 });
 

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -122,10 +122,47 @@ describe('archil create semantics', () => {
 
 runProviderTestSuite({
   name: 'archil',
-  provider: archil({
-    apiKey: process.env.ARCHIL_API_KEY,
-    region: process.env.ARCHIL_REGION,
-  }),
+  provider: (() => {
+    const provider = archil({
+      apiKey: process.env.ARCHIL_API_KEY,
+      region: process.env.ARCHIL_REGION,
+    });
+
+    // The generic provider test suite always calls create() without metadata.
+    // Archil create() requires an explicit disk id, so for integration tests we
+    // resolve one here (prefer ARCHIL_DISK_ID, else first visible disk) and
+    // inject it into create() calls made by the shared suite.
+    const originalCreate = provider.sandbox.create.bind(provider.sandbox);
+    let resolvedDiskId: string | undefined = process.env.ARCHIL_DISK_ID;
+
+    provider.sandbox.create = async (options?: any) => {
+      const requested = options?.metadata?.diskId as string | undefined;
+      if (requested) {
+        return originalCreate(options);
+      }
+
+      if (!resolvedDiskId) {
+        const disks = await provider.sandbox.list();
+        if (disks.length === 0) {
+          throw new Error(
+            'Archil integration tests require at least one existing disk. ' +
+              'Set ARCHIL_DISK_ID or create a disk in the Archil account.'
+          );
+        }
+        resolvedDiskId = disks[0].sandboxId;
+      }
+
+      return originalCreate({
+        ...options,
+        metadata: {
+          ...(options?.metadata || {}),
+          diskId: resolvedDiskId,
+        },
+      });
+    };
+
+    return provider;
+  })(),
   // Archil filesystem mount points vary by account/runtime and are not yet
   // stable enough for generic provider-test-suite path assumptions.
   // Keep command/runtime integration coverage on, and add dedicated filesystem

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -3,6 +3,16 @@ import { runProviderTestSuite } from '@computesdk/test-utils';
 import * as indexExports from '../index';
 import { archil } from '../index';
 
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
 describe('archil export shape', () => {
   it('is resolvable via camelCase conversion of the hyphenated provider name', () => {
     // Workbench resolves provider names by camelCase conversion. 'archil' is
@@ -18,16 +28,6 @@ describe('archil export shape', () => {
 });
 
 describe('archil getById semantics', () => {
-  const originalFetch = global.fetch;
-
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
   it('resolves an existing disk by id', async () => {
     const fetchMock = vi.fn(async () =>
       new Response(

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -4,8 +4,8 @@
  * Executes commands against an Archil disk via the Archil control-plane HTTP
  * API. Archil is exec-only — each command runs in an Archil-managed container
  * with the configured disk mounted, then returns stdout, stderr, and exit code.
- * There is no sandbox lifecycle to manage; "create" just resolves a handle to
- * the target disk.
+ * There is no sandbox lifecycle to manage; "create" resolves a handle to an
+ * existing disk id.
  */
 
 import { defineProvider } from '@computesdk/provider';
@@ -145,18 +145,18 @@ async function callApi<T>(
   return payload.data as T;
 }
 
-// Archil disk names must match /^[a-zA-Z0-9_-]+$/ and be 1–100 chars.
-function generateDiskName(): string {
-  const random = Math.random().toString(36).slice(2, 10);
-  return `computesdk-${Date.now()}-${random}`;
-}
+function resolveCreateDiskId(options?: CreateSandboxOptions): string {
+  const diskId = options?.metadata?.diskId as string | undefined;
 
-async function lookupDiskByName(
-  resolved: ResolvedConfig,
-  name: string,
-): Promise<DiskResponse | null> {
-  const disks = await callApi<DiskResponse[]>(resolved, 'GET', '/api/disks');
-  return disks.find((d) => d.name === name) ?? null;
+  if (!diskId) {
+    throw new Error(
+      'Archil create() requires an existing disk id in metadata.\n\n' +
+        'Example:\n' +
+        '  provider.sandbox.create({ metadata: { diskId: "disk_abc123" } })',
+    );
+  }
+
+  return diskId;
 }
 
 function shellEscape(value: string): string {
@@ -201,17 +201,11 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
     sandbox: {
       create: async (config: ArchilConfig, options?: CreateSandboxOptions) => {
         const resolved = resolveConfig(config);
-        const name = ((options?.name as string | undefined) ?? generateDiskName()).trim();
-        const created = await callApi<{ diskId: string }>(
-          resolved,
-          'POST',
-          '/api/disks',
-          { name },
-        );
+        const diskId = resolveCreateDiskId(options);
         const disk = await callApi<DiskResponse>(
           resolved,
           'GET',
-          `/api/disks/${encodeURIComponent(created.diskId)}`,
+          `/api/disks/${encodeURIComponent(diskId)}`,
         );
         return {
           sandbox: { disk, resolved, createdAt: new Date() },
@@ -221,23 +215,12 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
 
       getById: async (config: ArchilConfig, sandboxId: string) => {
         const resolved = resolveConfig(config);
-        // Try as disk id first; fall back to name lookup via list.
         try {
           const disk = await callApi<DiskResponse>(
             resolved,
             'GET',
             `/api/disks/${encodeURIComponent(sandboxId)}`,
           );
-          return {
-            sandbox: { disk, resolved, createdAt: new Date() },
-            sandboxId: disk.id,
-          };
-        } catch {
-          // not an id — try name
-        }
-        try {
-          const disk = await lookupDiskByName(resolved, sandboxId);
-          if (!disk) return null;
           return {
             sandbox: { disk, resolved, createdAt: new Date() },
             sandboxId: disk.id,
@@ -256,13 +239,8 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         }));
       },
 
-      destroy: async (config: ArchilConfig, sandboxId: string) => {
-        const resolved = resolveConfig(config);
-        await callApi<null>(
-          resolved,
-          'DELETE',
-          `/api/disks/${encodeURIComponent(sandboxId)}`,
-        );
+      destroy: async (_config: ArchilConfig, _sandboxId: string) => {
+        // No-op: Archil disks have an independent lifecycle.
       },
 
       runCommand: async (

--- a/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
+++ b/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
@@ -105,7 +105,16 @@ describeIntegration('compute provider integration', () => {
     const provider = providerFactory(getProviderConfig(testProvider));
 
     const sdk = compute({ provider });
-    const sandbox = await sdk.sandbox.create({ timeout: 120000 });
+    const sandbox = await sdk.sandbox.create({
+      timeout: 120000,
+      ...(testProvider === 'archil'
+        ? {
+            metadata: {
+              diskId: requireEnv('ARCHIL_DISK_ID'),
+            },
+          }
+        : {}),
+    });
 
     try {
       const result = await sandbox.runCode('print("computesdk-integration-ok")', 'python');


### PR DESCRIPTION
## Summary
- Refactor `@computesdk/archil` to use explicit disk-id semantics only.
- `create()` now requires an existing disk id in `metadata.diskId` and no longer provisions/deletes disks.
- `getById()` now resolves strictly by disk id (no name fallback).
- `destroy()` remains a no-op because disk lifecycle is managed externally in Archil.

## Docs and Tests
- Update `packages/archil/README.md` to document the strict `metadata.diskId` create contract.
- Add/adjust tests in `packages/archil/src/__tests__/index.test.ts` for:
  - create requires `diskId`
  - create resolves existing disk by id
  - getById does not fall back to name lookup

## Changeset
- Added `.changeset/archil-id-only-getbyid.md` with a minor bump for `@computesdk/archil`.

## Validation
- `pnpm --filter @computesdk/archil typecheck`
- `pnpm --filter @computesdk/archil test`
- `pnpm --filter @computesdk/archil build`