### PR TITLE
Add steel to sdk

### DIFF
--- a/packages/steel/example-steel.ts
+++ b/packages/steel/example-steel.ts
@@ -1,0 +1,33 @@
+import { chromium } from 'playwright-core';
+import { steel } from './src/index';
+import 'dotenv/config';
+
+async function main() {
+  const st = steel({ apiKey: process.env.STEEL_API_KEY });
+
+  // Create a new session
+  const session = await st.session.create();
+
+  // Connect to the session
+  const browser = await chromium.connectOverCDP(session.connectUrl!);
+
+  const defaultContext = browser.contexts()[0]!;
+  const page = defaultContext.pages()[0]!;
+
+  await page.goto('https://news.ycombinator.com/');
+  const topStory = await page.evaluate(() => {
+    const titleElement = document.querySelector('.titleline > a');
+    return titleElement ? titleElement.textContent : null;
+  });
+  console.log('Top story:', topStory);
+
+  await page.close();
+  await browser.close();
+
+  // Release the session
+  await session.destroy();
+
+  console.log(`Session complete: ${session.sessionId}`);
+}
+
+main().catch(console.error);

--- a/packages/steel/package.json
+++ b/packages/steel/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@computesdk/steel",
+  "version": "0.1.0",
+  "description": "Steel browser provider for ComputeSDK - cloud browser sessions with stealth mode, proxies, profiles, and session recording",
+  "author": "Garrison",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*",
+    "dotenv": "^16.0.0",
+    "playwright-core": "^1.40.0",
+    "steel-sdk": "^0.18.0"
+  },
+  "keywords": [
+    "computesdk",
+    "steel",
+    "browser",
+    "headless",
+    "playwright",
+    "puppeteer",
+    "stealth",
+    "proxy",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/steel"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/steel/src/__tests__/index.test.ts
+++ b/packages/steel/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { runBrowserProviderTestSuite } from '@computesdk/test-utils';
+import { steel } from '../index';
+
+runBrowserProviderTestSuite({
+  name: 'steel',
+  provider: steel({}),
+  skipIntegration: !process.env.STEEL_API_KEY,
+});

--- a/packages/steel/src/index.ts
+++ b/packages/steel/src/index.ts
@@ -1,0 +1,328 @@
+/**
+ * Steel Browser Provider - Factory-based Implementation
+ *
+ * Cloud browser sessions with stealth mode, proxies, persistent profiles,
+ * extensions, and session recordings via the Steel platform.
+ */
+
+import Steel, { toFile } from 'steel-sdk';
+import type {
+  Session as SteelSession,
+  SessionCreateParams,
+  Sessionslist,
+} from 'steel-sdk/resources/sessions';
+import { defineBrowserProvider } from '@computesdk/provider';
+
+import type {
+  BrowserSession,
+  CreateBrowserSessionOptions,
+  BrowserExtension,
+  BrowserLog,
+  BrowserRecording,
+  ProxyConfig,
+} from '@computesdk/provider';
+
+/**
+ * Steel-specific configuration options
+ */
+export interface SteelConfig {
+  /** Steel API key — falls back to STEEL_API_KEY env var */
+  apiKey?: string;
+  /** Optional API base URL override (defaults to https://api.steel.dev) */
+  baseUrl?: string;
+}
+
+/**
+ * The native Steel session object returned by their SDK
+ */
+type NativeSteelSession = SteelSession;
+
+/**
+ * Resolve config values from explicit config or environment variables
+ */
+function resolveConfig(config: SteelConfig) {
+  const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.STEEL_API_KEY) || '';
+
+  if (!apiKey) {
+    throw new Error(
+      `Missing Steel API key. Provide 'apiKey' in config or set STEEL_API_KEY environment variable. ` +
+      `Get your API key from https://app.steel.dev/settings/api-keys`
+    );
+  }
+
+  return { apiKey, baseUrl: config.baseUrl };
+}
+
+/**
+ * Create a Steel SDK client from config
+ */
+function createClient(config: SteelConfig): Steel {
+  const { apiKey, baseUrl } = resolveConfig(config);
+  return new Steel({ steelAPIKey: apiKey, baseURL: baseUrl ?? undefined });
+}
+
+/**
+ * Steel's `useProxy` field accepts either a boolean, a geolocation object,
+ * or a custom server. Apply a single ProxyConfig onto the create-session params.
+ * Steel only supports one proxy per session, so when multiple are passed
+ * we honor the first one.
+ */
+function applyProxy(params: SessionCreateParams, proxy: ProxyConfig) {
+  if (proxy.type === 'custom' && proxy.server) {
+    // Steel uses a separate proxyUrl field for custom proxies; this overrides
+    // useProxy and disables Steel-provided proxies in favor of the user's.
+    const url = new URL(proxy.server);
+    if (proxy.username) url.username = encodeURIComponent(proxy.username);
+    if (proxy.password) url.password = encodeURIComponent(proxy.password);
+    params.proxyUrl = url.toString();
+    return;
+  }
+
+  if (proxy.geolocation?.country || proxy.geolocation?.state || proxy.geolocation?.city) {
+    params.useProxy = {
+      geolocation: {
+        country: proxy.geolocation.country as any,
+        ...(proxy.geolocation.state ? { state: proxy.geolocation.state as any } : {}),
+        ...(proxy.geolocation.city ? { city: proxy.geolocation.city as any } : {}),
+      },
+    };
+    return;
+  }
+
+  params.useProxy = true;
+}
+
+/**
+ * Map ComputeSDK session options to Steel create-session params
+ */
+function mapSessionOptions(options?: CreateBrowserSessionOptions): SessionCreateParams {
+  if (!options) return {};
+
+  const params: SessionCreateParams = {};
+
+  if (options.viewport) params.dimensions = { width: options.viewport.width, height: options.viewport.height };
+  if (options.extensionIds && options.extensionIds.length > 0) params.extensionIds = options.extensionIds;
+  if (options.region) params.region = options.region as SessionCreateParams['region'];
+  // Steel session timeout is in milliseconds (default 5 minutes)
+  if (options.timeout !== undefined) params.timeout = options.timeout * 1000;
+  if (options.profileId) {
+    params.profileId = options.profileId;
+    params.persistProfile = true;
+  }
+
+  // Stealth wraps a few related flags. We toggle humanizeInteractions as the
+  // most user-visible knob; advanced users can override via options pass-through.
+  if (options.stealth) {
+    params.stealthConfig = { humanizeInteractions: true };
+  }
+
+  if (options.proxies === true) {
+    params.useProxy = true;
+  } else if (Array.isArray(options.proxies) && options.proxies.length > 0) {
+    applyProxy(params, options.proxies[0]!);
+  }
+
+  return params;
+}
+
+/**
+ * Map Steel's session status onto our standard set
+ */
+function mapStatus(status: string | undefined): BrowserSession['status'] {
+  switch (status) {
+    case 'live': return 'running';
+    case 'released': return 'completed';
+    case 'failed': return 'failed';
+    default: return 'created';
+  }
+}
+
+/**
+ * Append the apiKey (and sessionId if missing) to Steel's websocketUrl so
+ * callers can pass it directly to playwright/puppeteer. Steel returns
+ * `wss://connect.steel.dev?sessionId=...` and requires `apiKey` to be
+ * appended for authentication.
+ *
+ * SECURITY: the returned URL embeds the account-wide Steel API key as a
+ * query parameter. Treat it as a secret — do not log it, persist it, or
+ * forward it to systems that retain URLs (access logs, error trackers,
+ * tracing). Anyone with this URL has full access to the Steel account, not
+ * just this session.
+ */
+function buildConnectUrl(websocketUrl: string, apiKey: string, sessionId: string): string {
+  const hasQuery = websocketUrl.includes('?');
+  const sep = hasQuery ? '&' : '?';
+  let url = websocketUrl;
+  if (!websocketUrl.includes('apiKey=')) {
+    url = `${url}${sep}apiKey=${encodeURIComponent(apiKey)}`;
+  }
+  if (!url.includes('sessionId=')) {
+    url = `${url}&sessionId=${encodeURIComponent(sessionId)}`;
+  }
+  return url;
+}
+
+/**
+ * Create a Steel browser provider instance
+ *
+ * SECURITY NOTE: Steel's CDP endpoint authenticates via an `apiKey` query
+ * parameter on the WebSocket URL. As a result, every `connectUrl` returned
+ * by this provider (from `session.create()` and `session.getById()`, and
+ * `provider.getConnectUrl()`) embeds the account-wide Steel API key. Treat
+ * `connectUrl` as a secret: do not log, persist, or forward it to systems
+ * that retain URLs. `session.list()` deliberately omits `connectUrl` to
+ * avoid amplifying this leak surface — call `provider.getConnectUrl(id)` on
+ * demand instead.
+ *
+ * @example
+ * ```ts
+ * import { steel } from '@computesdk/steel';
+ * import { chromium } from 'playwright-core';
+ *
+ * const st = steel({ apiKey: process.env.STEEL_API_KEY });
+ *
+ * // Create a stealth browser session
+ * const session = await st.session.create({ stealth: true, proxies: true });
+ *
+ * // Connect with Playwright (do not log session.connectUrl — it contains the API key)
+ * const browser = await chromium.connectOverCDP(session.connectUrl);
+ * const page = browser.contexts()[0].pages()[0];
+ * await page.goto('https://example.com');
+ *
+ * // Release the session
+ * await session.destroy();
+ * ```
+ */
+export const steel = defineBrowserProvider<NativeSteelSession, SteelConfig>({
+  name: 'steel',
+  methods: {
+    // ─── Session Lifecycle ─────────────────────────────────────────────
+    session: {
+      create: async (config, options) => {
+        const { apiKey } = resolveConfig(config);
+        const client = createClient(config);
+        const session = await client.sessions.create(mapSessionOptions(options));
+        return {
+          session,
+          sessionId: session.id,
+          connectUrl: buildConnectUrl(session.websocketUrl, apiKey, session.id),
+          status: mapStatus(session.status),
+        };
+      },
+
+      getById: async (config, sessionId) => {
+        const { apiKey } = resolveConfig(config);
+        const client = createClient(config);
+        try {
+          const session = await client.sessions.retrieve(sessionId);
+          return {
+            session,
+            sessionId: session.id,
+            connectUrl: buildConnectUrl(session.websocketUrl, apiKey, session.id),
+            status: mapStatus(session.status),
+          };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const client = createClient(config);
+        const page = await client.sessions.list();
+        const sessions = (page as unknown as { sessions: Sessionslist['sessions'] }).sessions ?? [];
+        // We deliberately omit connectUrl from list entries: the URL would
+        // need to embed the account-wide Steel API key, and emitting it once
+        // per session inflates the leak surface (logs, traces, etc.). Callers
+        // that need a connectable URL should use getConnectUrl(sessionId).
+        return sessions.map((s) => ({
+          session: s as NativeSteelSession,
+          sessionId: s.id,
+          status: mapStatus(s.status),
+        }));
+      },
+
+      destroy: async (config, sessionId) => {
+        const client = createClient(config);
+        await client.sessions.release(sessionId);
+      },
+
+      getConnectUrl: async (config, sessionId) => {
+        const { apiKey } = resolveConfig(config);
+        const client = createClient(config);
+        const session = await client.sessions.retrieve(sessionId);
+        return buildConnectUrl(session.websocketUrl, apiKey, session.id);
+      },
+    },
+
+    // ─── Extensions ────────────────────────────────────────────────────
+    extension: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const buf = typeof options.file === 'string'
+          ? Buffer.from(options.file)
+          : Buffer.from(options.file);
+        const file = await toFile(buf, options.name ?? 'extension.zip');
+        const result = await client.extensions.upload({ file });
+        return {
+          extensionId: result.id,
+          name: result.name,
+        } satisfies BrowserExtension;
+      },
+
+      get: async (config, extensionId) => {
+        const client = createClient(config);
+        // Steel exposes only a list endpoint for extension lookup — filter the result.
+        const response = await client.extensions.list();
+        const found = response.extensions.find((e) => e.id === extensionId);
+        if (!found) return null;
+        return { extensionId: found.id, name: found.name } satisfies BrowserExtension;
+      },
+
+      delete: async (config, extensionId) => {
+        const client = createClient(config);
+        await client.extensions.delete(extensionId);
+      },
+    },
+
+    // ─── Logs (RRWeb session events) ───────────────────────────────────
+    // Steel doesn't expose a console-log endpoint — the closest equivalent
+    // is the RRWeb event stream from `sessions.events`. We surface those as
+    // log entries so callers have a uniform shape.
+    logs: {
+      list: async (config, sessionId) => {
+        const client = createClient(config);
+        const events = await client.sessions.events(sessionId);
+        return (events as Array<Record<string, unknown>>).map((event) => {
+          const ts = typeof event.timestamp === 'number' ? event.timestamp : Date.now();
+          return {
+            timestamp: new Date(ts),
+            level: 'info' as BrowserLog['level'],
+            message: typeof event.type === 'string' || typeof event.type === 'number'
+              ? `event:${String(event.type)}`
+              : 'event',
+            data: event,
+          } satisfies BrowserLog;
+        });
+      },
+    },
+
+    // ─── Recordings ────────────────────────────────────────────────────
+    recording: {
+      get: async (config, sessionId) => {
+        const client = createClient(config);
+        try {
+          const events = await client.sessions.events(sessionId);
+          if (!events || (Array.isArray(events) && events.length === 0)) return null;
+          return {
+            recordingId: sessionId,
+            sessionId,
+            format: 'rrweb',
+            data: events,
+          } satisfies BrowserRecording;
+        } catch {
+          return null;
+        }
+      },
+    },
+  },
+});

--- a/packages/steel/src/index.ts
+++ b/packages/steel/src/index.ts
@@ -72,8 +72,8 @@ function applyProxy(params: SessionCreateParams, proxy: ProxyConfig) {
     // Steel uses a separate proxyUrl field for custom proxies; this overrides
     // useProxy and disables Steel-provided proxies in favor of the user's.
     const url = new URL(proxy.server);
-    if (proxy.username) url.username = encodeURIComponent(proxy.username);
-    if (proxy.password) url.password = encodeURIComponent(proxy.password);
+    if (proxy.username) url.username = proxy.username;
+    if (proxy.password) url.password = proxy.password;
     params.proxyUrl = url.toString();
     return;
   }
@@ -92,11 +92,43 @@ function applyProxy(params: SessionCreateParams, proxy: ProxyConfig) {
   params.useProxy = true;
 }
 
+const warnedUnsupported = new Set<string>();
+function warnOnce(field: string, reason: string) {
+  if (warnedUnsupported.has(field)) return;
+  warnedUnsupported.add(field);
+  console.warn(`[@computesdk/steel] '${field}' is ignored: ${reason}`);
+}
+
 /**
- * Map ComputeSDK session options to Steel create-session params
+ * Map ComputeSDK session options to Steel create-session params.
+ *
+ * The following CreateBrowserSessionOptions fields are intentionally not
+ * forwarded because Steel's API has no equivalent knob:
+ * - `recording`: Steel always records sessions; fetch via the recording manager.
+ * - `logging`:   Steel always captures console logs; fetch via the logs manager.
+ * - `keepAlive`: Steel sessions run until `timeout` elapses or are released
+ *                explicitly; there is no separate keep-alive flag. Use a long
+ *                `timeout` to approximate the behavior.
+ * - `userMetadata`: Steel does not support arbitrary user metadata on sessions.
+ *
+ * If a caller passes a non-default value for any of these, we warn once per
+ * field so the silent drop is at least visible in logs.
  */
 function mapSessionOptions(options?: CreateBrowserSessionOptions): SessionCreateParams {
   if (!options) return {};
+
+  if (options.keepAlive === true) {
+    warnOnce('keepAlive', 'Steel has no keep-alive flag; use a long `timeout` instead.');
+  }
+  if (options.recording === false) {
+    warnOnce('recording', 'Steel always records sessions and cannot be disabled per session.');
+  }
+  if (options.logging === false) {
+    warnOnce('logging', 'Steel always captures console logs and cannot be disabled per session.');
+  }
+  if (options.userMetadata && Object.keys(options.userMetadata).length > 0) {
+    warnOnce('userMetadata', 'Steel does not support user metadata on sessions.');
+  }
 
   const params: SessionCreateParams = {};
 
@@ -150,16 +182,10 @@ function mapStatus(status: string | undefined): BrowserSession['status'] {
  * just this session.
  */
 function buildConnectUrl(websocketUrl: string, apiKey: string, sessionId: string): string {
-  const hasQuery = websocketUrl.includes('?');
-  const sep = hasQuery ? '&' : '?';
-  let url = websocketUrl;
-  if (!websocketUrl.includes('apiKey=')) {
-    url = `${url}${sep}apiKey=${encodeURIComponent(apiKey)}`;
-  }
-  if (!url.includes('sessionId=')) {
-    url = `${url}&sessionId=${encodeURIComponent(sessionId)}`;
-  }
-  return url;
+  const url = new URL(websocketUrl);
+  if (!url.searchParams.has('apiKey')) url.searchParams.set('apiKey', apiKey);
+  if (!url.searchParams.has('sessionId')) url.searchParams.set('sessionId', sessionId);
+  return url.toString();
 }
 
 /**
@@ -259,7 +285,7 @@ export const steel = defineBrowserProvider<NativeSteelSession, SteelConfig>({
       create: async (config, options) => {
         const client = createClient(config);
         const buf = typeof options.file === 'string'
-          ? Buffer.from(options.file)
+          ? Buffer.from(options.file, 'utf-8')
           : Buffer.from(options.file);
         const file = await toFile(buf, options.name ?? 'extension.zip');
         const result = await client.extensions.upload({ file });

--- a/packages/steel/tsconfig.json
+++ b/packages/steel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/steel/tsup.config.ts
+++ b/packages/steel/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/steel/vitest.config.ts
+++ b/packages/steel/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: [path.resolve(__dirname, './vitest.setup.ts')],
+  },
+});

--- a/packages/steel/vitest.setup.ts
+++ b/packages/steel/vitest.setup.ts
@@ -1,0 +1,5 @@
+import { config } from 'dotenv';
+import path from 'node:path';
+
+// Load the repo-root .env so STEEL_API_KEY is available during tests.
+config({ path: path.resolve(__dirname, '../../.env') });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,49 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/steel:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
+      playwright-core:
+        specifier: ^1.40.0
+        version: 1.58.2
+      steel-sdk:
+        specifier: ^0.18.0
+        version: 0.18.0
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/test-utils:
     dependencies:
       dotenv:
@@ -7317,6 +7360,9 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
+
+  steel-sdk@0.18.0:
+    resolution: {integrity: sha512-OdW4OIakOooeqgLdn+BRf3yyfeFx4HJ713/7pSa3g82t8NmlURs9xPg4oBLWUttRzaY6oMGNTQtq0DEYg2nOJA==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -14045,7 +14091,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -14234,7 +14280,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -15552,6 +15598,18 @@ snapshots:
   std-env@3.9.0: {}
 
   stdin-discarder@0.2.2: {}
+
+  steel-sdk@0.18.0:
+    dependencies:
+      '@types/node': 18.19.123
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   stoppable@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- New `@computesdk/steel` browser provider, backed by `steel-sdk@^0.18.0`
- Built on `defineBrowserProvider` and modeled on the existing Hyperbrowser package
- Maps the standard ComputeSDK browser surface (sessions, extensions, logs, recordings) onto Steel's API

## What's included
- **Sessions** — `create` / `getById` / `list` / `destroy` (Steel's `release`) / `getConnectUrl`. Supports stealth, custom + geo-targeted proxies, viewport, region, timeout, and `profileId` (auto-sets `persistProfile: true`).
- **Extensions** — upload / list-based `get` / delete via Steel's extensions API.
- **Logs & recording** — Steel has no console-log endpoint; we surface the rrweb event stream from `sessions.events` as `BrowserLog` entries, and as a `'rrweb'`-format `BrowserRecording`.
- **Status mapping**: `live → running`, `released → completed`, `failed → failed`.
- **Timeout** translated from seconds (ComputeSDK) → milliseconds (Steel).

## Notable design decisions
- **No profile manager.** Steel's `profiles.create` requires uploading a `userDataDir` and there's no delete endpoint, so it doesn't fit `BrowserProfileManager`'s simple `create()`/`delete()` shape. Users can still pass `profileId` to `session.create()`.
- **Security: `connectUrl` contains the account-wide Steel API key.** Steel authenticates the CDP WebSocket via an `apiKey` query parameter, so the URL we hand back is a secret in disguise. To limit the leak surface:
  - `session.list()` deliberately omits `connectUrl` — callers use `getConnectUrl(sessionId)` on demand.
  - Factory + helper JSDoc warns not to log/persist/forward the URL.
