### PR TITLE
refactor(providers): remove sandboxId handling from create

### DIFF
--- a/packages/agentuity/src/index.ts
+++ b/packages/agentuity/src/index.ts
@@ -287,18 +287,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                 const baseURL = resolveBaseURL(config);
                 const handle = { apiKey, baseURL };
 
-                if (options?.sandboxId) {
-                    // Reconnect to an existing sandbox — just verify it is reachable.
-                    const res = await agentuityFetch(handle, 'GET', `/sandbox/status/${options.sandboxId}`);
-                    if (!res.ok) {
-                        throw new Error(
-                            `Agentuity: sandbox ${options.sandboxId} not found or inaccessible (${res.status})`,
-                        );
-                    }
-                    const existing: AgentuityHandle = { sandboxId: options.sandboxId, apiKey, baseURL };
-                    return { sandbox: existing, sandboxId: options.sandboxId };
-                }
-
                 const runtime = toAgentuityRuntime(
                     (options as any)?.runtime ?? config.runtime,
                 );

--- a/packages/beam/src/index.ts
+++ b/packages/beam/src/index.ts
@@ -154,12 +154,8 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
             `Missing Beam workspace ID. Provide 'workspaceId' in config or set BEAM_WORKSPACE_ID environment variable.`
           );
         }
-        try {
-          if (options?.sandboxId) {
-            const instance = await Sandbox.connect(options.sandboxId);
-            return { sandbox: instance, sandboxId: instance.containerId };
-          }
 
+        try {
           // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
             runtime: optRuntime,

--- a/packages/codesandbox/src/index.ts
+++ b/packages/codesandbox/src/index.ts
@@ -48,11 +48,7 @@ export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig,
           let sandbox: CodesandboxSandbox;
           let sandboxId: string;
 
-          if (options?.sandboxId) {
-            // Resume existing CodeSandbox using sdk.sandboxes.resume()
-            sandbox = await sdk.sandboxes.resume(options.sandboxId);
-            sandboxId = options.sandboxId;
-          } else if (options?.snapshotId) {
+          if (options?.snapshotId) {
             // Resume from snapshot - in CodeSandbox, snapshots are hibernated sandboxes
             sandbox = await sdk.sandboxes.resume(options.snapshotId);
             sandboxId = options.snapshotId;

--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -146,7 +146,7 @@ export interface CreateSandboxOptions {
   directory?: string;
   overlays?: SandboxOverlayConfig[];
   servers?: SandboxServerConfig[];
-  // Allow provider-specific properties (e.g., sandboxId, domain for E2B)
+  // Allow provider-specific properties (e.g., domain for E2B)
   [key: string]: any;
 }
 

--- a/packages/daytona/src/index.ts
+++ b/packages/daytona/src/index.ts
@@ -50,27 +50,22 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
           let session: DaytonaSandbox;
           let sandboxId: string;
 
-          if (options?.sandboxId) {
-            // Reconnect to existing Daytona sandbox
-            session = await daytona.get(options.sandboxId);
-            sandboxId = options.sandboxId;
-          } else {
-            // Destructure known ComputeSDK fields, collect the rest for passthrough
-            const {
-              runtime: _runtime,
-              timeout: _timeout,
-              envs,
-              name,
-              metadata,
-              templateId,
-              snapshotId,
-              sandboxId: _sandboxId,
-              namespace: _namespace,
-              directory: _directory,
-              overlays: _overlays,
-              servers: _servers,
-              ...providerOptions
-            } = options || {};
+          // Destructure known ComputeSDK fields, collect the rest for passthrough
+          const {
+            runtime: _runtime,
+            timeout: _timeout,
+            envs,
+            name,
+            metadata,
+            templateId,
+            snapshotId,
+            sandboxId: _sandboxId,
+            namespace: _namespace,
+            directory: _directory,
+            overlays: _overlays,
+            servers: _servers,
+            ...providerOptions
+          } = options || {};
 
             // Build create params from options
             // Daytona SDK uses envVars (not envs), labels (not metadata)
@@ -108,9 +103,8 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
               ? { timeout: Math.ceil(timeout / 1000) }
               : undefined;
 
-            session = await daytona.create(createParams as any, createOptions);
-            sandboxId = session.id;
-          }
+          session = await daytona.create(createParams as any, createOptions);
+          sandboxId = session.id;
 
           return {
             sandbox: session,

--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -155,27 +155,6 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
 
         const docker = new Docker(cfg.connection as any);
 
-        // Reattach?
-        if (options?.sandboxId) {
-          try {
-            const container = docker.getContainer(options.sandboxId);
-            const info = await container.inspect();
-            return {
-              sandbox: <DockerSandboxHandle>{
-                docker,
-                container,
-                containerId: options.sandboxId,
-                image: info.Config?.Image ?? cfg.image.name,
-                createdAt: new Date(info.Created || Date.now()),
-              },
-              sandboxId: options.sandboxId,
-            };
-          } catch (err) {
-            // Failed to reattach to existing container; will create a new one.
-            console.warn(`Could not reattach to Docker container with ID ${options.sandboxId}:`, err);
-          }
-        }
-
         // Choose image based on runtime if needed
         const chosenImage = pickImageForRuntime(effectiveRuntime, cfg.image);
         await ensureImage(docker, chosenImage);
@@ -467,4 +446,3 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
     },
   },
 });
-

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -57,30 +57,22 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
           let sandbox: E2BSandbox;
           let sandboxId: string;
 
-          if (options?.sandboxId) {
-            // Reconnect to existing E2B session
-            sandbox = await E2BSandbox.connect(options.sandboxId, {
-              apiKey: apiKey,
-              domain: options.domain,
-            });
-            sandboxId = options.sandboxId;
-          } else {
-            // Destructure known ComputeSDK fields, collect the rest for passthrough
-            const {
-              runtime: _runtime,
-              timeout: _timeout,
-              envs,
-              name: _name,
-              metadata,
-              templateId,
-              snapshotId,
-              sandboxId: _sandboxId,
-              namespace: _namespace,
-              directory: _directory,
-              overlays: _overlays,
-              servers: _servers,
-              ...providerOptions
-            } = options || {};
+          // Destructure known ComputeSDK fields, collect the rest for passthrough
+          const {
+            runtime: _runtime,
+            timeout: _timeout,
+            envs,
+            name: _name,
+            metadata,
+            templateId,
+            snapshotId,
+            sandboxId: _sandboxId,
+            namespace: _namespace,
+            directory: _directory,
+            overlays: _overlays,
+            servers: _servers,
+            ...providerOptions
+          } = options || {};
 
             // Build create options, spreading provider-specific options (e.g., domain)
             const createOpts: Record<string, any> = {
@@ -91,16 +83,18 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
               ...providerOptions, // Spread provider-specific options (e.g., domain)
             };
 
-            // Create new E2B session
-            // E2B supports both templateId and snapshotId (snapshotId maps to template)
-            const templateOrSnapshot = templateId || snapshotId;
-            if (templateOrSnapshot) {
-              sandbox = await E2BSandbox.create(templateOrSnapshot, createOpts);
-            } else {
-              sandbox = await E2BSandbox.create(createOpts);
-            }
-            sandboxId = sandbox.sandboxId || `e2b-${Date.now()}`;
+          // Create new E2B session
+          // E2B supports both templateId and snapshotId (snapshotId maps to template)
+          const templateOrSnapshot = templateId || snapshotId;
+          if (templateOrSnapshot) {
+            sandbox = await E2BSandbox.create(templateOrSnapshot, createOpts);
+          } else {
+            sandbox = await E2BSandbox.create(createOpts);
           }
+          if (!sandbox.sandboxId) {
+            throw new Error('E2B create() returned sandbox without an ID');
+          }
+          sandboxId = sandbox.sandboxId;
 
           return {
             sandbox,

--- a/packages/hopx/src/index.ts
+++ b/packages/hopx/src/index.ts
@@ -77,27 +77,22 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
           let sandbox: HopxSandbox;
           let sandboxId: string;
 
-          if (options?.sandboxId) {
-            // Reconnect to existing HopX sandbox using Sandbox.connect()
-            sandbox = await HopxSandbox.connect(options.sandboxId, apiKey, config.baseURL);
-            sandboxId = options.sandboxId;
-          } else {
-            // Destructure known ComputeSDK fields, collect the rest for passthrough
-            const {
-              runtime: _runtime,
-              timeout: _timeout,
-              envs,
-              name,
-              metadata: _metadata,
-              templateId,
-              snapshotId,
-              sandboxId: _sandboxId,
-              namespace: _namespace,
-              directory: _directory,
-              overlays: _overlays,
-              servers: _servers,
-              ...providerOptions
-            } = options || {};
+          // Destructure known ComputeSDK fields, collect the rest for passthrough
+          const {
+            runtime: _runtime,
+            timeout: _timeout,
+            envs,
+            name,
+            metadata: _metadata,
+            templateId,
+            snapshotId,
+            sandboxId: _sandboxId,
+            namespace: _namespace,
+            directory: _directory,
+            overlays: _overlays,
+            servers: _servers,
+            ...providerOptions
+          } = options || {};
 
             // Create new HopX sandbox using Sandbox.create()
             const createOptions: any = {
@@ -124,9 +119,8 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
               createOptions.name = name;
             }
 
-            sandbox = await HopxSandbox.create(createOptions);
-            sandboxId = sandbox.sandboxId;
-          }
+          sandbox = await HopxSandbox.create(createOptions);
+          sandboxId = sandbox.sandboxId;
 
           return {
             sandbox,
@@ -519,4 +513,3 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
 
 // Export HopX sandbox type for explicit typing
 export type { Sandbox as HopxSandbox } from '@hopx-ai/sdk';
-

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "computesdk": "workspace:*",
-    "@computesdk/provider": "workspace:*"
+    "@computesdk/provider": "workspace:*",
+    "nanoid": "^5.1.6"
   },
   "peerDependencies": {
     "just-bash": ">=2.0.0"

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -15,6 +15,7 @@
 
 import { Bash } from 'just-bash';
 import type { BashExecResult, BashOptions } from 'just-bash';
+import { nanoid } from 'nanoid';
 import { defineProvider } from '@computesdk/provider';
 import type {
   CodeResult,
@@ -81,13 +82,7 @@ const _provider = defineProvider<JustBashSandbox, JustBashConfig>({
        * Create a new just-bash sandbox
        */
       create: async (config: JustBashConfig, options?: CreateSandboxOptions) => {
-        const sandboxId = options?.sandboxId || `just-bash-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-        // Check if reconnecting to existing sandbox
-        if (options?.sandboxId && activeSandboxes.has(options.sandboxId)) {
-          const existing = activeSandboxes.get(options.sandboxId)!;
-          return { sandbox: existing, sandboxId: existing.id };
-        }
+        const sandboxId = `just-bash-${nanoid(10)}`;
 
         const bash = new Bash({
           files: config.files,

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -99,13 +99,8 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
           let sandbox: any;
           let sandboxId: string;
 
-          if (options?.sandboxId) {
-            // Reconnect to existing Modal sandbox
-            sandbox = await Sandbox.fromId(options.sandboxId);
-            sandboxId = options.sandboxId;
-          } else {
-            // Create new Modal sandbox
-            const app = await App.lookup('computesdk-modal', { createIfMissing: true });
+          // Create new Modal sandbox
+          const app = await App.lookup('computesdk-modal', { createIfMissing: true });
 
             // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {
@@ -171,9 +166,8 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
               sandboxOptions.name = name;
             }
             
-            sandbox = await app.createSandbox(image, sandboxOptions);
-            sandboxId = sandbox.sandboxId;
-          }
+          sandbox = await app.createSandbox(image, sandboxOptions);
+          sandboxId = sandbox.sandboxId;
 
           const modalSandbox: ModalSandbox = {
             sandbox,

--- a/packages/secure-exec/package.json
+++ b/packages/secure-exec/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "secure-exec": "^0.1.1-rc.3",
     "@computesdk/provider": "workspace:*",
-    "computesdk": "workspace:*"
+    "computesdk": "workspace:*",
+    "nanoid": "^5.1.6"
   },
   "keywords": [
     "computesdk",

--- a/packages/secure-exec/src/index.ts
+++ b/packages/secure-exec/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from 'secure-exec';
 import type { VirtualFileSystem, CommandExecutor } from 'secure-exec';
 import { spawn } from 'node:child_process';
+import { nanoid } from 'nanoid';
 import { defineProvider } from '@computesdk/provider';
 
 import type {
@@ -131,7 +132,7 @@ export const secureExec = defineProvider<SecureExecInstance, SecureExecConfig>({
 
         await fs.mkdir('/workspace');
 
-        const sandboxId = options?.sandboxId || `secureexec_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+        const sandboxId = `secureexec_${nanoid(10)}`;
 
         return {
           sandbox: { runtime, fs, sandboxId },

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -136,31 +136,24 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         try {
           let sandbox: VercelSandbox;
 
-          if (options?.sandboxId) {
-            // Vercel doesn't support reconnecting to existing sandboxes
-            // Each sandbox is ephemeral and must be created fresh
-            throw new Error(
-              `Vercel provider does not support reconnecting to existing sandboxes. Vercel sandboxes are ephemeral and must be created fresh each time.`
-            );
-          } else {
-            // Destructure known ComputeSDK fields, collect the rest for passthrough
-            const {
-              runtime: optRuntime,
-              timeout: _timeout,
-              envs: _envs, // Vercel SDK does not support envs at sandbox creation time
-              name: _name,
-              metadata: _metadata,
-              templateId,
-              snapshotId: optSnapshotId,
-              sandboxId: _sandboxId,
-              namespace: _namespace,
-              directory: _directory,
-              overlays: _overlays,
-              servers: _servers,
-              ports: optPorts,
-              source: optSource,
-              ...providerOptions
-            } = options || {};
+          // Destructure known ComputeSDK fields, collect the rest for passthrough
+          const {
+            runtime: optRuntime,
+            timeout: _timeout,
+            envs: _envs, // Vercel SDK does not support envs at sandbox creation time
+            name: _name,
+            metadata: _metadata,
+            templateId,
+            snapshotId: optSnapshotId,
+            sandboxId: _sandboxId,
+            namespace: _namespace,
+            directory: _directory,
+            overlays: _overlays,
+            servers: _servers,
+            ports: optPorts,
+            source: optSource,
+            ...providerOptions
+          } = options || {};
 
             // Construct base params, spreading provider-specific options
             const params: any = {
@@ -207,8 +200,7 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
               params.projectId = creds.projectId;
             }
 
-            sandbox = await VercelSandbox.create(params);
-          }
+          sandbox = await VercelSandbox.create(params);
 
           return {
             sandbox,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -908,6 +908,9 @@ importers:
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.9
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -1300,6 +1303,9 @@ importers:
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.9
       secure-exec:
         specifier: ^0.1.1-rc.3
         version: 0.1.1-rc.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -5551,6 +5557,7 @@ packages:
 
   freestyle-sandboxes@0.1.34:
     resolution: {integrity: sha512-RUCiWoFWLDfe3rETet7DmC5S7022L2kbmYWdHNJMUX/nBIKmKUpCT28szabCYH0Hsl5LyF3Zmanl3itB+m4m2A==}
+    deprecated: This package has been deprecated. Please use freestyle instead.
     hasBin: true
 
   fresh@2.0.0:
@@ -6371,6 +6378,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   napi-build-utils@2.0.0:
@@ -14458,6 +14470,8 @@ snapshots:
   nano-spawn@1.0.2: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.9: {}
 
   napi-build-utils@2.0.0:
     optional: true


### PR DESCRIPTION
## Summary
- remove `options.sandboxId` handling from provider `sandbox.create(...)` flows so create paths are strictly creation-oriented
- keep reconnection semantics in `sandbox.getById(...)`, while `create` now ignores any stray `sandboxId` field from caller input
- adopt `nanoid` for local generated IDs in `just-bash` and `secure-exec` for cleaner collision-resistant IDs

## Notes
- also updated the `CreateSandboxOptions` comment in `computesdk` types to stop implying `sandboxId` is a create option
- verified via typecheck across all touched provider packages and `computesdk`