### PR TITLE
refactor(archil): require top-level diskId in create()

### DIFF
--- a/.changeset/archil-top-level-diskid.md
+++ b/.changeset/archil-top-level-diskid.md
@@ -1,0 +1,9 @@
+---
+"@computesdk/archil": minor
+---
+
+Refine Archil sandbox API to strict disk-id semantics.
+
+- `create()` now requires a top-level `diskId` option (no metadata wrapper).
+- `getById()` now resolves strictly by disk id (no name fallback).
+- Docs/tests updated to match the stricter Archil contract.

--- a/packages/archil/README.md
+++ b/packages/archil/README.md
@@ -33,7 +33,7 @@ const provider = archil();
 
 // Attach to an existing disk by id.
 const { sandbox } = await provider.sandbox.create({
-  metadata: { diskId: 'disk_abc123' },
+  diskId: 'disk_abc123',
 });
 
 const result = await provider.sandbox.runCommand(sandbox, 'echo hello > /mnt/note && cat /mnt/note');
@@ -45,13 +45,13 @@ const byId = await provider.sandbox.getById(sandbox.sandboxId);
 await provider.sandbox.destroy(sandbox.sandboxId);
 ```
 
-`create()` requires `metadata.diskId` as the target disk id.
+`create()` requires top-level `diskId` as the target disk id.
 
 ## Supported operations
 
 | Method        | Supported | Notes                                                       |
 | ------------- | --------- | ----------------------------------------------------------- |
-| `create`      | ✅        | Resolves an existing disk from `metadata.diskId`.           |
+| `create`      | ✅        | Resolves an existing disk from top-level `diskId`.          |
 | `getById`     | ✅        | Requires the disk id.                                        |
 | `list`        | ✅        | Lists all disks visible to the API key.                     |
 | `destroy`     | no-op     | Disk lifecycle is managed by Archil.                        |

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -78,9 +78,9 @@ describe('archil getById semantics', () => {
 });
 
 describe('archil create semantics', () => {
-  it('requires disk id in metadata', async () => {
+  it('requires top-level disk id', async () => {
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
-    await expect(provider.sandbox.create()).rejects.toThrow(/requires an existing disk id/i);
+    await expect(provider.sandbox.create()).rejects.toThrow(/requires an existing disk id on the top-level options/i);
   });
 
   it('resolves existing disk id without creating a new disk', async () => {
@@ -111,7 +111,7 @@ describe('archil create semantics', () => {
     global.fetch = fetchMock as typeof fetch;
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
-    const created = await provider.sandbox.create({ metadata: { diskId: 'disk_abc123' } });
+    const created = await provider.sandbox.create({ diskId: 'disk_abc123' });
 
     expect(created.sandboxId).toBe('disk_abc123');
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -128,13 +128,14 @@ runProviderTestSuite({
       region: process.env.ARCHIL_REGION,
     });
 
-    // The generic provider test suite always calls create() without metadata.
+    // The generic provider test suite always calls create() without provider-
+    // specific options.
     // Archil create() requires an explicit disk id, so inject ARCHIL_DISK_ID.
     const originalCreate = provider.sandbox.create.bind(provider.sandbox);
     const configuredDiskId = process.env.ARCHIL_DISK_ID;
 
     provider.sandbox.create = async (options?: any) => {
-      const requested = options?.metadata?.diskId as string | undefined;
+      const requested = options?.diskId as string | undefined;
       if (requested) {
         return originalCreate(options);
       }
@@ -145,10 +146,7 @@ runProviderTestSuite({
 
       return originalCreate({
         ...options,
-        metadata: {
-          ...(options?.metadata || {}),
-          diskId: configuredDiskId,
-        },
+        diskId: configuredDiskId,
       });
     };
 

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -80,6 +80,10 @@ interface ArchilSandbox {
   createdAt: Date;
 }
 
+interface ArchilCreateOptions extends CreateSandboxOptions {
+  diskId?: string;
+}
+
 function resolveConfig(config: ArchilConfig): ResolvedConfig {
   const apiKey = config.apiKey ?? process.env.ARCHIL_API_KEY;
   const region = config.region ?? process.env.ARCHIL_REGION;
@@ -145,14 +149,14 @@ async function callApi<T>(
   return payload.data as T;
 }
 
-function resolveCreateDiskId(options?: CreateSandboxOptions): string {
-  const diskId = options?.metadata?.diskId as string | undefined;
+function resolveCreateDiskId(options?: ArchilCreateOptions): string {
+  const diskId = options?.diskId;
 
   if (!diskId) {
     throw new Error(
-      'Archil create() requires an existing disk id in metadata.\n\n' +
+      'Archil create() requires an existing disk id on the top-level options.\n\n' +
         'Example:\n' +
-        '  provider.sandbox.create({ metadata: { diskId: "disk_abc123" } })',
+        '  provider.sandbox.create({ diskId: "disk_abc123" })',
     );
   }
 
@@ -199,7 +203,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
   name: 'archil',
   methods: {
     sandbox: {
-      create: async (config: ArchilConfig, options?: CreateSandboxOptions) => {
+      create: async (config: ArchilConfig, options?: ArchilCreateOptions) => {
         const resolved = resolveConfig(config);
         const diskId = resolveCreateDiskId(options);
         const disk = await callApi<DiskResponse>(

--- a/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
+++ b/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
@@ -109,12 +109,10 @@ describeIntegration('compute provider integration', () => {
       timeout: 120000,
       ...(testProvider === 'archil'
         ? {
-            metadata: {
-              diskId: requireEnv('ARCHIL_DISK_ID'),
-            },
+            diskId: requireEnv('ARCHIL_DISK_ID'),
           }
         : {}),
-    });
+    } as any);
 
     try {
       const result = await sandbox.runCode('print("computesdk-integration-ok")', 'python');


### PR DESCRIPTION
## Summary
- Refactor `@computesdk/archil` `create()` contract to require top-level `diskId`.
- Remove `metadata.diskId` usage from Archil provider internals, docs, and tests.
- Keep Archil `getById()` strict ID-only semantics.

## Details
- `provider.sandbox.create({ diskId: 'dsk-...' })` is now the required shape.
- Error messaging in Archil now points to top-level `diskId` usage.
- Updated Archil README examples and supported-operations notes.
- Updated Archil test adapter for shared provider suite to inject `diskId` at top-level.
- Updated computesdk integration test to pass top-level `diskId` for Archil provider runs.

## Changeset
- Added `.changeset/archil-top-level-diskid.md` (`@computesdk/archil`: minor).

## Validation
- `pnpm --filter @computesdk/archil typecheck`
- `pnpm --filter @computesdk/archil test`
- `pnpm --filter @computesdk/archil build`
- `pnpm --filter computesdk typecheck`
- `pnpm --filter computesdk test -- compute-provider-integration`