### PR TITLE
feat: add ephemeral box option to upstash create

### DIFF
--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -5,7 +5,7 @@
  * Supports code execution, shell commands, filesystem, snapshots, and preview URLs.
  */
 
-import { Box } from '@upstash/box';
+import { Box, EphemeralBox } from '@upstash/box';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
@@ -20,6 +20,8 @@ export interface UpstashConfig {
   runtime?: Runtime;
   /** Execution timeout in milliseconds (default: 600000) */
   timeout?: number;
+  /** Create ephemeral boxes instead of full boxes (default: false, uses full Box) */
+  ephemeral?: boolean;
 }
 
 /**
@@ -74,7 +76,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
               timeout,
               env: options?.envs,
             });
-          } else {
+          } else if ((options?.ephemeral ?? config.ephemeral ?? false) === false) {
             // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {
               runtime: _runtime,
@@ -89,10 +91,11 @@ export const upstash = defineProvider<Box, UpstashConfig>({
               directory: _directory,
               overlays: _overlays,
               servers: _servers,
+              ephemeral: _ephemeral,
               ...providerOptions
             } = options || {};
 
-            // Create new box
+            // Create new full box
             box = await Box.create({
               apiKey,
               runtime: (_runtime ?? config.runtime ?? 'node') as any,
@@ -100,6 +103,15 @@ export const upstash = defineProvider<Box, UpstashConfig>({
               env: envs,
               ...providerOptions,
             });
+          } else {
+            // create lightweight ephemeral box (exec + files only, instant ready)
+            const ephemeralBox = await EphemeralBox.create({
+              apiKey,
+              runtime: (options?.runtime ?? config.runtime ?? 'node') as any,
+              timeout,
+              ttl: options?.ttl,
+            });
+            box = ephemeralBox as unknown as Box;
           }
 
           return {
@@ -298,8 +310,8 @@ export const upstash = defineProvider<Box, UpstashConfig>({
         // Map Upstash statuses to universal set: 'running' | 'stopped' | 'error'
         const universalStatus: SandboxInfo['status'] =
           (status === 'creating' || status === 'idle' || status === 'running') ? 'running' :
-          status === 'error' ? 'error' :
-          'stopped'; // paused, deleted, or any unknown state
+            status === 'error' ? 'error' :
+              'stopped'; // paused, deleted, or any unknown state
 
         return {
           id: sandbox.id,

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -74,13 +74,26 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
           let box: UpstashSandboxInstance;
 
           if (options?.snapshotId) {
-            // Restore from snapshot via Box.fromSnapshot()
-            box = await Box.fromSnapshot(options.snapshotId, {
-              apiKey,
-              runtime: (options?.runtime ?? config.runtime ?? 'node') as any,
-              timeout,
-              env: options?.envs,
-            });
+            const runtime = (options?.runtime ?? config.runtime ?? 'node') as any;
+
+            if (options?.ephemeral === true) {
+              // Restore lightweight ephemeral box from snapshot
+              box = await EphemeralBox.fromSnapshot(options.snapshotId, {
+                apiKey,
+                runtime,
+                timeout,
+                ttl: options?.ttl,
+                env: options?.envs,
+              });
+            } else {
+              // Restore full box from snapshot
+              box = await Box.fromSnapshot(options.snapshotId, {
+                apiKey,
+                runtime,
+                timeout,
+                env: options?.envs,
+              });
+            }
           } else if (options?.ephemeral !== true) {
             // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -10,9 +10,9 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-type PreviewCapableSandbox = {
-  getPreviewUrl: (port: number) => Promise<{ url: string }>;
-};
+type UpstashSandbox = Pick<Box, 'id' | 'cwd' | 'exec' | 'files' | 'getStatus'>;
+
+type PreviewCapableSandbox = UpstashSandbox & Pick<Box, 'getPreviewUrl'>;
 
 function supportsPreviewUrls(sandbox: unknown): sandbox is PreviewCapableSandbox {
   return (
@@ -33,8 +33,6 @@ export interface UpstashConfig {
   runtime?: Runtime;
   /** Execution timeout in milliseconds (default: 600000) */
   timeout?: number;
-  /** Create ephemeral boxes instead of full boxes (default: false, uses full Box) */
-  ephemeral?: boolean;
 }
 
 /**
@@ -42,7 +40,7 @@ export interface UpstashConfig {
  * Upstash requires all file paths to be under /workspace/home.
  * Absolute paths like "/tmp/foo" get remapped to "/workspace/home/tmp/foo".
  */
-function resolvePath(sandbox: Box, path: string): string {
+function resolvePath(sandbox: UpstashSandbox, path: string): string {
   const root = sandbox.cwd;
   if (path.startsWith(root)) {
     return path;
@@ -56,7 +54,7 @@ function resolvePath(sandbox: Box, path: string): string {
 /**
  * Create an Upstash Box provider instance using the factory pattern
  */
-export const upstash = defineProvider<Box, UpstashConfig>({
+export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
   name: 'upstash',
   methods: {
     sandbox: {
@@ -73,7 +71,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
         const timeout = options?.timeout ?? config.timeout ?? 600000;
 
         try {
-          let box: Box;
+          let box: UpstashSandbox;
 
           if (options?.snapshotId) {
             // Restore from snapshot via Box.fromSnapshot()
@@ -83,7 +81,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
               timeout,
               env: options?.envs,
             });
-          } else if ((options?.ephemeral ?? config.ephemeral ?? false) === false) {
+          } else if (options?.ephemeral !== true) {
             // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {
               runtime: _runtime,
@@ -119,7 +117,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
               timeout,
               ttl: options?.ttl,
             });
-            box = ephemeralBox as unknown as Box;
+            box = ephemeralBox;
           }
 
           return {
@@ -186,7 +184,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
       },
 
       // Instance operations
-      runCode: async (sandbox: Box, code: string, runtime?: Runtime): Promise<CodeResult> => {
+      runCode: async (sandbox: UpstashSandbox, code: string, runtime?: Runtime): Promise<CodeResult> => {
         try {
           // Auto-detect runtime if not specified
           const effectiveRuntime = runtime || (
@@ -255,7 +253,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
         }
       },
 
-      runCommand: async (sandbox: Box, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
+      runCommand: async (sandbox: UpstashSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
 
         try {
@@ -310,7 +308,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
         }
       },
 
-      getInfo: async (sandbox: Box): Promise<SandboxInfo> => {
+      getInfo: async (sandbox: UpstashSandbox): Promise<SandboxInfo> => {
         // getStatus() returns { status: string } where status is one of:
         // "creating" | "idle" | "running" | "paused" | "error" | "deleted"
         const { status } = await sandbox.getStatus();
@@ -335,7 +333,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
         };
       },
 
-      getUrl: async (sandbox: Box, options: { port: number; protocol?: string }): Promise<string> => {
+      getUrl: async (sandbox: UpstashSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         if (!supportsPreviewUrls(sandbox)) {
           throw new Error(
             'Preview URLs are not supported on ephemeral boxes. Use ephemeral: false to create a full box with preview support.'
@@ -357,19 +355,19 @@ export const upstash = defineProvider<Box, UpstashConfig>({
       // Filesystem methods - Upstash Box has full filesystem support
       // All paths must be under /workspace/home — resolvePath() remaps absolute paths.
       filesystem: {
-        readFile: async (sandbox: Box, path: string): Promise<string> => {
+        readFile: async (sandbox: UpstashSandbox, path: string): Promise<string> => {
           return await sandbox.files.read(resolvePath(sandbox, path));
         },
 
-        writeFile: async (sandbox: Box, path: string, content: string): Promise<void> => {
+        writeFile: async (sandbox: UpstashSandbox, path: string, content: string): Promise<void> => {
           await sandbox.files.write({ path: resolvePath(sandbox, path), content });
         },
 
-        mkdir: async (sandbox: Box, path: string): Promise<void> => {
+        mkdir: async (sandbox: UpstashSandbox, path: string): Promise<void> => {
           await sandbox.exec.command(`mkdir -p "${escapeShellArg(resolvePath(sandbox, path))}"`);
         },
 
-        readdir: async (sandbox: Box, path: string): Promise<FileEntry[]> => {
+        readdir: async (sandbox: UpstashSandbox, path: string): Promise<FileEntry[]> => {
           const entries = await sandbox.files.list(resolvePath(sandbox, path));
 
           return entries.map((entry: any) => ({
@@ -380,7 +378,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
           }));
         },
 
-        exists: async (sandbox: Box, path: string): Promise<boolean> => {
+        exists: async (sandbox: UpstashSandbox, path: string): Promise<boolean> => {
           try {
             const run = await sandbox.exec.command(`test -e "${escapeShellArg(resolvePath(sandbox, path))}" && echo "exists" || echo "not_found"`);
             return (run.result || '').trim() === 'exists';
@@ -389,13 +387,13 @@ export const upstash = defineProvider<Box, UpstashConfig>({
           }
         },
 
-        remove: async (sandbox: Box, path: string): Promise<void> => {
+        remove: async (sandbox: UpstashSandbox, path: string): Promise<void> => {
           await sandbox.exec.command(`rm -rf "${escapeShellArg(resolvePath(sandbox, path))}"`);
         },
       },
 
       // Provider-specific typed getInstance method
-      getInstance: (sandbox: Box): Box => {
+      getInstance: (sandbox: UpstashSandbox): UpstashSandbox => {
         return sandbox;
       },
     },

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -10,6 +10,19 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
+type PreviewCapableSandbox = {
+  getPreviewUrl: (port: number) => Promise<{ url: string }>;
+};
+
+function supportsPreviewUrls(sandbox: unknown): sandbox is PreviewCapableSandbox {
+  return (
+    typeof sandbox === 'object' &&
+    sandbox !== null &&
+    'getPreviewUrl' in sandbox &&
+    typeof (sandbox as { getPreviewUrl?: unknown }).getPreviewUrl === 'function'
+  );
+}
+
 /**
  * Upstash-specific configuration options
  */
@@ -323,7 +336,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
       },
 
       getUrl: async (sandbox: Box, options: { port: number; protocol?: string }): Promise<string> => {
-        if (typeof (sandbox as any).getPreviewUrl !== 'function') {
+        if (!supportsPreviewUrls(sandbox)) {
           throw new Error(
             'Preview URLs are not supported on ephemeral boxes. Use ephemeral: false to create a full box with preview support.'
           );

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -92,6 +92,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
               overlays: _overlays,
               servers: _servers,
               ephemeral: _ephemeral,
+              ttl: _ttl,
               ...providerOptions
             } = options || {};
 
@@ -328,6 +329,12 @@ export const upstash = defineProvider<Box, UpstashConfig>({
       },
 
       getUrl: async (sandbox: Box, options: { port: number; protocol?: string }): Promise<string> => {
+        if (typeof (sandbox as any).getPreviewUrl !== 'function') {
+          throw new Error(
+            'Preview URLs are not supported on ephemeral boxes. Use ephemeral: false to create a full box with preview support.'
+          );
+        }
+
         try {
           // getPreviewUrl() creates a publicly accessible URL for a port
           // Returns: { url, port, token?, username?, password? }

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -62,13 +62,7 @@ export const upstash = defineProvider<Box, UpstashConfig>({
         try {
           let box: Box;
 
-          if (options?.sandboxId) {
-            // Reconnect to existing box via Box.get()
-            box = await Box.get(options.sandboxId, {
-              apiKey,
-              timeout,
-            });
-          } else if (options?.snapshotId) {
+          if (options?.snapshotId) {
             // Restore from snapshot via Box.fromSnapshot()
             box = await Box.fromSnapshot(options.snapshotId, {
               apiKey,

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -10,17 +10,17 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-type UpstashSandbox = Pick<Box, 'id' | 'cwd' | 'exec' | 'files' | 'getStatus'>;
+export type UpstashSandboxInstance = Box | EphemeralBox;
 
-type PreviewCapableSandbox = UpstashSandbox & Pick<Box, 'getPreviewUrl'>;
-
-function supportsPreviewUrls(sandbox: unknown): sandbox is PreviewCapableSandbox {
+export function isEphemeralSandboxInstance(sandbox: UpstashSandboxInstance): sandbox is EphemeralBox {
   return (
-    typeof sandbox === 'object' &&
-    sandbox !== null &&
-    'getPreviewUrl' in sandbox &&
-    typeof (sandbox as { getPreviewUrl?: unknown }).getPreviewUrl === 'function'
+    'expiresAt' in sandbox &&
+    typeof sandbox.expiresAt === 'number'
   );
+}
+
+export function isUpstashBoxInstance(sandbox: UpstashSandboxInstance): sandbox is Box {
+  return !isEphemeralSandboxInstance(sandbox);
 }
 
 /**
@@ -40,7 +40,7 @@ export interface UpstashConfig {
  * Upstash requires all file paths to be under /workspace/home.
  * Absolute paths like "/tmp/foo" get remapped to "/workspace/home/tmp/foo".
  */
-function resolvePath(sandbox: UpstashSandbox, path: string): string {
+function resolvePath(sandbox: UpstashSandboxInstance, path: string): string {
   const root = sandbox.cwd;
   if (path.startsWith(root)) {
     return path;
@@ -54,7 +54,7 @@ function resolvePath(sandbox: UpstashSandbox, path: string): string {
 /**
  * Create an Upstash Box provider instance using the factory pattern
  */
-export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
+export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
   name: 'upstash',
   methods: {
     sandbox: {
@@ -71,7 +71,7 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
         const timeout = options?.timeout ?? config.timeout ?? 600000;
 
         try {
-          let box: UpstashSandbox;
+          let box: UpstashSandboxInstance;
 
           if (options?.snapshotId) {
             // Restore from snapshot via Box.fromSnapshot()
@@ -184,7 +184,7 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
       },
 
       // Instance operations
-      runCode: async (sandbox: UpstashSandbox, code: string, runtime?: Runtime): Promise<CodeResult> => {
+      runCode: async (sandbox: UpstashSandboxInstance, code: string, runtime?: Runtime): Promise<CodeResult> => {
         try {
           // Auto-detect runtime if not specified
           const effectiveRuntime = runtime || (
@@ -253,7 +253,7 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
         }
       },
 
-      runCommand: async (sandbox: UpstashSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
+      runCommand: async (sandbox: UpstashSandboxInstance, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
 
         try {
@@ -308,7 +308,7 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
         }
       },
 
-      getInfo: async (sandbox: UpstashSandbox): Promise<SandboxInfo> => {
+      getInfo: async (sandbox: UpstashSandboxInstance): Promise<SandboxInfo> => {
         // getStatus() returns { status: string } where status is one of:
         // "creating" | "idle" | "running" | "paused" | "error" | "deleted"
         const { status } = await sandbox.getStatus();
@@ -333,8 +333,8 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
         };
       },
 
-      getUrl: async (sandbox: UpstashSandbox, options: { port: number; protocol?: string }): Promise<string> => {
-        if (!supportsPreviewUrls(sandbox)) {
+      getUrl: async (sandbox: UpstashSandboxInstance, options: { port: number; protocol?: string }): Promise<string> => {
+        if (isEphemeralSandboxInstance(sandbox)) {
           throw new Error(
             'Preview URLs are not supported on ephemeral boxes. Use ephemeral: false to create a full box with preview support.'
           );
@@ -355,19 +355,19 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
       // Filesystem methods - Upstash Box has full filesystem support
       // All paths must be under /workspace/home — resolvePath() remaps absolute paths.
       filesystem: {
-        readFile: async (sandbox: UpstashSandbox, path: string): Promise<string> => {
+        readFile: async (sandbox: UpstashSandboxInstance, path: string): Promise<string> => {
           return await sandbox.files.read(resolvePath(sandbox, path));
         },
 
-        writeFile: async (sandbox: UpstashSandbox, path: string, content: string): Promise<void> => {
+        writeFile: async (sandbox: UpstashSandboxInstance, path: string, content: string): Promise<void> => {
           await sandbox.files.write({ path: resolvePath(sandbox, path), content });
         },
 
-        mkdir: async (sandbox: UpstashSandbox, path: string): Promise<void> => {
+        mkdir: async (sandbox: UpstashSandboxInstance, path: string): Promise<void> => {
           await sandbox.exec.command(`mkdir -p "${escapeShellArg(resolvePath(sandbox, path))}"`);
         },
 
-        readdir: async (sandbox: UpstashSandbox, path: string): Promise<FileEntry[]> => {
+        readdir: async (sandbox: UpstashSandboxInstance, path: string): Promise<FileEntry[]> => {
           const entries = await sandbox.files.list(resolvePath(sandbox, path));
 
           return entries.map((entry: any) => ({
@@ -378,7 +378,7 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
           }));
         },
 
-        exists: async (sandbox: UpstashSandbox, path: string): Promise<boolean> => {
+        exists: async (sandbox: UpstashSandboxInstance, path: string): Promise<boolean> => {
           try {
             const run = await sandbox.exec.command(`test -e "${escapeShellArg(resolvePath(sandbox, path))}" && echo "exists" || echo "not_found"`);
             return (run.result || '').trim() === 'exists';
@@ -387,13 +387,13 @@ export const upstash = defineProvider<UpstashSandbox, UpstashConfig>({
           }
         },
 
-        remove: async (sandbox: UpstashSandbox, path: string): Promise<void> => {
+        remove: async (sandbox: UpstashSandboxInstance, path: string): Promise<void> => {
           await sandbox.exec.command(`rm -rf "${escapeShellArg(resolvePath(sandbox, path))}"`);
         },
       },
 
       // Provider-specific typed getInstance method
-      getInstance: (sandbox: UpstashSandbox): UpstashSandbox => {
+      getInstance: (sandbox: UpstashSandboxInstance): UpstashSandboxInstance => {
         return sandbox;
       },
     },


### PR DESCRIPTION
## Summary
- Add `EphemeralBox` support to the Upstash provider with per-call opt-in via `sandbox.create({ ephemeral: true })`
- Keep full `Box` as default while capability-gating preview URLs for ephemeral sandboxes
- Export native instance type guards to improve `getInstance()` narrowing: `isEphemeralSandboxInstance` and `isUpstashBoxInstance`

### Behavior
- **Default:** `sandbox.create()` creates a full `Box`
- **Ephemeral:** `sandbox.create({ ephemeral: true })` creates an `EphemeralBox`
- **Snapshot restore:**
  - `sandbox.create({ snapshotId })` -> `Box.fromSnapshot(...)`
  - `sandbox.create({ snapshotId, ephemeral: true })` -> `EphemeralBox.fromSnapshot(...)`

### Notes
- `ephemeral` is intentionally create-call scoped (not provider config scoped) for explicitness
- Requesting preview URLs on ephemeral sandboxes now throws a clear, actionable error