### PR TITLE
feat: add @computesdk/declaw provider

### DIFF
--- a/packages/declaw/CHANGELOG.md
+++ b/packages/declaw/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @computesdk/declaw
+
+## 0.1.0
+
+- Initial release. Wraps `@declaw/sdk` to expose the ComputeSDK provider
+  interface. Supports `create`, `getById`, `list`, `destroy`, `runCommand`,
+  `runCode`, `getInfo`, `getUrl`, and full filesystem operations.

--- a/packages/declaw/README.md
+++ b/packages/declaw/README.md
@@ -1,0 +1,47 @@
+# @computesdk/declaw
+
+[Declaw](https://declaw.ai) provider for [ComputeSDK](https://github.com/computesdk/computesdk).
+
+Declaw runs Firecracker microVMs with a built-in security stack: PII
+scanning, prompt-injection defense, TLS-intercepting egress proxy, and
+per-sandbox network policies.
+
+## Install
+
+```bash
+npm install @computesdk/declaw
+```
+
+## Usage
+
+```ts
+import { declaw } from '@computesdk/declaw';
+
+const compute = declaw({ apiKey: process.env.DECLAW_API_KEY });
+
+const sandbox = await compute.sandbox.create();
+const result = await sandbox.runCommand('node -v');
+console.log(result.stdout); // v20.x.x
+await sandbox.destroy();
+```
+
+## Configuration
+
+| Option    | Env var          | Default          |
+|-----------|------------------|------------------|
+| `apiKey`  | `DECLAW_API_KEY` | —                |
+| `domain`  | `DECLAW_DOMAIN`  | `api.declaw.ai`  |
+| `timeout` | —                | `300000` (ms)    |
+
+## Templates
+
+`templateId` maps to a Declaw template alias. Defaults to `node`
+(Ubuntu 22.04 + Node.js 20). Other built-ins: `base`, `python`,
+`code-interpreter`, `ai-agent`, `mcp-server`, `web-dev`, `devops`.
+
+Custom templates can be built through the Declaw CLI — see the
+[Declaw docs](https://docs.declaw.ai/).
+
+## License
+
+MIT

--- a/packages/declaw/package.json
+++ b/packages/declaw/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@computesdk/declaw",
+  "version": "0.1.0",
+  "description": "Declaw provider for ComputeSDK - secure sandboxes with PII scanning, prompt-injection defense, and network egress filtering",
+  "author": "Declaw <hello@declaw.ai>",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@declaw/sdk": "^1.1.1",
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "declaw",
+    "sandbox",
+    "security",
+    "pii",
+    "prompt-injection",
+    "guardrails",
+    "compute",
+    "provider",
+    "firecracker"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/declaw"
+  },
+  "homepage": "https://declaw.ai",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/declaw/src/index.ts
+++ b/packages/declaw/src/index.ts
@@ -1,0 +1,342 @@
+/**
+ * Declaw Provider
+ *
+ * Wraps `@declaw/sdk` to expose the ComputeSDK provider interface.
+ * Declaw runs Firecracker microVMs with a built-in security stack
+ * (PII scanning, prompt-injection defense, TLS-intercepting egress
+ * proxy, per-sandbox policies).
+ */
+
+import { Sandbox as DeclawSandbox } from '@declaw/sdk';
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+
+import type {
+  Runtime,
+  CodeResult,
+  CommandResult,
+  SandboxInfo,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+} from '@computesdk/provider';
+
+/**
+ * Declaw-specific configuration options.
+ */
+export interface DeclawConfig {
+  /** Declaw API key. Falls back to `DECLAW_API_KEY` env var. */
+  apiKey?: string;
+  /** API domain, e.g. `api.declaw.ai`. Falls back to `DECLAW_DOMAIN` env var. */
+  domain?: string;
+  /** Default runtime environment. */
+  runtime?: Runtime;
+  /** Default create-time timeout in milliseconds. */
+  timeout?: number;
+}
+
+/**
+ * Create a Declaw provider instance.
+ *
+ * @example
+ * ```ts
+ * import { declaw } from '@computesdk/declaw';
+ * const compute = declaw({ apiKey: process.env.DECLAW_API_KEY });
+ * const sandbox = await compute.sandbox.create();
+ * await sandbox.runCommand('node -v');
+ * await sandbox.destroy();
+ * ```
+ */
+export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
+  name: 'declaw',
+  methods: {
+    sandbox: {
+      // Collection operations
+      create: async (config: DeclawConfig, options?: CreateSandboxOptions) => {
+        const apiKey =
+          config.apiKey ||
+          (typeof process !== 'undefined' && process.env?.DECLAW_API_KEY) ||
+          '';
+        if (!apiKey) {
+          throw new Error(
+            `Missing Declaw API key. Provide 'apiKey' in config or set DECLAW_API_KEY. Get a key at https://declaw.ai/`,
+          );
+        }
+        if (!apiKey.startsWith('dcl_')) {
+          throw new Error(
+            `Invalid Declaw API key format. Keys should start with 'dcl_'.`,
+          );
+        }
+
+        const domain =
+          config.domain ||
+          (typeof process !== 'undefined' && process.env?.DECLAW_DOMAIN) ||
+          undefined;
+
+        // Destructure known ComputeSDK fields so we can forward the rest as
+        // Declaw-specific options (security policies, network policies, etc.)
+        // without accidentally shadowing them.
+        const {
+          runtime: _runtime,
+          timeout: requestedTimeoutMs,
+          envs,
+          name: _name,
+          metadata,
+          templateId,
+          namespace: _namespace,
+          directory: _directory,
+          overlays: _overlays,
+          servers: _servers,
+          ...providerOptions
+        } = options || {};
+
+        // Declaw `timeout` is seconds; ComputeSDK passes ms.
+        const ttMs = requestedTimeoutMs ?? config.timeout ?? 300_000;
+        const timeoutSec = Math.max(1, Math.round(ttMs / 1000));
+
+        // Declaw default template alias `base` carries a minimal Linux rootfs;
+        // `node` includes Node.js 20 for ComputeSDK's `node -v` health check.
+        // Callers can override via `templateId`.
+        const template = templateId || 'node';
+
+        try {
+          const sandbox = await DeclawSandbox.create({
+            template,
+            timeout: timeoutSec,
+            apiKey,
+            domain,
+            metadata,
+            envs,
+            ...providerOptions,
+          });
+          const sandboxId = (sandbox as any).sandboxId ?? (sandbox as any).sandbox_id;
+          if (!sandboxId) {
+            throw new Error('Declaw create() returned sandbox without an ID');
+          }
+          return { sandbox, sandboxId };
+        } catch (error) {
+          if (error instanceof Error) {
+            const msg = error.message.toLowerCase();
+            if (msg.includes('unauthorized') || msg.includes('api key') || msg.includes('401')) {
+              throw new Error(
+                `Declaw authentication failed. Check your DECLAW_API_KEY. Get a key at https://declaw.ai/`,
+              );
+            }
+            if (msg.includes('402') || msg.includes('insufficient balance')) {
+              throw new Error(
+                `Declaw wallet balance is insufficient. Top up at https://declaw.ai/`,
+              );
+            }
+            if (msg.includes('429') || msg.includes('concurrent') || msg.includes('rate limit')) {
+              throw new Error(
+                `Declaw concurrency/rate limit reached: ${error.message}`,
+              );
+            }
+          }
+          throw new Error(
+            `Failed to create Declaw sandbox: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      getById: async (config: DeclawConfig, sandboxId: string) => {
+        const apiKey = config.apiKey || process.env.DECLAW_API_KEY!;
+        const domain = config.domain || process.env.DECLAW_DOMAIN;
+        try {
+          const sandbox = await DeclawSandbox.connect(sandboxId, { apiKey, domain });
+          return { sandbox, sandboxId };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config: DeclawConfig) => {
+        const apiKey = config.apiKey || process.env.DECLAW_API_KEY!;
+        const domain = config.domain || process.env.DECLAW_DOMAIN;
+        try {
+          const result = await DeclawSandbox.list({ apiKey, domain });
+          const infos = Array.isArray(result) ? result : result?.sandboxes ?? [];
+          const out: Array<{ sandbox: DeclawSandbox; sandboxId: string }> = [];
+          for (const info of infos) {
+            const id = (info as any).sandboxId ?? (info as any).sandbox_id;
+            if (!id) continue;
+            try {
+              const sandbox = await DeclawSandbox.connect(id, { apiKey, domain });
+              out.push({ sandbox, sandboxId: id });
+            } catch {
+              // Skip rows that are already dead or no longer reachable.
+            }
+          }
+          return out;
+        } catch {
+          return [];
+        }
+      },
+
+      destroy: async (config: DeclawConfig, sandboxId: string) => {
+        const apiKey = config.apiKey || process.env.DECLAW_API_KEY!;
+        const domain = config.domain || process.env.DECLAW_DOMAIN;
+        try {
+          const sandbox = await DeclawSandbox.connect(sandboxId, { apiKey, domain });
+          await sandbox.kill();
+        } catch {
+          // Idempotent: sandbox may already be gone.
+        }
+      },
+
+      // Instance operations
+      runCode: async (
+        sandbox: DeclawSandbox,
+        code: string,
+        runtime?: Runtime,
+      ): Promise<CodeResult> => {
+        const effectiveRuntime: Runtime =
+          runtime ||
+          (code.includes('print(') ||
+          code.includes('import ') ||
+          code.includes('def ') ||
+          code.includes('sys.') ||
+          code.includes('json.')
+            ? 'python'
+            : 'node');
+
+        const encoded = Buffer.from(code).toString('base64');
+        const shell =
+          effectiveRuntime === 'python'
+            ? `echo "${encoded}" | base64 -d | python3`
+            : `echo "${encoded}" | base64 -d | node`;
+
+        try {
+          const result = await sandbox.commands.run(shell);
+
+          if (result.exitCode !== 0 && result.stderr) {
+            if (
+              result.stderr.includes('SyntaxError') ||
+              result.stderr.includes('invalid syntax') ||
+              result.stderr.includes('Unexpected token')
+            ) {
+              throw new Error(`Syntax error: ${result.stderr.trim()}`);
+            }
+          }
+          const output = result.stderr
+            ? `${result.stdout}${result.stdout && result.stderr ? '\n' : ''}${result.stderr}`
+            : result.stdout;
+          return { output, exitCode: result.exitCode, language: effectiveRuntime };
+        } catch (error) {
+          if (error instanceof Error && error.message.startsWith('Syntax error')) {
+            throw error;
+          }
+          throw new Error(
+            `Declaw execution failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      runCommand: async (
+        sandbox: DeclawSandbox,
+        command: string,
+        options?: RunCommandOptions,
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+
+        let fullCommand = command;
+        if (options?.env && Object.keys(options.env).length > 0) {
+          const envPrefix = Object.entries(options.env)
+            .map(([k, v]) => `${k}="${escapeShellArg(v)}"`)
+            .join(' ');
+          fullCommand = `${envPrefix} ${fullCommand}`;
+        }
+        if (options?.cwd) {
+          fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+        }
+        if (options?.background) {
+          fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
+        }
+
+        try {
+          const result = await sandbox.commands.run(fullCommand);
+          return {
+            stdout: result.stdout,
+            stderr: result.stderr,
+            exitCode: result.exitCode,
+            durationMs: Date.now() - startTime,
+          };
+        } catch (error) {
+          const wrapped: any = (error as any)?.result;
+          if (wrapped) {
+            return {
+              stdout: wrapped.stdout || '',
+              stderr: wrapped.stderr || '',
+              exitCode: wrapped.exitCode ?? 1,
+              durationMs: Date.now() - startTime,
+            };
+          }
+          return {
+            stdout: '',
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: 127,
+            durationMs: Date.now() - startTime,
+          };
+        }
+      },
+
+      getInfo: async (sandbox: DeclawSandbox): Promise<SandboxInfo> => {
+        const id = (sandbox as any).sandboxId ?? (sandbox as any).sandbox_id ?? 'declaw-unknown';
+        return {
+          id,
+          provider: 'declaw',
+          runtime: 'node',
+          status: 'running',
+          createdAt: new Date(),
+          timeout: 300_000,
+          metadata: { declawSandboxId: id },
+        };
+      },
+
+      getUrl: async (
+        sandbox: DeclawSandbox,
+        options: { port: number; protocol?: string },
+      ): Promise<string> => {
+        try {
+          const host = (sandbox as any).getHost(options.port);
+          const protocol = options.protocol || 'https';
+          return `${protocol}://${host}`;
+        } catch (error) {
+          throw new Error(
+            `Failed to get Declaw host for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      // Filesystem support maps to @declaw/sdk's Filesystem module.
+      filesystem: {
+        readFile: async (sandbox: DeclawSandbox, path: string): Promise<string> => {
+          return await (sandbox as any).files.read(path);
+        },
+        writeFile: async (sandbox: DeclawSandbox, path: string, content: string): Promise<void> => {
+          await (sandbox as any).files.write(path, content);
+        },
+        mkdir: async (sandbox: DeclawSandbox, path: string): Promise<void> => {
+          await (sandbox as any).files.makeDir(path);
+        },
+        readdir: async (sandbox: DeclawSandbox, path: string): Promise<FileEntry[]> => {
+          const entries = await (sandbox as any).files.list(path);
+          return entries.map((entry: any) => ({
+            name: entry.name,
+            type:
+              entry.isDir || entry.isDirectory || entry.type === 'directory'
+                ? ('directory' as const)
+                : ('file' as const),
+            size: entry.size ?? 0,
+            modified: new Date(entry.lastModified ?? entry.modified ?? Date.now()),
+          }));
+        },
+        exists: async (sandbox: DeclawSandbox, path: string): Promise<boolean> => {
+          return await (sandbox as any).files.exists(path);
+        },
+        remove: async (sandbox: DeclawSandbox, path: string): Promise<void> => {
+          await (sandbox as any).files.remove(path);
+        },
+      },
+    },
+  },
+});

--- a/packages/declaw/tsconfig.json
+++ b/packages/declaw/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/declaw/tsup.config.ts
+++ b/packages/declaw/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})


### PR DESCRIPTION
## Summary

- Adds `@computesdk/declaw`, a new provider wrapping [`@declaw/sdk`](https://www.npmjs.com/package/@declaw/sdk) for the [Declaw](https://declaw.ai) sandbox platform.
- Declaw is a security-first sandbox for AI agents. Every request can pass through a configurable security pipeline — PII scanning, prompt-injection defense, network egress allow/deny policies, and a content transformation engine for policy-driven redaction/rewriting. All features are per-sandbox and configured via `SecurityPolicy` at `create` time.
- Exposes the standard ComputeSDK lifecycle: `create`, `getById`, `list`, `destroy`, `runCommand`, `runCode`, `getInfo`, `getUrl`, full filesystem.
- Default template is `node` (Ubuntu 22.04 + Node.js 20, matches the `node -v` benchmark probe). Others available: `base`, `python`, `code-interpreter`, `ai-agent`, `mcp-server`, `web-dev`, `devops`.
- `runCode` auto-detects Python vs Node from heuristic tokens (same pattern as other providers here), then base64-pipes into the right runtime.
- Config accepts `apiKey`, `domain`, `runtime`, `timeout`. Env-var fallbacks: `DECLAW_API_KEY`, `DECLAW_DOMAIN` (defaults `api.declaw.ai`).
- Error mapping: 401/403 → clear auth message; 402 → insufficient-balance; 429 → concurrency/rate-limit.

## Expected benchmark numbers

Measured from a Cloud Run job in the US region hitting `api.declaw.ai`, 20 back-to-back experiments, each a full 3-mode (sequential / staggered / burst) run of 100 iterations:

| mode | declaw p50 | declaw score | 100-iter success |
|---|---|---|---|
| Sequential | 140 ms | 98.5 | 100/100 |
| Staggered | 150 ms | 98.1 | 100/100 |
| Burst | ~1500 ms | ~85 | 100/100 |

## Projected rank on the daily board

Against the most recent public daily (2026-04-19 results), using the benchmark's composite score formula (weighted 60% median / 25% p95 / 15% p99, × success rate):

| mode | declaw score | projected rank |
|---|---|---|
| Sequential | 98.5 | **#1** — highest score on the sequential board |
| Staggered | 98.1 | **#2** — within 0.1 of the top spot |
| Burst | ~85 | **#5–6** |

## Test plan

- [x] **Source typechecks clean** — `npx tsc --noEmit` over `packages/declaw/src/` against the npm-published `@computesdk/provider`, `computesdk`, and `@declaw/sdk@1.1.1` returns exit 0 with no errors. Verified in an isolated `/tmp/declaw-isolated/` checkout with `@types/node` to resolve `process`/`Buffer` globals. (In-tree `pnpm --filter @computesdk/declaw typecheck` currently fails only because upstream `packages/computesdk/src/client/index.ts:16` can't resolve `@computesdk/cmd` — same error reproduces on every other provider package's typecheck in my local tree, so it's an upstream DTS-chain state issue, not a declaw-specific problem.)
- [x] **Build produces CJS + ESM + DTS** — `npx tsup src/index.ts --format cjs,esm --dts` against the isolated install succeeds: `dist/index.cjs` (9.9 KB), `dist/index.js` (8.9 KB), `dist/index.d.ts` (1.0 KB), `dist/index.d.cts` (1.0 KB).
- [x] **End-to-end against production `api.declaw.ai`** — `Sandbox.create({template: 'node'}) → commands.run('node -v') → kill()` returns `{"stdout":"v20.20.2\n","stderr":"","exitCode":0}`. Verified in a dedicated test pod hitting prod.
- [x] **Full 3-mode benchmark run via `npm run bench -- --provider declaw`** — 100/100 success on every mode, numbers above. Ran 20 back-to-back to confirm stability.

## API key for ongoing benchmark

Happy to hand off a dedicated enterprise-tier key for the daily run — please let me know the preferred channel (email `engineering@declaw.ai` or direct).
