### PR TITLE
feat: add hyperbrowser browser package to sdk

### DIFF
--- a/packages/hyperbrowser/example-hyperbrowser.ts
+++ b/packages/hyperbrowser/example-hyperbrowser.ts
@@ -1,0 +1,33 @@
+import { chromium } from 'playwright-core';
+import { hyperbrowser } from './src/index';
+import 'dotenv/config';
+
+async function main() {
+  const hb = hyperbrowser({ apiKey: process.env.HYPERBROWSER_API_KEY });
+
+  // Create a new session
+  const session = await hb.session.create();
+
+  // Connect to the session
+  const browser = await chromium.connectOverCDP(session.connectUrl);
+
+  const defaultContext = browser.contexts()[0]!;
+  const page = defaultContext.pages()[0]!;
+
+  await page.goto('https://news.ycombinator.com/');
+  const topStory = await page.evaluate(() => {
+    const titleElement = document.querySelector('.titleline > a');
+    return titleElement ? titleElement.textContent : null;
+  });
+  console.log('Top story:', topStory);
+
+  await page.close();
+  await browser.close();
+
+  // Clean up the session
+  await session.destroy();
+
+  console.log(`Session complete: ${session.sessionId}`);
+}
+
+main().catch(console.error);

--- a/packages/hyperbrowser/package.json
+++ b/packages/hyperbrowser/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@computesdk/hyperbrowser",
+  "version": "0.1.0",
+  "description": "Hyperbrowser browser provider for ComputeSDK - cloud browser sessions with stealth mode, proxies, profiles, and session recording",
+  "author": "Garrison",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "@hyperbrowser/sdk": "^0.89.0",
+    "computesdk": "workspace:*",
+    "dotenv": "^16.0.0",
+    "playwright-core": "^1.40.0"
+  },
+  "keywords": [
+    "computesdk",
+    "hyperbrowser",
+    "browser",
+    "headless",
+    "playwright",
+    "puppeteer",
+    "stealth",
+    "proxy",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/hyperbrowser"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/hyperbrowser/src/__tests__/index.test.ts
+++ b/packages/hyperbrowser/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { runBrowserProviderTestSuite } from '@computesdk/test-utils';
+import { hyperbrowser } from '../index';
+
+runBrowserProviderTestSuite({
+  name: 'hyperbrowser',
+  provider: hyperbrowser({}),
+  skipIntegration: !process.env.HYPERBROWSER_API_KEY,
+});

--- a/packages/hyperbrowser/src/index.ts
+++ b/packages/hyperbrowser/src/index.ts
@@ -1,0 +1,348 @@
+/**
+ * Hyperbrowser Browser Provider - Factory-based Implementation
+ *
+ * Cloud browser sessions with stealth mode, proxies, profiles,
+ * extensions, event logs, and session recordings via the Hyperbrowser platform.
+ */
+
+import { Hyperbrowser } from '@hyperbrowser/sdk';
+import type {
+  CreateSessionParams,
+  SessionDetail,
+  SessionEventLog,
+} from '@hyperbrowser/sdk/types';
+import { defineBrowserProvider } from '@computesdk/provider';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type {
+  BrowserSession,
+  CreateBrowserSessionOptions,
+  BrowserProfile,
+  BrowserExtension,
+  BrowserLog,
+  BrowserRecording,
+  ProxyConfig,
+} from '@computesdk/provider';
+
+/**
+ * Hyperbrowser-specific configuration options
+ */
+export interface HyperbrowserConfig {
+  /** Hyperbrowser API key — falls back to HYPERBROWSER_API_KEY env var */
+  apiKey?: string;
+  /** Optional API base URL override */
+  baseUrl?: string;
+  /** Optional request timeout (ms) */
+  timeout?: number;
+}
+
+/**
+ * The native Hyperbrowser session object returned by their SDK.
+ * SessionDetail includes wsEndpoint and live URLs; the list endpoint
+ * returns a leaner Session shape without wsEndpoint.
+ */
+type HyperbrowserSession = SessionDetail;
+
+/**
+ * Resolve config values from explicit config or environment variables
+ */
+function resolveConfig(config: HyperbrowserConfig) {
+  const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.HYPERBROWSER_API_KEY) || '';
+
+  if (!apiKey) {
+    throw new Error(
+      `Missing Hyperbrowser API key. Provide 'apiKey' in config or set HYPERBROWSER_API_KEY environment variable. ` +
+      `Get your API key from https://app.hyperbrowser.ai/quickstart`
+    );
+  }
+
+  return { apiKey, baseUrl: config.baseUrl, timeout: config.timeout };
+}
+
+/**
+ * Create a Hyperbrowser SDK client from config
+ */
+function createClient(config: HyperbrowserConfig): Hyperbrowser {
+  const { apiKey, baseUrl, timeout } = resolveConfig(config);
+  return new Hyperbrowser({ apiKey, baseUrl, timeout });
+}
+
+/**
+ * Apply a single ProxyConfig entry onto the Hyperbrowser create-session params.
+ * Hyperbrowser only supports one proxy per session, so when multiple are passed
+ * we honor the first one.
+ */
+function applyProxy(params: CreateSessionParams, proxy: ProxyConfig) {
+  params.useProxy = true;
+  if (proxy.type === 'custom' && proxy.server) {
+    params.proxyServer = proxy.server;
+    if (proxy.username) params.proxyServerUsername = proxy.username;
+    if (proxy.password) params.proxyServerPassword = proxy.password;
+  }
+  if (proxy.geolocation?.country) params.proxyCountry = proxy.geolocation.country as CreateSessionParams['proxyCountry'];
+  if (proxy.geolocation?.state) params.proxyState = proxy.geolocation.state as CreateSessionParams['proxyState'];
+  if (proxy.geolocation?.city) params.proxyCity = proxy.geolocation.city;
+}
+
+/**
+ * Map ComputeSDK session options to Hyperbrowser create session params
+ */
+function mapSessionOptions(options?: CreateBrowserSessionOptions): CreateSessionParams {
+  if (!options) return {};
+
+  const params: CreateSessionParams = {};
+
+  if (options.stealth !== undefined) params.useStealth = options.stealth;
+  if (options.viewport) params.screen = { width: options.viewport.width, height: options.viewport.height };
+  if (options.recording !== undefined) params.enableWebRecording = options.recording;
+  if (options.logging !== undefined) params.enableLogCapture = options.logging;
+  if (options.extensionIds && options.extensionIds.length > 0) params.extensionIds = options.extensionIds;
+  if (options.region) params.region = options.region as CreateSessionParams['region'];
+  if (options.profileId) {
+    params.profile = { id: options.profileId, persistChanges: true };
+  }
+  // Hyperbrowser only accepts a session timeout in minutes
+  if (options.timeout !== undefined) params.timeoutMinutes = Math.max(1, Math.ceil(options.timeout / 60));
+
+  if (options.proxies === true) {
+    params.useProxy = true;
+  } else if (Array.isArray(options.proxies) && options.proxies.length > 0) {
+    applyProxy(params, options.proxies[0]!);
+  }
+
+  return params;
+}
+
+/**
+ * Map Hyperbrowser session status onto our standard set
+ */
+function mapStatus(status: string | undefined): BrowserSession['status'] {
+  switch (status) {
+    case 'active': return 'running';
+    case 'closed': return 'completed';
+    case 'error': return 'failed';
+    default: return 'created';
+  }
+}
+
+/**
+ * Map a Hyperbrowser session event log type to a log level
+ */
+function mapLogLevel(type: SessionEventLog['type']): BrowserLog['level'] {
+  return type === 'captcha_error' ? 'error' : 'info';
+}
+
+/**
+ * Hyperbrowser's extension API only accepts a file path on disk. If a buffer
+ * or raw string of bytes is provided, write it to a temp file first.
+ */
+function materializeExtensionFile(file: Uint8Array | string, name?: string): { filePath: string; cleanup: () => void } {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hyperbrowser-ext-'));
+  const filePath = path.join(tmpDir, name ?? 'extension.zip');
+  if (typeof file === 'string') {
+    fs.writeFileSync(filePath, file);
+  } else {
+    fs.writeFileSync(filePath, Buffer.from(file));
+  }
+  return {
+    filePath,
+    cleanup: () => {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    },
+  };
+}
+
+/**
+ * Create a Hyperbrowser browser provider instance
+ *
+ * @example
+ * ```ts
+ * import { hyperbrowser } from '@computesdk/hyperbrowser';
+ * import { chromium } from 'playwright-core';
+ *
+ * const hb = hyperbrowser({ apiKey: process.env.HYPERBROWSER_API_KEY });
+ *
+ * // Create a stealth browser session
+ * const session = await hb.session.create({ stealth: true, proxies: true });
+ * console.log(session.connectUrl); // wsEndpoint
+ *
+ * // Connect with Playwright
+ * const browser = await chromium.connectOverCDP(session.connectUrl);
+ * const page = browser.contexts()[0].pages()[0];
+ * await page.goto('https://example.com');
+ *
+ * // Stop the session
+ * await session.destroy();
+ * ```
+ */
+export const hyperbrowser = defineBrowserProvider<HyperbrowserSession, HyperbrowserConfig>({
+  name: 'hyperbrowser',
+  methods: {
+    // ─── Session Lifecycle ─────────────────────────────────────────────
+    session: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const session = await client.sessions.create(mapSessionOptions(options));
+        return {
+          session,
+          sessionId: session.id,
+          connectUrl: session.wsEndpoint,
+          status: mapStatus(session.status),
+        };
+      },
+
+      getById: async (config, sessionId) => {
+        const client = createClient(config);
+        try {
+          const session = await client.sessions.get(sessionId);
+          return {
+            session,
+            sessionId: session.id,
+            connectUrl: session.wsEndpoint,
+            status: mapStatus(session.status),
+          };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const client = createClient(config);
+        const response = await client.sessions.list();
+        // The list response returns a lean Session shape without wsEndpoint;
+        // callers needing the connect URL should use getConnectUrl(sessionId).
+        return response.sessions.map((s) => ({
+          session: s as HyperbrowserSession,
+          sessionId: s.id,
+          connectUrl: '',
+          status: mapStatus(s.status),
+        }));
+      },
+
+      destroy: async (config, sessionId) => {
+        const client = createClient(config);
+        await client.sessions.stop(sessionId);
+      },
+
+      getConnectUrl: async (config, sessionId) => {
+        const client = createClient(config);
+        const session = await client.sessions.get(sessionId);
+        return session.wsEndpoint;
+      },
+    },
+
+    // ─── Profiles (Persistent Browser Contexts) ────────────────────────
+    profile: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const result = await client.profiles.create(options?.name ? { name: options.name } : {});
+        return {
+          profileId: result.id,
+          name: result.name ?? options?.name,
+          metadata: options?.metadata as Record<string, unknown> | undefined,
+        } satisfies BrowserProfile;
+      },
+
+      get: async (config, profileId) => {
+        const client = createClient(config);
+        try {
+          const result = await client.profiles.get(profileId);
+          return {
+            profileId: result.id,
+            name: result.name ?? undefined,
+            createdAt: result.createdAt ? new Date(result.createdAt) : undefined,
+          } satisfies BrowserProfile;
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const client = createClient(config);
+        const response = await client.profiles.list();
+        return response.profiles.map((p) => ({
+          profileId: p.id,
+          name: p.name ?? undefined,
+          createdAt: p.createdAt ? new Date(p.createdAt) : undefined,
+        } satisfies BrowserProfile));
+      },
+
+      delete: async (config, profileId) => {
+        const client = createClient(config);
+        await client.profiles.delete(profileId);
+      },
+    },
+
+    // ─── Extensions ────────────────────────────────────────────────────
+    extension: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const { filePath, cleanup } = materializeExtensionFile(options.file, options.name);
+        try {
+          const result = await client.extensions.create({ filePath, name: options.name });
+          return {
+            extensionId: result.id,
+            name: result.name,
+          } satisfies BrowserExtension;
+        } finally {
+          cleanup();
+        }
+      },
+
+      get: async (config, extensionId) => {
+        const client = createClient(config);
+        // Hyperbrowser exposes only a list endpoint — filter the result.
+        const extensions = await client.extensions.list();
+        const found = extensions.find((e) => e.id === extensionId);
+        if (!found) return null;
+        return { extensionId: found.id, name: found.name } satisfies BrowserExtension;
+      },
+
+      delete: async () => {
+        throw new Error(
+          `Hyperbrowser does not expose an extension delete endpoint. ` +
+          `Manage extensions from the Hyperbrowser dashboard instead.`
+        );
+      },
+    },
+
+    // ─── Logs (Session Event Logs) ─────────────────────────────────────
+    logs: {
+      list: async (config, sessionId) => {
+        const client = createClient(config);
+        const response = await client.sessions.eventLogs.list(sessionId);
+        return response.data.map((log) => ({
+          timestamp: new Date(log.timestamp),
+          level: mapLogLevel(log.type),
+          message: log.type,
+          data: { ...log.metadata, targetId: log.targetId, pageUrl: log.pageUrl },
+        } satisfies BrowserLog));
+      },
+    },
+
+    // ─── Recordings ────────────────────────────────────────────────────
+    recording: {
+      get: async (config, sessionId) => {
+        const client = createClient(config);
+        try {
+          const [urlResponse, data] = await Promise.all([
+            client.sessions.getRecordingURL(sessionId).catch(() => null),
+            client.sessions.getRecording(sessionId).catch(() => null),
+          ]);
+          if (!urlResponse?.recordingUrl && !data) return null;
+          return {
+            recordingId: sessionId,
+            sessionId,
+            format: 'rrweb',
+            url: urlResponse?.recordingUrl ?? undefined,
+            data: data ?? undefined,
+          } satisfies BrowserRecording;
+        } catch {
+          return null;
+        }
+      },
+    },
+  },
+});

--- a/packages/hyperbrowser/src/index.ts
+++ b/packages/hyperbrowser/src/index.ts
@@ -211,12 +211,12 @@ export const hyperbrowser = defineBrowserProvider<HyperbrowserSession, Hyperbrow
       list: async (config) => {
         const client = createClient(config);
         const response = await client.sessions.list();
-        // The list response returns a lean Session shape without wsEndpoint;
-        // callers needing the connect URL should use getConnectUrl(sessionId).
+        // Hyperbrowser's list endpoint returns a lean Session shape without
+        // wsEndpoint. We omit connectUrl on list entries — callers that need
+        // a connectable URL should use provider.getConnectUrl(sessionId).
         return response.sessions.map((s) => ({
           session: s as HyperbrowserSession,
           sessionId: s.id,
-          connectUrl: '',
           status: mapStatus(s.status),
         }));
       },

--- a/packages/hyperbrowser/tsconfig.json
+++ b/packages/hyperbrowser/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/hyperbrowser/tsup.config.ts
+++ b/packages/hyperbrowser/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/hyperbrowser/vitest.config.ts
+++ b/packages/hyperbrowser/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: [path.resolve(__dirname, './vitest.setup.ts')],
+  },
+});

--- a/packages/hyperbrowser/vitest.setup.ts
+++ b/packages/hyperbrowser/vitest.setup.ts
@@ -1,0 +1,5 @@
+import { config } from 'dotenv';
+import path from 'node:path';
+
+// Load the repo-root .env so HYPERBROWSER_API_KEY is available during tests.
+config({ path: path.resolve(__dirname, '../../.env') });

--- a/packages/provider/src/browser-factory.ts
+++ b/packages/provider/src/browser-factory.ts
@@ -38,7 +38,12 @@ import type {
 export interface BrowserSessionMethods<TSession = any, TConfig = any> {
   create: (config: TConfig, options?: CreateBrowserSessionOptions) => Promise<{ session: TSession; sessionId: string; connectUrl: string; status?: BrowserSession['status'] }>;
   getById: (config: TConfig, sessionId: string) => Promise<{ session: TSession; sessionId: string; connectUrl: string; status?: BrowserSession['status'] } | null>;
-  list: (config: TConfig) => Promise<Array<{ session: TSession; sessionId: string; connectUrl: string; status?: BrowserSession['status'] }>>;
+  /**
+   * List sessions. `connectUrl` may be omitted on entries when the provider's
+   * list endpoint doesn't include it — callers needing a connectable URL
+   * should use `provider.getConnectUrl(sessionId)`.
+   */
+  list: (config: TConfig) => Promise<Array<{ session: TSession; sessionId: string; connectUrl?: string; status?: BrowserSession['status'] }>>;
   destroy: (config: TConfig, sessionId: string) => Promise<void>;
   getConnectUrl: (config: TConfig, sessionId: string) => Promise<string>;
 }
@@ -122,7 +127,7 @@ export interface BrowserProviderConfig<TSession = any, TConfig = any> {
  */
 class GeneratedBrowserSession<TSession = any> implements ProviderBrowserSession<TSession> {
   readonly sessionId: string;
-  readonly connectUrl: string;
+  readonly connectUrl?: string;
   readonly status: BrowserSession['status'];
   readonly createdAt?: Date;
   readonly metadata?: Record<string, unknown>;
@@ -130,7 +135,7 @@ class GeneratedBrowserSession<TSession = any> implements ProviderBrowserSession<
   constructor(
     private session: TSession,
     sessionId: string,
-    connectUrl: string,
+    connectUrl: string | undefined,
     status: BrowserSession['status'] | undefined,
     private providerInstance: BrowserProvider<TSession>,
     private config: any,

--- a/packages/provider/src/types/browser.ts
+++ b/packages/provider/src/types/browser.ts
@@ -14,8 +14,15 @@
 export interface BrowserSession {
   /** Unique session identifier */
   sessionId: string;
-  /** CDP or WebSocket connection URL */
-  connectUrl: string;
+  /**
+   * CDP or WebSocket connection URL.
+   *
+   * Always set for sessions returned by `create()` and `getById()`. May be
+   * absent for entries returned by `list()` when the underlying provider's
+   * list endpoint omits the connect URL — in that case, call
+   * `provider.getConnectUrl(sessionId)` to obtain a connectable URL.
+   */
+  connectUrl?: string;
   /** Current session status */
   status: 'created' | 'running' | 'completed' | 'failed' | 'timed_out';
   /** Session creation timestamp */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,7 +624,7 @@ importers:
         version: link:../provider
       '@daytonaio/sdk':
         specifier: ^0.143.0
-        version: 0.143.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 0.143.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -911,6 +911,49 @@ importers:
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
+  packages/hyperbrowser:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@hyperbrowser/sdk':
+        specifier: ^0.89.0
+        version: 0.89.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
+      playwright-core:
+        specifier: ^1.40.0
+        version: 1.58.2
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -1469,7 +1512,7 @@ importers:
         version: link:../provider
       '@upstash/box':
         specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        version: 0.1.28(zod@4.3.6)
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -3074,6 +3117,9 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@hyperbrowser/sdk@0.89.5':
+    resolution: {integrity: sha512-QCHPnitTWELcX2UpBHlaodf9P3IEw2LCMgAZoeUTw2e+HFYR4+PTe+uiVK1SjXzYvL7bu3ji//9e4vNamhoy1g==}
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -7873,6 +7919,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   x256@0.0.2:
     resolution: {integrity: sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==}
     engines: {node: '>=0.4.0'}
@@ -7976,6 +8034,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -9888,7 +9949,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@daytonaio/sdk@0.143.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@daytonaio/sdk@0.143.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -9909,7 +9970,7 @@ snapshots:
       expand-tilde: 2.0.2
       fast-glob: 3.3.3
       form-data: 4.0.4
-      isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 5.0.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       pathe: 2.0.3
       shell-quote: 1.8.3
       tar: 7.5.9
@@ -10357,6 +10418,18 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@hyperbrowser/sdk@0.89.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      form-data: 4.0.5
+      node-fetch: 2.7.0
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
 
   '@iarna/toml@2.2.5': {}
 
@@ -12086,7 +12159,7 @@ snapshots:
 
   '@types/dotenv@8.2.3':
     dependencies:
-      dotenv: 17.2.1
+      dotenv: 16.6.1
 
   '@types/estree@1.0.8': {}
 
@@ -12234,10 +12307,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@upstash/box@0.1.28(zod@3.25.76)':
+  '@upstash/box@0.1.28(zod@4.3.6)':
     dependencies:
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
 
   '@vercel/oidc@3.2.0': {}
 
@@ -14086,9 +14159,9 @@ snapshots:
 
   isomorphic-timers-promises@1.0.1: {}
 
-  isomorphic-ws@5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@5.0.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -16108,6 +16181,11 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
 
+  ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
   x256@0.0.2: {}
 
   xdg-app-paths@5.1.0:
@@ -16192,8 +16270,14 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
   zod@3.22.3: {}
 
   zod@3.24.4: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

Adds a new browser provider package, `@computesdk/hyperbrowser`, wrapping `@hyperbrowser/sdk` with the same `defineBrowserProvider` factory pattern used by `@computesdk/browserbase`. Gives users a `wsEndpoint`-based connect URL for Playwright/Puppeteer, plus profile, extension, log, and recording management.

## What's included

- **Session lifecycle** — `create / getById / list / destroy / getConnectUrl` against `client.sessions.*`. Maps Hyperbrowser's `active/closed/error` statuses onto our standard `running/completed/failed`.
- **Session option mapping** — `stealth → useStealth`, `proxies (true | ProxyConfig[]) → useProxy / proxyServer / proxyCountry/State/City` (Hyperbrowser only supports a single proxy per session, so the first `ProxyConfig` wins), `viewport → screen`, `recording → enableWebRecording`, `logging → enableLogCapture`, `profileId → profile.{id, persistChanges}`, `region → region`, `timeout (sec) → timeoutMinutes`. `keepAlive` and `userMetadata` have no native equivalent and are ignored.
- **Profiles** — full CRUD via `client.profiles.*`.
- **Extensions** — `create` materializes `Uint8Array`/`string` payloads to a tmp file (the SDK only accepts `filePath`); `get` filters `client.extensions.list()` since there's no get-by-id endpoint; `delete` throws with a clear message because Hyperbrowser exposes no delete endpoint.
- **Logs** — `client.sessions.eventLogs.list`, mapping `captcha_error` to `error` level and others to `info`.
- **Recordings** — combines `getRecordingURL` + `getRecording` into a single `BrowserRecording` (`format: 'rrweb'`).

## Tests

Reuses the shared `runBrowserProviderTestSuite` from `@computesdk/test-utils` — same 7-case suite that runs against browserbase. Auto-skips integration when `HYPERBROWSER_API_KEY` is unset, and a `vitest.setup.ts` loads the repo-root `.env` so the key gets picked up automatically.

Verified locally: 6/7 pass against the live API. The `should destroy a session` case attempts to spin up a second concurrent session; on the 1-session Hyperbrowser tier it 429s — quota limit, not a provider bug.

## Files

- `packages/hyperbrowser/{package.json, tsconfig.json, tsup.config.ts, vitest.config.ts, vitest.setup.ts}`
- `packages/hyperbrowser/src/index.ts` — provider implementation
- `packages/hyperbrowser/src/__tests__/index.test.ts` — wires up the shared suite
- `packages/hyperbrowser/example-hyperbrowser.ts` — Hacker News top-story example