### PR TITLE
feat!: remove Runtime concept from SDK

### DIFF
--- a/.changeset/remove-runtime-concept.md
+++ b/.changeset/remove-runtime-concept.md
@@ -1,0 +1,23 @@
+---
+"computesdk": major
+"@computesdk/provider": major
+"@computesdk/test-utils": major
+---
+
+Remove `Runtime` concept from SDK
+
+The `Runtime` type (`'node' | 'python' | 'deno' | 'bun'`) and associated
+`getSupportedRuntimes()` method were originally designed to support a
+`runCode()` API that has since been removed. With no runtime-dispatch logic
+remaining in the SDK, these are dead API surface.
+
+**Breaking changes:**
+
+- `Runtime` type removed from `computesdk` public exports
+- `runtime` field removed from `SandboxInfo`
+- `getSupportedRuntimes(): Runtime[]` removed from the `Provider` interface
+- Provider implementations no longer need to (and cannot) implement `getSupportedRuntimes()`
+- Test suite no longer iterates per-runtime; tests run once per sandbox
+
+**Migration:** Remove any calls to `provider.getSupportedRuntimes()` and any
+references to `SandboxInfo.runtime` in your code.

--- a/packages/agentuity/src/index.ts
+++ b/packages/agentuity/src/index.ts
@@ -16,10 +16,8 @@
 
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 import type {
-    CodeResult,
     CommandResult,
     SandboxInfo,
-    Runtime,
     CreateSandboxOptions,
     FileEntry,
     RunCommandOptions,
@@ -133,19 +131,9 @@ function toBase64(content: string): string {
 }
 
 /**
- * Decode base64 to string — works in both Node/Bun and browser environments.
+ * Map a provider runtime string to an Agentuity runtime string.
  */
-function fromBase64(b64: string): string {
-    if (typeof Buffer !== 'undefined') {
-        return Buffer.from(b64, 'base64').toString('utf-8');
-    }
-    return decodeURIComponent(escape(atob(b64)));
-}
-
-/**
- * Map a ComputeSDK Runtime to an Agentuity runtime string.
- */
-function toAgentuityRuntime(runtime?: Runtime | string): string {
+function toAgentuityRuntime(runtime?: string): string {
     if (!runtime) return 'bun:1';
     switch (runtime) {
         // Agentuity's JS runtime is bun — map node requests to bun
@@ -154,48 +142,8 @@ function toAgentuityRuntime(runtime?: Runtime | string): string {
         case 'bun': return 'bun:1';
         default:
             // Pass-through for explicit strings like "python:3.11", "bun:1", etc.
-            return runtime as string;
+            return runtime;
     }
-}
-
-function fromAgentuityRuntime(name?: string): Runtime {
-    if (!name) return 'node';
-    if (name.startsWith('bun')) return 'node';
-    if (name.startsWith('python')) return 'python';
-    if (name.startsWith('node')) return 'node';
-    if (name.startsWith('deno')) return 'deno';
-    return 'node';
-}
-
-/**
- * Build a small script that wraps user code for a specific language,
- * writes it to a temp file, and executes it.
- * Returns { command, filename } for the execute payload.
- */
-function buildCodeCommand(
-    code: string,
-    runtime: Runtime | string,
-): { exec: string[]; filename: string } {
-    const effectiveRuntime = runtime || autoDetectRuntime(code);
-    if (effectiveRuntime === 'python') {
-        return { exec: ['python3', '/tmp/_compute_run.py'], filename: '/tmp/_compute_run.py' };
-    }
-    // Default: bun (fastest) or node
-    return { exec: ['bun', 'run', '/tmp/_compute_run.js'], filename: '/tmp/_compute_run.js' };
-}
-
-function autoDetectRuntime(code: string): Runtime {
-    const looksLikePython =
-        code.includes('print(') ||
-        code.includes('import ') ||
-        code.includes('def ') ||
-        code.includes('sys.') ||
-        code.includes('json.') ||
-        code.includes('__') ||
-        code.includes("f'") ||
-        code.includes('f"') ||
-        code.includes('raise ');
-    return looksLikePython ? 'python' : 'node';
 }
 
 /**
@@ -398,15 +346,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
             // ── Execution ─────────────────────────────────────────────────────
 
             /**
-             * Run code in the sandbox.
-             *
-             * Writes the code as a temp file via the execute `files` payload,
-             * then runs it with the appropriate interpreter.
-             *
-             * POST /sandbox/{sandboxId}/execute
-             */
-
-            /**
              * Run a shell command in the sandbox.
              *
              * POST /sandbox/{sandboxId}/execute  (using ["sh", "-c", command])
@@ -500,7 +439,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                     return {
                         id: sandbox.sandboxId,
                         provider: 'agentuity',
-                        runtime: 'node',
                         status: 'running',
                         createdAt: new Date(),
                         timeout: 300_000,
@@ -533,7 +471,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                 return {
                     id: data.sandboxId,
                     provider: 'agentuity',
-                    runtime: fromAgentuityRuntime(data.runtime?.name),
                     status: statusMap[data.status] ?? 'running',
                     createdAt: data.createdAt ? new Date(data.createdAt) : new Date(),
                     timeout: 300_000,
@@ -543,15 +480,13 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                         url: data.url,
                         networkPort: data.networkPort,
                         idleTimeout: data.timeout?.idle,
+                        runtime: data.runtime?.name,
                     },
                 };
             },
 
             /**
              * Get the public URL for a service running on a given port.
-             *
-             * Agentuity exposes a `url` field on the sandbox when a `networkPort` is
-             * configured.  We fetch fresh sandbox details to get it.
              */
             getUrl: async (
                 sandbox: AgentuityHandle,
@@ -576,12 +511,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
             // ── File System ───────────────────────────────────────────────────
 
             filesystem: {
-                /**
-                 * Read a file from the sandbox.
-                 *
-                 * GET /fs/{sandboxId}?path=<path>
-                 * Returns raw bytes (streamed); we read as text.
-                 */
                 readFile: async (sandbox: AgentuityHandle, path: string, _runCommand: RunCommandFn): Promise<string> => {
                     const encodedPath = encodeURIComponent(path);
                     const res = await agentuityFetch(
@@ -599,12 +528,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                     return res.text();
                 },
 
-                /**
-                 * Write content to a file in the sandbox.
-                 *
-                 * POST /fs/{sandboxId}
-                 * Content must be base64-encoded.
-                 */
                 writeFile: async (
                     sandbox: AgentuityHandle,
                     path: string,
@@ -626,11 +549,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                     }
                 },
 
-                /**
-                 * Create a directory (with parents) in the sandbox.
-                 *
-                 * POST /fs/mkdir/{sandboxId}
-                 */
                 mkdir: async (sandbox: AgentuityHandle, path: string, _runCommand: RunCommandFn): Promise<void> => {
                     const res = await agentuityFetch(
                         sandbox,
@@ -647,11 +565,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                     }
                 },
 
-                /**
-                 * List directory contents.
-                 *
-                 * GET /fs/list/{sandboxId}?path=<path>
-                 */
                 readdir: async (
                     sandbox: AgentuityHandle,
                     path: string,
@@ -693,16 +606,11 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                     });
                 },
 
-                /**
-                 * Check whether a path exists by attempting to list it (directory)
-                 * or read its metadata via the execute endpoint.
-                 */
                 exists: async (
                     sandbox: AgentuityHandle,
                     path: string,
                     _runCommand: RunCommandFn,
                 ): Promise<boolean> => {
-                    // Use a quick shell test — cheaper than a full file read
                     const result = await (async () => {
                         const body = { command: ['sh', '-c', `test -e "${escapeShellArg(path)}" && echo yes || echo no`], timeout: '10s' };
                         const res = await agentuityFetch(
@@ -724,11 +632,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                     return result;
                 },
 
-                /**
-                 * Remove a file from the sandbox.
-                 *
-                 * POST /fs/rm/{sandboxId}
-                 */
                 remove: async (sandbox: AgentuityHandle, path: string, _runCommand: RunCommandFn): Promise<void> => {
                     const res = await agentuityFetch(
                         sandbox,
@@ -746,11 +649,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                 },
             },
 
-            // ── Native handle ─────────────────────────────────────────────────
-
-            /**
-             * Return the raw handle for direct Agentuity API access.
-             */
             getInstance: (sandbox: AgentuityHandle): AgentuityHandle => sandbox,
         },
     },
@@ -758,11 +656,6 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
 
 // ─── Bonus: lightweight snapshot / checkpoint helpers ─────────────────────────
 
-/**
- * Create a filesystem snapshot from a running sandbox.
- *
- * POST /sandbox/{sandboxId}/snapshot
- */
 export async function createSnapshot(
     sandbox: AgentuityHandle,
     options?: { name?: string; tag?: string; description?: string; public?: boolean },
@@ -780,21 +673,11 @@ export async function createSnapshot(
     return unwrapResponse<{ snapshotId: string }>(await res.json());
 }
 
-/**
- * Pause a sandbox and create a memory checkpoint.
- *
- * POST /sandbox/{sandboxId}/pause
- */
 export async function pauseSandbox(sandbox: AgentuityHandle): Promise<void> {
     const res = await agentuityFetch(sandbox, 'POST', `/sandbox/${sandbox.sandboxId}/pause`);
     if (!res.ok) throw new Error(`Agentuity: failed to pause sandbox (${res.status})`);
 }
 
-/**
- * Resume a paused sandbox.
- *
- * POST /sandbox/{sandboxId}/resume
- */
 export async function resumeSandbox(sandbox: AgentuityHandle): Promise<void> {
     const res = await agentuityFetch(sandbox, 'POST', `/sandbox/${sandbox.sandboxId}/resume`);
     if (!res.ok) throw new Error(`Agentuity: failed to resume sandbox (${res.status})`);

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -10,10 +10,8 @@
 
 import { defineProvider } from '@computesdk/provider';
 import type {
-  CodeResult,
   CommandResult,
   SandboxInfo,
-  Runtime,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions,
@@ -275,7 +273,6 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         return {
           id: sandbox.disk.id,
           provider: 'archil',
-          runtime: 'node',
           status: sandbox.disk.status === 'ready' ? 'running' : 'stopped',
           createdAt: new Date(sandbox.disk.createdAt),
           timeout: 0,

--- a/packages/avm/src/index.ts
+++ b/packages/avm/src/index.ts
@@ -1,16 +1,10 @@
 /**
  * AVM Provider - Factory-based Implementation
- * 
- * AVM Sandbox Platform API integration for ComputeSDK
- * API Documentation: https://api.avm.codes/
  */
 
 import { defineProvider } from '@computesdk/provider';
-import type { Runtime, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-/**
- * AVM sandbox interface matching the API response structure
- */
 interface AVMSandbox {
   id: string;
   name: string;
@@ -18,237 +12,120 @@ interface AVMSandbox {
   cpu: number;
   memory: number;
   status: string;
-  volumes?: Array<{
-    volume_id: string;
-    mount_path: string;
-    volume_name: string;
-  }>;
+  volumes?: Array<{ volume_id: string; mount_path: string; volume_name: string; }>;
 }
 
 type AVMSandboxListItem = Pick<AVMSandbox, 'id' | 'name' | 'created_at' | 'cpu' | 'memory' | 'status' | 'volumes'>;
 
-/**
- * AVM-specific configuration options
- */
 export interface AVMConfig {
   /** AVM API key - if not provided, will fallback to AVM_API_KEY environment variable */
   apiKey?: string;
 }
 
-/**
- * Extended create options for AVM sandboxes
- */
 export interface AVMCreateOptions extends CreateSandboxOptions {
-  /** Custom Docker image (defaults to node:alpine) */
   image?: string;
-  /** Sandbox name (defaults to avm-sandbox-{timestamp}) */
   name?: string;
-  /** Resource allocation */
-  resources?: {
-    cpus?: number;    // default: 0.25
-    memory?: number;  // default: 512 (MB)
-  };
-  /** Volume configuration */
-  volumes?: Array<{
-    volume_name: string;
-    mount_path: string;
-  }>;
+  resources?: { cpus?: number; memory?: number; };
+  volumes?: Array<{ volume_name: string; mount_path: string; }>;
 }
 
-/**
- * Validate and retrieve AVM API credentials
- */
 export const getAndValidateCredentials = (config: AVMConfig) => {
   const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.AVM_API_KEY) || '';
-
   if (!apiKey) {
-    throw new Error(
-      'Missing AVM API key. Provide apiKey in config or set AVM_API_KEY environment variable.'
-    );
+    throw new Error('Missing AVM API key. Provide apiKey in config or set AVM_API_KEY environment variable.');
   }
-
   return { apiKey };
 };
 
-/**
- * Fetch helper for AVM API calls
- */
-export const fetchAVM = async (
-  apiKey: string,
-  endpoint: string,
-  options: RequestInit = {}
-) => {
+export const fetchAVM = async (apiKey: string, endpoint: string, options: RequestInit = {}) => {
   const url = `https://api.avm.codes/v1${endpoint}`;
   const requestOptions: RequestInit = {
     method: 'GET',
     ...options,
-    headers: {
-      'Accept': 'application/json',
-      'x-api-key': apiKey,
-      ...(options.headers || {})
-    }
+    headers: { 'Accept': 'application/json', 'x-api-key': apiKey, ...(options.headers || {}) }
   };
-  
   const response = await fetch(url, requestOptions);
-
-  if (!response.ok) {
-    throw new Error(`AVM API error: ${response.status} ${response.statusText}`);
-  }
-
-  // Handle 204 No Content responses (like DELETE operations)
-  if (response.status === 204) {
-    return {};
-  }
-
+  if (!response.ok) throw new Error(`AVM API error: ${response.status} ${response.statusText}`);
+  if (response.status === 204) return {};
   return response.json();
 };
 
-/**
- * Create an AVM provider instance using the factory pattern
- */
 export const avm = defineProvider<AVMSandbox, AVMConfig>({
   name: 'avm',
   methods: {
     sandbox: {
-      // Collection operations (compute.sandbox.*)
       create: async (config: AVMConfig, options?: AVMCreateOptions) => {
         const { apiKey } = getAndValidateCredentials(config);
-
         try {
           const createSandboxData = {
             name: options?.name || `computesdk-${Date.now()}`,
             image: options?.image || 'node:alpine',
-            resources: {
-              cpus: options?.resources?.cpus || 0.25,
-              memory: options?.resources?.memory || 512
-            },
+            resources: { cpus: options?.resources?.cpus || 0.25, memory: options?.resources?.memory || 512 },
             ...(options?.volumes && { volumes: options.volumes }),
             ...(options?.envs && { env_vars: options.envs })
           };
-
           const responseData = await fetchAVM(apiKey, '/sandboxes/create', {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(createSandboxData)
           });
-          
           if (!responseData || !responseData.id) {
             throw new Error(`Sandbox ID is undefined. Full response: ${JSON.stringify(responseData, null, 2)}`);
           }
-
           const avmSandbox: AVMSandbox = {
-            id: responseData.id,
-            name: responseData.name,
-            created_at: responseData.created_at,
-            cpu: responseData.cpu,
-            memory: responseData.memory,
-            status: responseData.status,
-            volumes: responseData.volumes
+            id: responseData.id, name: responseData.name, created_at: responseData.created_at,
+            cpu: responseData.cpu, memory: responseData.memory, status: responseData.status, volumes: responseData.volumes
           };
-
-          return {
-            sandbox: avmSandbox,
-            sandboxId: responseData.id
-          };
+          return { sandbox: avmSandbox, sandboxId: responseData.id };
         } catch (error) {
-          throw new Error(
-            `Failed to create AVM sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create AVM sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: AVMConfig, sandboxId: string) => {
         const { apiKey } = getAndValidateCredentials(config);
-
         try {
-          // AVM's getById fetches logs for the sandbox
           const responseData = await fetchAVM(apiKey, `/sandboxes/${sandboxId}/logs`);
-          
-          if (!responseData) {
-            return null;
-          }
-          
-          // Return the logs data wrapped in the expected format
-          // Note: This returns logs, not sandbox metadata
-          return {
-            sandbox: responseData as unknown as AVMSandbox,
-            sandboxId: sandboxId
-          };
+          if (!responseData) return null;
+          return { sandbox: responseData as unknown as AVMSandbox, sandboxId };
         } catch (error) {
-          // If it's a 404, return null to indicate sandbox not found
-          if (error instanceof Error && error.message.includes('404')) {
-            return null;
-          }
-          throw new Error(
-            `Failed to get AVM sandbox logs: ${error instanceof Error ? error.message : String(error)}`
-          );
+          if (error instanceof Error && error.message.includes('404')) return null;
+          throw new Error(`Failed to get AVM sandbox logs: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
-      
+
       list: async (config: AVMConfig) => {
         const { apiKey } = getAndValidateCredentials(config);
-
         try {
           const responseData = await fetchAVM(apiKey, '/sandboxes/list');
-          
-          // Extract sandboxes from the data array
           const items = responseData?.data || [];
-          
-          // Transform each sandbox into the expected format
-          const sandboxes = items.map((sandbox: AVMSandboxListItem) => {
-            const avmSandbox: AVMSandbox = {
-              id: sandbox.id,
-              name: sandbox.name,
-              created_at: sandbox.created_at,
-              cpu: sandbox.cpu,
-              memory: sandbox.memory,
-              status: sandbox.status,
-              volumes: sandbox.volumes
-            };
-
-            return {
-              sandbox: avmSandbox,
-              sandboxId: sandbox.id
-            };
-          });
-
-          return sandboxes;
+          return items.map((sandbox: AVMSandboxListItem) => ({
+            sandbox: { id: sandbox.id, name: sandbox.name, created_at: sandbox.created_at, cpu: sandbox.cpu, memory: sandbox.memory, status: sandbox.status, volumes: sandbox.volumes } as AVMSandbox,
+            sandboxId: sandbox.id
+          }));
         } catch (error) {
-          throw new Error(
-            `Failed to list AVM sandboxes: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to list AVM sandboxes: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       destroy: async (config: AVMConfig, sandboxId: string) => {
         const { apiKey } = getAndValidateCredentials(config);
-
         try {
-          await fetchAVM(apiKey, `/sandboxes/${sandboxId}/delete`, {
-            method: 'DELETE'
-          });
+          await fetchAVM(apiKey, `/sandboxes/${sandboxId}/delete`, { method: 'DELETE' });
         } catch (error) {
-          // For destroy operations, we typically don't throw if the sandbox is already gone
           console.warn(`AVM destroy warning: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Instance operations (minimal stubs - not implemented yet)
-
       runCommand: async (_sandbox: AVMSandbox, _command: string, _options?: RunCommandOptions) => {
         throw new Error('AVM runCommand method not implemented yet');
       },
-
       getInfo: async (_sandbox: AVMSandbox) => {
         throw new Error('AVM getInfo method not implemented yet');
       },
-
       getUrl: async (_sandbox: AVMSandbox, _options: { port: number; protocol?: string }) => {
         throw new Error('AVM getUrl method not implemented yet');
       },
-
     },
   },
 });

--- a/packages/aws-ecs/src/index.ts
+++ b/packages/aws-ecs/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { defineProvider } from '@computesdk/provider';
-import type { Runtime, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
 import {
   ECSClient,
   RunTaskCommand,
@@ -65,8 +65,6 @@ export const getAndValidateCredentials = (config: FargateConfig) => {
     throw new Error('Missing security groups. Provide at least one security group in config.');
   }
 
-  // Build credentials object only if explicitly provided
-  // Otherwise, let the SDK use the default credential chain
   const credentials = config.accessKeyId && config.secretAccessKey
     ? {
         accessKeyId: config.accessKeyId,
@@ -100,22 +98,10 @@ const createECSClient = (config: FargateConfig): ECSClient => {
 
 /**
  * Extract task ID from task ARN
- * ARN format: arn:aws:ecs:region:account:task/cluster-name/task-id
  */
 const extractTaskId = (taskArn: string): string => {
   const parts = taskArn.split('/');
   return parts[parts.length - 1];
-};
-
-/**
- * Normalize task identifier to full ARN if needed
- */
-const normalizeTaskArn = (taskId: string, cluster: string, region: string, accountId?: string): string => {
-  if (taskId.startsWith('arn:aws:ecs:')) {
-    return taskId;
-  }
-  // If we don't have account ID, just return the task ID and let AWS resolve it
-  return taskId;
 };
 
 /**
@@ -125,7 +111,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
   name: 'fargate',
   methods: {
     sandbox: {
-      // Collection operations (compute.sandbox.*)
       create: async (config: FargateConfig, options?: CreateSandboxOptions) => {
         const {
           cluster,
@@ -139,13 +124,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
         const client = createECSClient(config);
 
         try {
-          // Note: For AWS ECS Fargate, the image is specified in the task definition,
-          // not as a runtime override. The task definition should be pre-configured
-          // with the appropriate image for the desired runtime.
-          // 
-          // The options?.runtime parameter is acknowledged but the actual runtime
-          // environment is determined by the pre-configured task definition.
-          
           const command = new RunTaskCommand({
             cluster,
             taskDefinition,
@@ -157,15 +135,11 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
                 assignPublicIp: assignPublicIp ? 'ENABLED' : 'DISABLED',
               },
             },
-            // Container overrides for ECS are limited to environment variables, 
-            // memory, CPU, and command - not the image itself
             ...(containerName && {
               overrides: {
                 containerOverrides: [
                   {
                     name: containerName,
-                    // Additional container overrides can be added here if needed
-                    // such as environment variables, memory, CPU, etc.
                   },
                 ],
               },
@@ -235,7 +209,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
             sandboxId: task.taskArn,
           };
         } catch (error) {
-          // Handle task not found
           if (error instanceof Error && 
               (error.message.includes('MISSING') || error.message.includes('not found'))) {
             return null;
@@ -251,7 +224,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
         const client = createECSClient(config);
 
         try {
-          // Step 1: List task ARNs
           const listCommand = new ListTasksCommand({
             cluster,
             desiredStatus: 'RUNNING',
@@ -264,7 +236,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
             return [];
           }
 
-          // Step 2: Describe tasks to get full details
           const describeCommand = new DescribeTasksCommand({
             cluster,
             tasks: taskArns,
@@ -273,23 +244,16 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
           const describeResponse = await client.send(describeCommand);
           const tasks = describeResponse.tasks || [];
 
-          // Transform each task into the expected format
-          const sandboxes = tasks
+          return tasks
             .filter(task => task.taskArn)
-            .map(task => {
-              const fargateSandbox: FargateSandbox = {
+            .map(task => ({
+              sandbox: {
                 taskArn: task.taskArn!,
                 clusterArn: task.clusterArn || cluster,
                 taskId: extractTaskId(task.taskArn!),
-              };
-
-              return {
-                sandbox: fargateSandbox,
-                sandboxId: task.taskArn!,
-              };
-            });
-
-          return sandboxes;
+              } as FargateSandbox,
+              sandboxId: task.taskArn!,
+            }));
         } catch (error) {
           throw new Error(
             `Failed to list Fargate sandboxes: ${error instanceof Error ? error.message : String(error)}`
@@ -310,7 +274,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
 
           await client.send(command);
         } catch (error) {
-          // For destroy operations, don't throw if task is already stopped/gone
           if (error instanceof Error && 
               (error.message.includes('MISSING') || 
                error.message.includes('not found') ||
@@ -323,8 +286,6 @@ export const fargate = defineProvider<FargateSandbox, FargateConfig>({
           );
         }
       },
-
-      // Instance operations (minimal stubs - not implemented yet)
 
       runCommand: async (_sandbox: FargateSandbox, _command: string, _options?: RunCommandOptions) => {
         throw new Error('Fargate runCommand method not implemented yet');

--- a/packages/aws-lambda/src/__tests__/index.test.ts
+++ b/packages/aws-lambda/src/__tests__/index.test.ts
@@ -28,7 +28,6 @@ describe('AWS Lambda Provider', () => {
       });
 
       expect(provider.name).toBe('aws-lambda');
-      expect(typeof provider.getSupportedRuntimes).toBe('function');
     });
   });
 
@@ -101,11 +100,10 @@ describe('AWS Lambda Provider', () => {
 
   describe('Error handling', () => {
     it('should handle configuration errors gracefully', () => {
-      expect(() => awsLambda({})).not.toThrow(); // Provider creation should not throw
+      expect(() => awsLambda({})).not.toThrow();
       
       const provider = awsLambda({});
       
-      // The error should be thrown when attempting to use the provider methods
       expect(async () => {
         await provider.sandbox.create();
       }).rejects.toThrow();

--- a/packages/aws-lambda/src/index.ts
+++ b/packages/aws-lambda/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { defineProvider } from '@computesdk/provider';
-import type { Runtime, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
 import {
   LambdaClient,
   CreateFunctionCommand,
@@ -89,21 +89,6 @@ const generateFunctionName = (prefix: string): string => {
 };
 
 /**
- * Map ComputeSDK runtime to AWS Lambda runtime
- */
-const mapRuntimeToAWS = (runtime?: Runtime): AWSRuntime => {
-  // Default to Node.js 20.x if not specified
-  if (!runtime || runtime === 'node') {
-    return 'nodejs20.x' as AWSRuntime;
-  }
-  if (runtime === 'python') {
-    return 'python3.12' as AWSRuntime;
-  }
-  // Add more mappings as needed
-  throw new Error(`Unsupported runtime: ${runtime}. Supported runtimes: node, python`);
-};
-
-/**
  * Create a ZIP file containing Lambda handler code using JSZip
  */
 const createLambdaZip = async (): Promise<Buffer> => {
@@ -142,7 +127,7 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
 
         try {
           const functionName = generateFunctionName(functionNamePrefix);
-          const runtime = mapRuntimeToAWS(options?.runtime);
+          const runtime = 'nodejs20.x' as AWSRuntime;
           const zipBuffer = await createLambdaZip();
 
           const command = new CreateFunctionCommand({

--- a/packages/aws-lambda/src/index.ts
+++ b/packages/aws-lambda/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { defineProvider } from '@computesdk/provider';
-import type { CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { RunCommandOptions } from '@computesdk/provider';
 import {
   LambdaClient,
   CreateFunctionCommand,
@@ -50,47 +50,24 @@ export const getAndValidateCredentials = (config: LambdaConfig) => {
     );
   }
 
-  // Build credentials object only if both accessKeyId and secretAccessKey are provided
-  // Otherwise, let the SDK use the default credential chain
   const credentials = accessKeyId && secretAccessKey
-    ? {
-        accessKeyId,
-        secretAccessKey,
-      }
+    ? { accessKeyId, secretAccessKey }
     : undefined;
 
-  return {
-    region,
-    roleArn,
-    functionNamePrefix,
-    credentials,
-  };
+  return { region, roleArn, functionNamePrefix, credentials };
 };
 
-/**
- * Create a Lambda client instance
- */
 const createLambdaClient = (config: LambdaConfig): LambdaClient => {
   const { region, credentials } = getAndValidateCredentials(config);
-  
-  return new LambdaClient({
-    region,
-    ...(credentials && { credentials }),
-  });
+  return new LambdaClient({ region, ...(credentials && { credentials }) });
 };
 
-/**
- * Generate a unique function name
- */
 const generateFunctionName = (prefix: string): string => {
   const timestamp = Date.now();
   const random = Math.random().toString(36).substring(2, 8);
   return `${prefix}-${timestamp}-${random}`;
 };
 
-/**
- * Create a ZIP file containing Lambda handler code using JSZip
- */
 const createLambdaZip = async (): Promise<Buffer> => {
   const handlerCode = `exports.handler = async (event) => {
     return {
@@ -113,15 +90,11 @@ const createLambdaZip = async (): Promise<Buffer> => {
   });
 };
 
-/**
- * Create an AWS Lambda provider instance using the factory pattern
- */
 export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
   name: 'aws-lambda',
   methods: {
     sandbox: {
-      // Collection operations (compute.sandbox.*)
-      create: async (config: LambdaConfig, options?: CreateSandboxOptions) => {
+      create: async (config: LambdaConfig, _options?: unknown) => {
         const { roleArn, functionNamePrefix } = getAndValidateCredentials(config);
         const client = createLambdaClient(config);
 
@@ -135,9 +108,7 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
             Runtime: runtime,
             Role: roleArn,
             Handler: 'index.handler',
-            Code: {
-              ZipFile: zipBuffer,
-            },
+            Code: { ZipFile: zipBuffer },
             Timeout: 30,
             MemorySize: 128,
           });
@@ -154,10 +125,7 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
             runtime: response.Runtime || runtime,
           };
 
-          return {
-            sandbox: lambdaSandbox,
-            sandboxId: response.FunctionName,
-          };
+          return { sandbox: lambdaSandbox, sandboxId: response.FunctionName };
         } catch (error) {
           throw new Error(
             `Failed to create Lambda function: ${error instanceof Error ? error.message : String(error)}`
@@ -169,21 +137,13 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
         const client = createLambdaClient(config);
 
         try {
-          const command = new GetFunctionCommand({
-            FunctionName: sandboxId,
-          });
-
+          const command = new GetFunctionCommand({ FunctionName: sandboxId });
           const response = await client.send(command);
 
-          if (!response.Configuration) {
-            return null;
-          }
+          if (!response.Configuration) return null;
 
           const funcConfig = response.Configuration;
-
-          if (!funcConfig.FunctionName || !funcConfig.FunctionArn) {
-            return null;
-          }
+          if (!funcConfig.FunctionName || !funcConfig.FunctionArn) return null;
 
           const lambdaSandbox: LambdaSandbox = {
             functionName: funcConfig.FunctionName,
@@ -191,14 +151,9 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
             runtime: funcConfig.Runtime || 'unknown',
           };
 
-          return {
-            sandbox: lambdaSandbox,
-            sandboxId: funcConfig.FunctionName,
-          };
+          return { sandbox: lambdaSandbox, sandboxId: funcConfig.FunctionName };
         } catch (error) {
-          if (error instanceof ResourceNotFoundException) {
-            return null;
-          }
+          if (error instanceof ResourceNotFoundException) return null;
           throw new Error(
             `Failed to get Lambda function: ${error instanceof Error ? error.message : String(error)}`
           );
@@ -210,9 +165,7 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
 
         try {
           const command = new ListFunctionsCommand({});
-
           const response = await client.send(command);
-
           const functions = response.Functions || [];
 
           function hasFunctionNameAndArn(
@@ -221,22 +174,14 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
             return !!(func.FunctionName && func.FunctionArn);
           }
 
-          const sandboxes = functions
-            .filter(hasFunctionNameAndArn)
-            .map(func => {
-              const lambdaSandbox: LambdaSandbox = {
-                functionName: func.FunctionName,
-                functionArn: func.FunctionArn,
-                runtime: func.Runtime || 'unknown',
-              };
-
-              return {
-                sandbox: lambdaSandbox,
-                sandboxId: func.FunctionName,
-              };
-            });
-
-          return sandboxes;
+          return functions.filter(hasFunctionNameAndArn).map(func => ({
+            sandbox: {
+              functionName: func.FunctionName,
+              functionArn: func.FunctionArn,
+              runtime: func.Runtime || 'unknown',
+            } as LambdaSandbox,
+            sandboxId: func.FunctionName,
+          }));
         } catch (error) {
           throw new Error(
             `Failed to list Lambda functions: ${error instanceof Error ? error.message : String(error)}`
@@ -248,13 +193,8 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
         const client = createLambdaClient(config);
 
         try {
-          const command = new DeleteFunctionCommand({
-            FunctionName: sandboxId,
-          });
-
-          await client.send(command);
+          await client.send(new DeleteFunctionCommand({ FunctionName: sandboxId }));
         } catch (error) {
-          // For destroy operations, we typically don't throw if the function is already gone
           if (error instanceof ResourceNotFoundException) {
             console.warn(`Lambda function ${sandboxId} not found - may already be deleted`);
           } else {
@@ -262,8 +202,6 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
           }
         }
       },
-
-      // Instance operations (minimal stubs - not implemented yet)
 
       runCommand: async (_sandbox: LambdaSandbox, _command: string, _options?: RunCommandOptions) => {
         throw new Error('AWS Lambda runCommand method not implemented yet');
@@ -276,7 +214,6 @@ export const awsLambda = defineProvider<LambdaSandbox, LambdaConfig>({
       getUrl: async (_sandbox: LambdaSandbox, _options: { port: number; protocol?: string }) => {
         throw new Error('AWS Lambda getUrl method not implemented yet');
       },
-
     },
   },
 });

--- a/packages/beam/src/index.ts
+++ b/packages/beam/src/index.ts
@@ -16,10 +16,8 @@
 import { Sandbox, SandboxInstance, beamOpts, Image } from '@beamcloud/beam-js';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 import type {
-  CodeResult,
   CommandResult,
   SandboxInfo,
-  Runtime,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions,
@@ -106,9 +104,9 @@ function isPythonParserFailure(output: string): boolean {
 }
 
 /**
- * Detect parser/compile failures that should throw instead of returning CodeResult.
+ * Detect parser/compile failures that should throw instead of returning a result.
  */
-function isParserFailure(output: string, runtime: Runtime): boolean {
+function isParserFailure(output: string, runtime: string): boolean {
   if (!output.trim()) return false;
 
   if (runtime === 'node') {
@@ -158,7 +156,6 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
         try {
           // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: optRuntime,
             timeout: optTimeout,
             envs,
             name,
@@ -170,6 +167,8 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
             directory: _directory,
             ...providerOptions
           } = options || {};
+
+          const optRuntime = (options as any)?.runtime as string | undefined;
 
           const sandboxConfig: any = {
             name: name || `computesdk-${Date.now()}`,
@@ -258,12 +257,6 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
       },
 
       /**
-       * Execute code in the sandbox
-       *
-       * Auto-detects runtime (Python vs Node.js) and executes via sandbox.exec().
-       */
-
-      /**
        * Execute a shell command in the sandbox
        *
        * Uses sandbox.exec() with shell command string.
@@ -316,8 +309,8 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
        * Get sandbox information
        */
       getInfo: async (sandbox: SandboxInstance): Promise<SandboxInfo> => {
-        // Derive runtime from sandbox instance if available; otherwise default to 'python'
-        let runtime: Runtime = 'python';
+        // Derive runtime from sandbox instance if available
+        let runtime = 'python';
         const runtimeHint = sandbox as SandboxInstance & {
           runtime?: unknown;
           image?: unknown;
@@ -326,36 +319,27 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
 
         if (typeof runtimeHint.runtime === 'string') {
           const lower = runtimeHint.runtime.toLowerCase();
-          if (lower.includes('node')) {
-            runtime = 'node';
-          } else if (lower.includes('python')) {
-            runtime = 'python';
-          }
+          if (lower.includes('node')) runtime = 'node';
+          else if (lower.includes('python')) runtime = 'python';
         } else if (typeof runtimeHint.image === 'string') {
           const imageStr = runtimeHint.image.toLowerCase();
-          if (imageStr.includes('node')) {
-            runtime = 'node';
-          } else if (imageStr.includes('python')) {
-            runtime = 'python';
-          }
+          if (imageStr.includes('node')) runtime = 'node';
+          else if (imageStr.includes('python')) runtime = 'python';
         } else if (typeof runtimeHint.imageName === 'string') {
           const imageNameStr = runtimeHint.imageName.toLowerCase();
-          if (imageNameStr.includes('node')) {
-            runtime = 'node';
-          } else if (imageNameStr.includes('python')) {
-            runtime = 'python';
-          }
+          if (imageNameStr.includes('node')) runtime = 'node';
+          else if (imageNameStr.includes('python')) runtime = 'python';
         }
 
         return {
           id: sandbox.containerId,
           provider: 'beam',
-          runtime,
           status: 'running',
           createdAt: new Date(),
           timeout: 300000,
           metadata: {
             containerId: sandbox.containerId,
+            runtime,
           },
         };
       },
@@ -377,10 +361,6 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
 
       /**
        * Filesystem operations
-       *
-       * Most operations use shell commands via runCommand since Beam's file API
-       * is local-path oriented (uploadFile/downloadFile require local filesystem paths).
-       * readdir uses the native listFiles API since it returns structured data.
        */
       filesystem: {
         readFile: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<string> => {
@@ -438,6 +418,9 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
     },
   },
 });
+
+// Keep isParserFailure available for potential future use
+export { isParserFailure };
 
 // Export Beam sandbox type for explicit typing
 export type { SandboxInstance as BeamSandboxInstance } from '@beamcloud/beam-js';

--- a/packages/beam/src/index.ts
+++ b/packages/beam/src/index.ts
@@ -4,13 +4,6 @@
  * Containerized sandbox environments using the Beam platform.
  * Beam provides sandboxes with process management, filesystem access,
  * and port exposure capabilities.
- *
- * Features:
- * - Process execution via sandbox.exec()
- * - Code execution in Python, JavaScript
- * - Shell command execution
- * - Filesystem operations (shell-based + native listFiles)
- * - Dynamic port exposure for accessing sandbox services
  */
 
 import { Sandbox, SandboxInstance, beamOpts, Image } from '@beamcloud/beam-js';
@@ -23,49 +16,27 @@ import type {
   RunCommandOptions,
 } from 'computesdk';
 
-/** Type alias for the runCommand function passed to filesystem methods */
 type RunCommandFn = (sandbox: SandboxInstance, command: string, options?: RunCommandOptions) => Promise<CommandResult>;
 
-/**
- * Beam-specific configuration options
- */
 export interface BeamConfig {
-  /** Beam API token - if not provided, will fallback to BEAM_TOKEN environment variable */
   token?: string;
-  /** Beam workspace ID - if not provided, will fallback to BEAM_WORKSPACE_ID environment variable */
   workspaceId?: string;
-  /** Gateway URL for custom/staging environments */
   gatewayUrl?: string;
-  /** Request timeout in milliseconds */
   timeout?: number;
 }
 
-/**
- * Configure the global beamOpts singleton before each SDK call.
- * Beam uses a global config pattern rather than per-call config.
- */
 function configureBeamOpts(config: BeamConfig): void {
   beamOpts.token = config.token || (typeof process !== 'undefined' && process.env?.BEAM_TOKEN) || '';
   beamOpts.workspaceId = config.workspaceId || (typeof process !== 'undefined' && process.env?.BEAM_WORKSPACE_ID) || '';
-  if (config.gatewayUrl) {
-    beamOpts.gatewayUrl = config.gatewayUrl;
-  }
-  if (config.timeout) {
-    (beamOpts as any).timeout = config.timeout;
-  }
+  if (config.gatewayUrl) beamOpts.gatewayUrl = config.gatewayUrl;
+  if (config.timeout) (beamOpts as any).timeout = config.timeout;
 }
 
-/**
- * Shell-escape a string using single quotes (POSIX).
- */
 function shellEscape(arg: string): string {
   if (arg === '') return "''";
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
-/**
- * Detect Node parser/compile failures while avoiding runtime SyntaxError matches.
- */
 function isNodeParserFailure(output: string): boolean {
   const hasSyntaxMarker =
     output.includes('SyntaxError') ||
@@ -88,9 +59,6 @@ function isNodeParserFailure(output: string): boolean {
   return hasSyntaxMarker && hasCompileContext && !hasRuntimeSyntaxSignature;
 }
 
-/**
- * Detect Python parser failures (syntax/indentation/tab) emitted by python -c.
- */
 function isPythonParserFailure(output: string): boolean {
   const hasSyntaxMarker =
     output.includes('SyntaxError') ||
@@ -103,41 +71,17 @@ function isPythonParserFailure(output: string): boolean {
   return hasSyntaxMarker && hasStringFileContext && !hasRuntimeTraceback;
 }
 
-/**
- * Detect parser/compile failures that should throw instead of returning a result.
- */
 function isParserFailure(output: string, runtime: string): boolean {
   if (!output.trim()) return false;
-
-  if (runtime === 'node') {
-    return isNodeParserFailure(output);
-  }
-
-  if (runtime === 'python') {
-    return isPythonParserFailure(output);
-  }
-
+  if (runtime === 'node') return isNodeParserFailure(output);
+  if (runtime === 'python') return isPythonParserFailure(output);
   return false;
 }
 
-/**
- * Create a Beam provider instance using the factory pattern
- *
- * Beam provides containerized sandbox environments with:
- * - Process management (exec, runCode)
- * - Filesystem access
- * - Dynamic port exposure
- * - Snapshot and image creation capabilities
- */
 export const beam = defineProvider<SandboxInstance, BeamConfig>({
   name: 'beam',
   methods: {
     sandbox: {
-      /**
-       * Create a new Beam sandbox
-       *
-       * Uses Sandbox class from @beamcloud/beam-js to provision a container.
-       */
       create: async (config: BeamConfig, options?: CreateSandboxOptions) => {
         configureBeamOpts(config);
 
@@ -154,7 +98,6 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
         }
 
         try {
-          // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
             timeout: optTimeout,
             envs,
@@ -173,14 +116,11 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
           const sandboxConfig: any = {
             name: name || `computesdk-${Date.now()}`,
             keepWarmSeconds: 300,
-            ...providerOptions, // Spread provider-specific options
+            ...providerOptions,
           };
 
-          // options.timeout takes precedence over config.timeout
           const timeout = optTimeout ?? config.timeout;
-          if (timeout) {
-            sandboxConfig.keepWarmSeconds = Math.ceil(timeout / 1000);
-          }
+          if (timeout) sandboxConfig.keepWarmSeconds = Math.ceil(timeout / 1000);
 
           if (optRuntime === 'node') {
             sandboxConfig.image = Image.fromRegistry('node:20-slim');
@@ -194,12 +134,10 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
           const instance = await sandbox.create();
           return { sandbox: instance, sandboxId: instance.containerId };
         } catch (error) {
-          if (error instanceof Error) {
-            if (error.message.includes('unauthorized') || error.message.includes('401')) {
-              throw new Error(
-                `Beam authentication failed. Please check your BEAM_TOKEN environment variable. Get your token from https://app.beam.cloud`
-              );
-            }
+          if (error instanceof Error && (error.message.includes('unauthorized') || error.message.includes('401'))) {
+            throw new Error(
+              `Beam authentication failed. Please check your BEAM_TOKEN environment variable. Get your token from https://app.beam.cloud`
+            );
           }
           throw new Error(
             `Failed to create Beam sandbox: ${error instanceof Error ? error.message : String(error)}`
@@ -207,116 +145,49 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
         }
       },
 
-      /**
-       * Connect to an existing Beam sandbox by ID
-       *
-       * Uses Sandbox.connect() to reconnect to a running sandbox.
-       */
       getById: async (config: BeamConfig, sandboxId: string) => {
         configureBeamOpts(config);
-
-        if (!beamOpts.token) {
-          return null;
-        }
-
+        if (!beamOpts.token) return null;
         try {
           const instance = await Sandbox.connect(sandboxId);
           return { sandbox: instance, sandboxId: instance.containerId };
-        } catch {
-          return null;
-        }
+        } catch { return null; }
       },
 
-      /**
-       * List all active Beam sandboxes
-       *
-       * Beam SDK has no sandbox list API; returns empty array.
-       */
-      list: async (_config: BeamConfig) => {
-        return [];
-      },
+      list: async (_config: BeamConfig) => [],
 
-      /**
-       * Destroy a Beam sandbox
-       *
-       * Connects to the sandbox and terminates it.
-       */
       destroy: async (config: BeamConfig, sandboxId: string) => {
         configureBeamOpts(config);
-
-        if (!beamOpts.token) {
-          return;
-        }
-
+        if (!beamOpts.token) return;
         try {
           const instance = await Sandbox.connect(sandboxId);
           await instance.terminate();
-        } catch {
-          // Sandbox might already be destroyed
-        }
+        } catch { /* Sandbox might already be destroyed */ }
       },
 
-      /**
-       * Execute a shell command in the sandbox
-       *
-       * Uses sandbox.exec() with shell command string.
-       */
       runCommand: async (sandbox: SandboxInstance, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
         try {
           let fullCommand = command;
-
           if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env)
-              .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
-              .join(' ');
+            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`).join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
+          if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
 
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
-
-          // Wrap in sh -c to get shell parsing (pipes, redirects, etc.)
           const proc = await sandbox.exec(['sh', '-c', fullCommand]);
           await proc.wait();
-          const [stdoutStr, stderrStr] = await Promise.all([
-            proc.stdout.read(),
-            proc.stderr.read(),
-          ]);
-
-          return {
-            stdout: stdoutStr || '',
-            stderr: stderrStr || '',
-            exitCode: proc.exitCode || 0,
-            durationMs: Date.now() - startTime,
-          };
+          const [stdoutStr, stderrStr] = await Promise.all([proc.stdout.read(), proc.stderr.read()]);
+          return { stdout: stdoutStr || '', stderr: stderrStr || '', exitCode: proc.exitCode || 0, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
-      /**
-       * Get sandbox information
-       */
       getInfo: async (sandbox: SandboxInstance): Promise<SandboxInfo> => {
-        // Derive runtime from sandbox instance if available
         let runtime = 'python';
-        const runtimeHint = sandbox as SandboxInstance & {
-          runtime?: unknown;
-          image?: unknown;
-          imageName?: unknown;
-        };
-
+        const runtimeHint = sandbox as SandboxInstance & { runtime?: unknown; image?: unknown; imageName?: unknown };
         if (typeof runtimeHint.runtime === 'string') {
           const lower = runtimeHint.runtime.toLowerCase();
           if (lower.includes('node')) runtime = 'node';
@@ -330,62 +201,39 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
           if (imageNameStr.includes('node')) runtime = 'node';
           else if (imageNameStr.includes('python')) runtime = 'python';
         }
-
         return {
           id: sandbox.containerId,
           provider: 'beam',
           status: 'running',
           createdAt: new Date(),
           timeout: 300000,
-          metadata: {
-            containerId: sandbox.containerId,
-            runtime,
-          },
+          metadata: { containerId: sandbox.containerId, runtime },
         };
       },
 
-      /**
-       * Get public URL for a specific port
-       *
-       * Uses sandbox.exposePort() to dynamically expose a port.
-       */
       getUrl: async (sandbox: SandboxInstance, options: { port: number; protocol?: string }): Promise<string> => {
         try {
           return await sandbox.exposePort(options.port);
         } catch (error) {
-          throw new Error(
-            `Failed to get Beam URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get Beam URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      /**
-       * Filesystem operations
-       */
       filesystem: {
         readFile: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<string> => {
           const result = await runCommand(sandbox, `cat ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to read file ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to read file ${path}: ${result.stderr}`);
           return result.stdout;
         },
-
         writeFile: async (sandbox: SandboxInstance, path: string, content: string, runCommand: RunCommandFn): Promise<void> => {
           const b64 = Buffer.from(content).toString('base64');
           const result = await runCommand(sandbox, `echo '${b64}' | base64 -d > ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to write file ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to write file ${path}: ${result.stderr}`);
         },
-
         mkdir: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<void> => {
           const result = await runCommand(sandbox, `mkdir -p ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
         },
-
         readdir: async (sandbox: SandboxInstance, path: string, _runCommand: RunCommandFn): Promise<FileEntry[]> => {
           const files = await sandbox.fs.listFiles(path);
           return files.map((file: any) => ({
@@ -395,32 +243,19 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
             modified: file.modTime ? new Date(file.modTime * 1000) : new Date(),
           }));
         },
-
         exists: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<boolean> => {
           const result = await runCommand(sandbox, `test -f ${shellEscape(path)} || test -d ${shellEscape(path)}`);
           return result.exitCode === 0;
         },
-
         remove: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<void> => {
           const result = await runCommand(sandbox, `rm -rf ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to remove ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to remove ${path}: ${result.stderr}`);
         },
       },
 
-      /**
-       * Get the native SandboxInstance for advanced usage
-       */
-      getInstance: (sandbox: SandboxInstance): SandboxInstance => {
-        return sandbox;
-      },
+      getInstance: (sandbox: SandboxInstance): SandboxInstance => sandbox,
     },
   },
 });
 
-// Keep isParserFailure available for potential future use
-export { isParserFailure };
-
-// Export Beam sandbox type for explicit typing
 export type { SandboxInstance as BeamSandboxInstance } from '@beamcloud/beam-js';

--- a/packages/blaxel/src/index.ts
+++ b/packages/blaxel/src/index.ts
@@ -38,7 +38,6 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 			create: async (config: BlaxelConfig, options?: CreateSandboxOptions) => {
 				// Destructure known ComputeSDK fields, collect the rest for passthrough
 				const {
-					runtime: optRuntime,
 					timeout: optTimeout,
 					envs,
 					name: _name,
@@ -50,6 +49,8 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 					directory: _directory,
 					...providerOptions
 				} = options || {};
+
+				const optRuntime = (options as any)?.runtime as string | undefined;
 
 				// Determine the image to use
 				let image = config.image || 'blaxel/base-image:latest';  // Default to prod-base
@@ -167,7 +168,6 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 					await SandboxInstance.delete(sandboxId);
 				} catch (error) {
 					// Sandbox might already be destroyed or doesn't exist
-					// This is acceptable for destroy operations
 				}
 			},
 
@@ -216,14 +216,15 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 		},
 
 			getInfo: async (sandbox: SandboxInstance): Promise<SandboxInfo> => {
+				const runtime = sandbox.spec?.runtime?.image?.includes('py') ? 'python' : 'node';
 				return {
 					id: sandbox.metadata?.name || 'blaxel-unknown',
 					provider: 'blaxel',
-					runtime: sandbox.spec?.runtime?.image?.includes('py') ? 'python' : 'node',
 					status: convertSandboxStatus(sandbox.status),
 					createdAt: sandbox.metadata?.createdAt ? new Date(sandbox.metadata.createdAt) : new Date(),
 					timeout: parseTTLToMilliseconds(sandbox.spec?.runtime?.ttl),
 					metadata: {
+						runtime,
 						...sandbox.metadata?.labels
 					}
 				};
@@ -346,13 +347,13 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 				exists: async (sandbox: SandboxInstance, path: string): Promise<boolean> => {
 					try {
 						await sandbox.fs.read(path);
-						return true;  // It's a file and exists
+						return true;
 					} catch {
 						try {
 							await sandbox.fs.ls(path);
-							return true;  // It's a directory and exists
+							return true;
 						} catch {
-							return false;  // Path doesn't exist
+							return false;
 						}
 					}
 				},
@@ -370,20 +371,15 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 
 		snapshot: {
 			create: async (config: BlaxelConfig, sandboxId: string, options?: { name?: string }) => {
-				// Blaxel automatically snapshots on scale-down, but we can trigger a manual snapshot
-				// by stopping the sandbox which saves its state
 				try {
 					initializeBlaxel(config);
 					
-					// Get the sandbox to access its snapshot
 					const sandbox = await SandboxInstance.get(sandboxId);
 					
 					if (!sandbox) {
 						throw new Error(`Sandbox ${sandboxId} not found`);
 					}
 
-					// Return the current state as a snapshot
-					// Blaxel's auto-snapshot on scale-down is the primary mechanism
 					return {
 						id: sandboxId,
 						provider: 'blaxel',
@@ -401,8 +397,6 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 			},
 
 			list: async (config: BlaxelConfig) => {
-				// Blaxel doesn't have a separate snapshot listing API
-				// List sandboxes as they contain the snapshot state
 				initializeBlaxel(config);
 				const sandboxList = await SandboxInstance.list();
 				return sandboxList.map(sandbox => ({
@@ -417,7 +411,6 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 			},
 
 			delete: async (config: BlaxelConfig, snapshotId: string) => {
-				// Deleting a snapshot in Blaxel is just deleting the sandbox
 				try {
 					initializeBlaxel(config);
 					await SandboxInstance.delete(snapshotId);
@@ -452,29 +445,20 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 
 /**
  * Parse TTL value from Blaxel's format to milliseconds
- * Supports formats like "30m", "24h", "7d" or plain numbers (seconds)
  */
 function parseTTLToMilliseconds(ttl: string | number | undefined): number {
-	if (!ttl) return 300000; // Default to 5 minutes
-
-	// If it's already a number, treat it as seconds and convert to milliseconds
-	if (typeof ttl === 'number') {
-		return ttl * 1000;
-	}
-
-	// Parse string formats like "30m", "24h", "7d"
+	if (!ttl) return 300000;
+	if (typeof ttl === 'number') return ttl * 1000;
 	const match = ttl.match(/^(\d+)([smhd])?$/);
-	if (!match) return 300000; // Default if format is invalid
-
+	if (!match) return 300000;
 	const value = parseInt(match[1], 10);
-	const unit = match[2] || 's'; // Default to seconds if no unit
-
+	const unit = match[2] || 's';
 	switch (unit) {
-		case 's': return value * 1000;           // seconds to ms
-		case 'm': return value * 60 * 1000;      // minutes to ms
-		case 'h': return value * 60 * 60 * 1000; // hours to ms
-		case 'd': return value * 24 * 60 * 60 * 1000; // days to ms
-		default: return 300000; // Default fallback
+		case 's': return value * 1000;
+		case 'm': return value * 60 * 1000;
+		case 'h': return value * 60 * 60 * 1000;
+		case 'd': return value * 24 * 60 * 60 * 1000;
+		default: return 300000;
 	}
 }
 
@@ -498,18 +482,15 @@ function convertSandboxStatus(status: string | undefined): 'running' | 'stopped'
 
 /**
  * Execute a command in the sandbox and capture stdout/stderr
- * Handles the common pattern of executing, streaming logs, and waiting for completion
  */
 async function executeWithStreaming(
 	sandbox: SandboxInstance,
 	command: string
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-	// Execute the command
 	const processResult = await sandbox.process.exec({
 		command,
 		waitForCompletion: true,
 	});
-	// Handle union type - ProcessResponseWithLog has stdout/stderr
 	const result = processResult as { stdout?: string; stderr?: string; exitCode?: number };
 	return {
 		stdout: result.stdout || '',

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -17,9 +17,6 @@ import { defineProvider } from '@computesdk/provider';
 
 /**
  * Lazy-load @cloudflare/sandbox to avoid importing it in Node.js environments.
- * The SDK only works inside the Cloudflare Workers runtime (its transitive dep
- * @cloudflare/containers uses extensionless ESM imports that break in Node).
- * Remote mode never needs this import.
  */
 let _getSandboxFn: ((binding: any, id: string, options?: any) => any) | null = null;
 async function getSandbox(binding: any, id: string, options?: any): Promise<any> {
@@ -30,7 +27,7 @@ async function getSandbox(binding: any, id: string, options?: any): Promise<any>
   return _getSandboxFn(binding, id, options);
 }
 
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -46,8 +43,8 @@ export interface CloudflareConfig {
   sandboxBinding?: any;
 
   // Shared options
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'python', 'node') */
+  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
   /** Environment variables to pass to sandbox */
@@ -80,7 +77,7 @@ function isRemote(config: CloudflareConfig): boolean {
   return !!(config.sandboxUrl && config.sandboxSecret);
 }
 
-function detectRuntime(code: string): Runtime {
+function detectRuntime(code: string): string {
   if (code.includes('print(') ||
     code.includes('import ') ||
     code.includes('def ') ||
@@ -103,7 +100,7 @@ function detectRuntime(code: string): Runtime {
   return 'python';
 }
 
-function runtimeToLanguage(runtime: Runtime): 'python' | 'javascript' | 'typescript' {
+function runtimeToLanguage(runtime: string): 'python' | 'javascript' | 'typescript' {
   switch (runtime) {
     case 'python': return 'python';
     case 'node': return 'javascript';
@@ -179,7 +176,7 @@ function shellEscape(s: string): string {
 /**
  * Process code execution results into a CodeResult (shared by remote and direct modes)
  */
-function processExecution(execution: any, detectedRuntime: Runtime): CodeResult {
+function processExecution(execution: any, detectedRuntime: string): CodeResult {
   const stdoutParts: string[] = [];
   const stderrParts: string[] = [];
 
@@ -244,7 +241,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
       create: async (config: CloudflareConfig, options?: CreateSandboxOptions) => {
         // Destructure known ComputeSDK fields, collect the rest for passthrough
         const {
-          runtime: _runtime,
           timeout: optTimeout,
           envs,
           name: _name,
@@ -254,7 +250,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
           sandboxId: optSandboxId,
           namespace: _namespace,
           directory: _directory,
-          ports: _ports,
           ...rest
         } = options || {};
 
@@ -464,7 +459,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
           return {
             id: cfSandbox.sandboxId,
             provider: 'cloudflare',
-            runtime: 'python',
             status: 'running',
             createdAt: new Date(),
             timeout: 300000,
@@ -477,7 +471,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
           return {
             id: cfSandbox.sandboxId,
             provider: 'cloudflare',
-            runtime: 'python',
             status: 'error',
             createdAt: new Date(),
             timeout: 300000,
@@ -538,7 +531,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
         },
 
         readdir: async (cfSandbox: CloudflareSandbox, path: string): Promise<FileEntry[]> => {
-          // Both modes use ls -la since there's no native readdir
           let result: any;
           if (cfSandbox.remote) {
             result = await workerRequestWithInit(cfSandbox, '/v1/sandbox/exec', {
@@ -576,3 +568,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
     }
   }
 });
+
+// Keep these exported for potential future use
+export { detectRuntime, runtimeToLanguage };

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -15,9 +15,6 @@
 
 import { defineProvider } from '@computesdk/provider';
 
-/**
- * Lazy-load @cloudflare/sandbox to avoid importing it in Node.js environments.
- */
 let _getSandboxFn: ((binding: any, id: string, options?: any) => any) | null = null;
 async function getSandbox(binding: any, id: string, options?: any): Promise<any> {
   if (!_getSandboxFn) {
@@ -29,94 +26,37 @@ async function getSandbox(binding: any, id: string, options?: any): Promise<any>
 
 import type { CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-// ─── Config ──────────────────────────────────────────────────────────────────
-
 export interface CloudflareConfig {
-  // Remote mode (from anywhere — talks to deployed gateway Worker)
-  /** URL of the deployed gateway Worker (e.g. https://computesdk-sandbox.user.workers.dev) */
   sandboxUrl?: string;
-  /** Shared secret for authenticating with the gateway Worker */
   sandboxSecret?: string;
-
-  // Direct mode (inside a Cloudflare Worker — uses DO binding)
-  /** Cloudflare Sandbox Durable Object binding from Workers environment */
   sandboxBinding?: any;
-
-  // Shared options
-  /** Default runtime environment (e.g. 'python', 'node') */
-  runtime?: string;
-  /** Execution timeout in milliseconds */
   timeout?: number;
-  /** Environment variables to pass to sandbox */
   envVars?: Record<string, string>;
-  /** Options passed to getSandbox() for lifecycle control (direct mode only) */
   sandboxOptions?: {
     sleepAfter?: string | number;
     keepAlive?: boolean;
   };
 }
 
-// ─── Internal types ──────────────────────────────────────────────────────────
-
 interface CloudflareSandbox {
   sandboxId: string;
   exposedPorts: Map<number, string>;
-  // Remote mode fields
   remote: boolean;
   sandboxUrl?: string;
   sandboxSecret?: string;
   pendingEnvVars?: Record<string, string>;
   remoteInitialized?: boolean;
-  // Direct mode fields
-  sandbox?: any; // The @cloudflare/sandbox instance
+  sandbox?: any;
 }
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function isRemote(config: CloudflareConfig): boolean {
   return !!(config.sandboxUrl && config.sandboxSecret);
-}
-
-function detectRuntime(code: string): string {
-  if (code.includes('print(') ||
-    code.includes('import ') ||
-    code.includes('def ') ||
-    code.includes('sys.') ||
-    code.includes('json.') ||
-    code.includes('__') ||
-    code.includes('f"') ||
-    code.includes("f'") ||
-    code.includes('raise ')) {
-    return 'python';
-  }
-  if (code.includes('console.log') ||
-    code.includes('process.') ||
-    code.includes('require(') ||
-    code.includes('module.exports') ||
-    code.includes('__dirname') ||
-    code.includes('__filename')) {
-    return 'node';
-  }
-  return 'python';
-}
-
-function runtimeToLanguage(runtime: string): 'python' | 'javascript' | 'typescript' {
-  switch (runtime) {
-    case 'python': return 'python';
-    case 'node': return 'javascript';
-    case 'bun': return 'javascript';
-    case 'deno': return 'typescript';
-    default: return 'python';
-  }
 }
 
 function createSandboxId(): string {
   return `cf-sandbox-${crypto.randomUUID()}`;
 }
 
-/**
- * Make an authenticated request to the remote gateway Worker
- */
 async function workerRequest(
   cfSandbox: CloudflareSandbox,
   path: string,
@@ -139,10 +79,7 @@ async function workerRequest(
     throw new Error(`Worker request failed: ${res.status} - ${text.slice(0, 200)}`);
   }
 
-  if (!res.ok) {
-    throw new Error(data.error || `Worker request failed: ${res.status}`);
-  }
-
+  if (!res.ok) throw new Error(data.error || `Worker request failed: ${res.status}`);
   return data;
 }
 
@@ -166,16 +103,10 @@ async function workerRequestWithInit(
   return data;
 }
 
-/**
- * Escape a string for safe use inside double-quoted shell arguments.
- */
 function shellEscape(s: string): string {
   return s.replace(/["$`\\!]/g, '\\$&');
 }
 
-/**
- * Process code execution results into a CodeResult (shared by remote and direct modes)
- */
 function processExecution(execution: any, detectedRuntime: string): CodeResult {
   const stdoutParts: string[] = [];
   const stderrParts: string[] = [];
@@ -207,9 +138,6 @@ function processExecution(execution: any, detectedRuntime: string): CodeResult {
   };
 }
 
-/**
- * Parse ls -la output into FileEntry objects (used by both modes for readdir)
- */
 function parseLsOutput(stdout: string): FileEntry[] {
   const lines = stdout.split('\n').filter((line: string) => line.trim() && !line.startsWith('total'));
 
@@ -230,16 +158,11 @@ function parseLsOutput(stdout: string): FileEntry[] {
   });
 }
 
-// ─── Provider ────────────────────────────────────────────────────────────────
-
 export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
   name: 'cloudflare',
   methods: {
     sandbox: {
-      // ─── Collection operations ───────────────────────────────────────
-
       create: async (config: CloudflareConfig, options?: CreateSandboxOptions) => {
-        // Destructure known ComputeSDK fields, collect the rest for passthrough
         const {
           timeout: optTimeout,
           envs,
@@ -255,11 +178,9 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
 
         const sandboxId = optSandboxId || createSandboxId();
         const envVars = { ...config.envVars, ...envs };
-        // options.timeout takes precedence over config.timeout
         const timeout = optTimeout ?? config.timeout;
         const sleepAfter = timeout ? `${Math.ceil(timeout / 1000)}s` : undefined;
 
-        // Remote mode
         if (isRemote(config)) {
           return {
             sandbox: {
@@ -275,7 +196,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
           };
         }
 
-        // Direct mode
         if (!config.sandboxBinding) {
           throw new Error(
             'Missing Cloudflare config. Either:\n' +
@@ -287,22 +207,13 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
 
         try {
           const sandboxOpts = { ...config.sandboxOptions };
-          if (sleepAfter) {
-            sandboxOpts.sleepAfter = sleepAfter;
-          }
+          if (sleepAfter) sandboxOpts.sleepAfter = sleepAfter;
           const sandbox = await getSandbox(config.sandboxBinding, sandboxId, sandboxOpts);
 
-          if (Object.keys(envVars).length > 0) {
-            await sandbox.setEnvVars(envVars);
-          }
+          if (Object.keys(envVars).length > 0) await sandbox.setEnvVars(envVars);
 
           return {
-            sandbox: {
-              sandbox,
-              sandboxId,
-              remote: false,
-              exposedPorts: new Map(),
-            },
+            sandbox: { sandbox, sandboxId, remote: false, exposedPorts: new Map() },
             sandboxId
           };
         } catch (error) {
@@ -322,38 +233,24 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
       },
 
       getById: async (config: CloudflareConfig, sandboxId: string) => {
-        // Remote mode
         if (isRemote(config)) {
           try {
             const cfSandbox: CloudflareSandbox = {
-              sandboxId,
-              remote: true,
-              sandboxUrl: config.sandboxUrl,
-              sandboxSecret: config.sandboxSecret,
-              remoteInitialized: true,
-              exposedPorts: new Map(),
+              sandboxId, remote: true, sandboxUrl: config.sandboxUrl,
+              sandboxSecret: config.sandboxSecret, remoteInitialized: true, exposedPorts: new Map(),
             };
-            // Verify sandbox is alive
             await workerRequest(cfSandbox, '/v1/sandbox/exec', { command: 'true' });
             return { sandbox: cfSandbox, sandboxId };
-          } catch {
-            return null;
-          }
+          } catch { return null; }
         }
 
-        // Direct mode
         if (!config.sandboxBinding) return null;
 
         try {
           const sandbox = await getSandbox(config.sandboxBinding, sandboxId, config.sandboxOptions);
           await sandbox.exec('true');
-          return {
-            sandbox: { sandbox, sandboxId, remote: false, exposedPorts: new Map() },
-            sandboxId
-          };
-        } catch {
-          return null;
-        }
+          return { sandbox: { sandbox, sandboxId, remote: false, exposedPorts: new Map() }, sandboxId };
+        } catch { return null; }
       },
 
       list: async (_config: CloudflareConfig) => {
@@ -373,122 +270,63 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
             );
             return;
           }
-
           if (config.sandboxBinding) {
             const sandbox = await getSandbox(config.sandboxBinding, sandboxId);
             await sandbox.destroy();
           }
-        } catch {
-          // Sandbox might already be destroyed
-        }
+        } catch { /* Sandbox might already be destroyed */ }
       },
-
-      // ─── Instance operations ─────────────────────────────────────────
 
       runCommand: async (cfSandbox: CloudflareSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
 
-        // Remote mode
         if (cfSandbox.remote) {
           try {
             let fullCommand = command;
-            if (options?.background) {
-              fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-            }
-
+            if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
             const result = await workerRequestWithInit(cfSandbox, '/v1/sandbox/exec', {
-              command: fullCommand,
-              cwd: options?.cwd,
-              env: options?.env,
-              timeout: options?.timeout,
+              command: fullCommand, cwd: options?.cwd, env: options?.env, timeout: options?.timeout,
             });
-
-            return {
-              stdout: result.stdout || '',
-              stderr: result.stderr || '',
-              exitCode: result.exitCode,
-              durationMs: Date.now() - startTime
-            };
+            return { stdout: result.stdout || '', stderr: result.stderr || '', exitCode: result.exitCode, durationMs: Date.now() - startTime };
           } catch (error) {
-            return {
-              stdout: '',
-              stderr: error instanceof Error ? error.message : String(error),
-              exitCode: 127,
-              durationMs: Date.now() - startTime
-            };
+            return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
           }
         }
 
-        // Direct mode
         try {
           let fullCommand = command;
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
-
+          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           const execResult = await cfSandbox.sandbox.exec(fullCommand, {
-            cwd: options?.cwd,
-            env: options?.env,
-            timeout: options?.timeout,
+            cwd: options?.cwd, env: options?.env, timeout: options?.timeout,
           });
-
-          return {
-            stdout: execResult.stdout || '',
-            stderr: execResult.stderr || '',
-            exitCode: execResult.exitCode,
-            durationMs: Date.now() - startTime
-          };
+          return { stdout: execResult.stdout || '', stderr: execResult.stderr || '', exitCode: execResult.exitCode, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
       getInfo: async (cfSandbox: CloudflareSandbox): Promise<SandboxInfo> => {
         try {
-          if (cfSandbox.remote) {
-            await workerRequestWithInit(cfSandbox, '/v1/sandbox/info');
-          } else {
-            await cfSandbox.sandbox.exec('true');
-          }
+          if (cfSandbox.remote) await workerRequestWithInit(cfSandbox, '/v1/sandbox/info');
+          else await cfSandbox.sandbox.exec('true');
 
           return {
-            id: cfSandbox.sandboxId,
-            provider: 'cloudflare',
-            status: 'running',
-            createdAt: new Date(),
-            timeout: 300000,
-            metadata: {
-              cloudflareSandboxId: cfSandbox.sandboxId,
-              mode: cfSandbox.remote ? 'remote' : 'direct',
-            }
+            id: cfSandbox.sandboxId, provider: 'cloudflare', status: 'running',
+            createdAt: new Date(), timeout: 300000,
+            metadata: { cloudflareSandboxId: cfSandbox.sandboxId, mode: cfSandbox.remote ? 'remote' : 'direct' }
           };
         } catch (error) {
           return {
-            id: cfSandbox.sandboxId,
-            provider: 'cloudflare',
-            status: 'error',
-            createdAt: new Date(),
-            timeout: 300000,
-            metadata: {
-              cloudflareSandboxId: cfSandbox.sandboxId,
-              mode: cfSandbox.remote ? 'remote' : 'direct',
-              error: error instanceof Error ? error.message : String(error)
-            }
+            id: cfSandbox.sandboxId, provider: 'cloudflare', status: 'error',
+            createdAt: new Date(), timeout: 300000,
+            metadata: { cloudflareSandboxId: cfSandbox.sandboxId, mode: cfSandbox.remote ? 'remote' : 'direct', error: error instanceof Error ? error.message : String(error) }
           };
         }
       },
 
       getUrl: async (cfSandbox: CloudflareSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         const { port, protocol = 'https' } = options;
-
-        if (cfSandbox.exposedPorts.has(port)) {
-          return cfSandbox.exposedPorts.get(port)!;
-        }
+        if (cfSandbox.exposedPorts.has(port)) return cfSandbox.exposedPorts.get(port)!;
 
         let preview: any;
         if (cfSandbox.remote) {
@@ -502,8 +340,6 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
         return url;
       },
 
-      // ─── Filesystem ────────────────────────────────────────────────
-
       filesystem: {
         readFile: async (cfSandbox: CloudflareSandbox, path: string): Promise<string> => {
           if (cfSandbox.remote) {
@@ -513,41 +349,24 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
           const file = await cfSandbox.sandbox.readFile(path);
           return file.content || '';
         },
-
         writeFile: async (cfSandbox: CloudflareSandbox, path: string, content: string): Promise<void> => {
-          if (cfSandbox.remote) {
-            await workerRequestWithInit(cfSandbox, '/v1/sandbox/writeFile', { path, content });
-            return;
-          }
+          if (cfSandbox.remote) { await workerRequestWithInit(cfSandbox, '/v1/sandbox/writeFile', { path, content }); return; }
           await cfSandbox.sandbox.writeFile(path, content);
         },
-
         mkdir: async (cfSandbox: CloudflareSandbox, path: string): Promise<void> => {
-          if (cfSandbox.remote) {
-            await workerRequestWithInit(cfSandbox, '/v1/sandbox/mkdir', { path });
-            return;
-          }
+          if (cfSandbox.remote) { await workerRequestWithInit(cfSandbox, '/v1/sandbox/mkdir', { path }); return; }
           await cfSandbox.sandbox.mkdir(path, { recursive: true });
         },
-
         readdir: async (cfSandbox: CloudflareSandbox, path: string): Promise<FileEntry[]> => {
           let result: any;
           if (cfSandbox.remote) {
-            result = await workerRequestWithInit(cfSandbox, '/v1/sandbox/exec', {
-              command: `ls -la "${shellEscape(path)}"`,
-              cwd: '/',
-            });
+            result = await workerRequestWithInit(cfSandbox, '/v1/sandbox/exec', { command: `ls -la "${shellEscape(path)}"`, cwd: '/' });
           } else {
             result = await cfSandbox.sandbox.exec(`ls -la "${shellEscape(path)}"`, { cwd: '/' });
           }
-
-          if (result.exitCode !== 0) {
-            throw new Error(`Directory listing failed: ${result.stderr}`);
-          }
-
+          if (result.exitCode !== 0) throw new Error(`Directory listing failed: ${result.stderr}`);
           return parseLsOutput(result.stdout);
         },
-
         exists: async (cfSandbox: CloudflareSandbox, path: string): Promise<boolean> => {
           if (cfSandbox.remote) {
             const result = await workerRequestWithInit(cfSandbox, '/v1/sandbox/exists', { path });
@@ -556,18 +375,11 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
           const result = await cfSandbox.sandbox.exists(path);
           return result.exists;
         },
-
         remove: async (cfSandbox: CloudflareSandbox, path: string): Promise<void> => {
-          if (cfSandbox.remote) {
-            await workerRequestWithInit(cfSandbox, '/v1/sandbox/deleteFile', { path });
-            return;
-          }
+          if (cfSandbox.remote) { await workerRequestWithInit(cfSandbox, '/v1/sandbox/deleteFile', { path }); return; }
           await cfSandbox.sandbox.deleteFile(path);
         }
       }
     }
   }
 });
-
-// Keep these exported for potential future use
-export { detectRuntime, runtimeToLanguage };

--- a/packages/codesandbox/src/index.ts
+++ b/packages/codesandbox/src/index.ts
@@ -1,168 +1,88 @@
 /**
  * Codesandbox Provider - Factory-based Implementation
- * 
- * Full-featured provider with filesystem support using the factory pattern.
  */
 
 import { CodeSandbox } from '@codesandbox/sdk';
 import type { Sandbox as CodesandboxSandbox } from '@codesandbox/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Runtime, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-type HibernateCapableSandbox = CodesandboxSandbox & {
-  hibernate: () => Promise<void>;
-};
+type HibernateCapableSandbox = CodesandboxSandbox & { hibernate: () => Promise<void>; };
 
-/**
- * Codesandbox-specific configuration options
- */
 export interface CodesandboxConfig {
   /** CodeSandbox API key - if not provided, will fallback to CSB_API_KEY environment variable */
   apiKey?: string;
   /** Template to use for new sandboxes */
   templateId?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'node', 'python') */
+  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
 }
 
-/**
- * Create a Codesandbox provider instance using the factory pattern
- */
 export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig, any, any>({
   name: 'codesandbox',
   methods: {
     sandbox: {
-      // Collection operations (compute.sandbox.*)
       create: async (config: CodesandboxConfig, options?: CreateSandboxOptions) => {
-        // Validate API key
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.CSB_API_KEY) || '';
-
         if (!apiKey) {
-          throw new Error(
-            `Missing CodeSandbox API key. Provide 'apiKey' in config or set CSB_API_KEY environment variable. Get your API key from https://codesandbox.io/t/api`
-          );
+          throw new Error(`Missing CodeSandbox API key. Provide 'apiKey' in config or set CSB_API_KEY environment variable.`);
         }
-
         const sdk = new CodeSandbox(apiKey);
-
         try {
           let sandbox: CodesandboxSandbox;
           let sandboxId: string;
-
           if (options?.snapshotId) {
-            // Resume from snapshot - in CodeSandbox, snapshots are hibernated sandboxes
             sandbox = await sdk.sandboxes.resume(options.snapshotId);
             sandboxId = options.snapshotId;
           } else {
-            // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {
-              runtime: _runtime,
-              timeout: _timeout,
-              envs,
-              name: _name,
-              metadata: _metadata,
-              templateId: optTemplateId,
-              snapshotId: _snapshotId,
-              sandboxId: _sandboxId,
-              namespace: _namespace,
-              directory: _directory,
-              ...providerOptions
+              timeout: _timeout, envs, name: _name, metadata: _metadata,
+              templateId: optTemplateId, snapshotId: _snapshotId, sandboxId: _sandboxId,
+              namespace: _namespace, directory: _directory, ...providerOptions
             } = options || {};
-
-            // Create new CodeSandbox using sdk.sandboxes.create()
-            const createOptions: any = {
-              ...providerOptions, // Spread provider-specific options
-            };
-
-            // options.templateId takes precedence over config.templateId
+            const createOptions: any = { ...providerOptions };
             const templateId = optTemplateId || config.templateId;
-            if (templateId) {
-              createOptions.id = templateId;
-            }
-
-            // Remap envs to envVars
-            if (envs && Object.keys(envs).length > 0) {
-              createOptions.envVars = envs;
-            }
-
+            if (templateId) createOptions.id = templateId;
+            if (envs && Object.keys(envs).length > 0) createOptions.envVars = envs;
             sandbox = await sdk.sandboxes.create(createOptions);
             sandboxId = sandbox.id;
           }
-
-          return {
-            sandbox,
-            sandboxId
-          };
+          return { sandbox, sandboxId };
         } catch (error) {
           if (error instanceof Error) {
             if (error.message.includes('unauthorized') || error.message.includes('API key')) {
-              throw new Error(
-                `CodeSandbox authentication failed. Please check your CSB_API_KEY environment variable. Get your API key from https://codesandbox.io/t/api`
-              );
+              throw new Error(`CodeSandbox authentication failed. Please check your CSB_API_KEY environment variable.`);
             }
             if (error.message.includes('quota') || error.message.includes('limit')) {
-              throw new Error(
-                `CodeSandbox quota exceeded. Please check your usage at https://codesandbox.io/dashboard`
-              );
+              throw new Error(`CodeSandbox quota exceeded. Please check your usage at https://codesandbox.io/dashboard`);
             }
           }
-          throw new Error(
-            `Failed to create CodeSandbox sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create CodeSandbox sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: CodesandboxConfig, sandboxId: string) => {
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.CSB_API_KEY) || '';
-
-        if (!apiKey) {
-          throw new Error(
-            `Missing CodeSandbox API key. Provide 'apiKey' in config or set CSB_API_KEY environment variable.`
-          );
-        }
-
+        if (!apiKey) throw new Error(`Missing CodeSandbox API key.`);
         const sdk = new CodeSandbox(apiKey);
-
         try {
-          // Resume existing sandbox using sdk.sandboxes.resume()
           const sandbox = await sdk.sandboxes.resume(sandboxId);
-
-          return {
-            sandbox,
-            sandboxId
-          };
-        } catch (error) {
-          // Sandbox doesn't exist or can't be accessed
-          return null;
-        }
+          return { sandbox, sandboxId };
+        } catch { return null; }
       },
 
       list: async (_config: CodesandboxConfig) => {
-        throw new Error(
-          `CodeSandbox provider does not support listing sandboxes. CodeSandbox SDK does not provide a native list API. Consider using the CodeSandbox dashboard or implement your own tracking system.`
-        );
+        throw new Error(`CodeSandbox provider does not support listing sandboxes.`);
       },
 
       destroy: async (config: CodesandboxConfig, sandboxId: string) => {
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.CSB_API_KEY) || '';
-
-        if (!apiKey) {
-          throw new Error(
-            `Missing CodeSandbox API key. Provide 'apiKey' in config or set CSB_API_KEY environment variable.`
-          );
-        }
-
+        if (!apiKey) throw new Error(`Missing CodeSandbox API key.`);
         const sdk = new CodeSandbox(apiKey);
-
-        try {
-          await sdk.sandboxes.shutdown(sandboxId);
-        } catch {
-          // Ignore — may already be stopped
-        }
-
+        try { await sdk.sandboxes.shutdown(sandboxId); } catch { /* ignore */ }
         try {
           await sdk.sandboxes.delete(sandboxId);
         } catch (error) {
@@ -173,103 +93,54 @@ export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig,
         }
       },
 
-      // Instance operations (sandbox.*)
-
       runCommand: async (sandbox: CodesandboxSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
-
         try {
-          // Connect to the sandbox client using sandbox.connect()
           const client = await sandbox.connect();
-
-          // Build command with options
           let fullCommand = command;
-
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env)
-              .map(([k, v]) => `${k}="${escapeShellArg(v)}"`)
-              .join(' ');
+            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(v)}"`).join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
-
-          // Handle working directory
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-
-          // Handle background execution
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
-
-          // Execute command using CodeSandbox client.commands.run()
+          if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           const output = await client.commands.run(fullCommand);
-
-          return {
-            stdout: output,
-            stderr: '',
-            exitCode: 0,
-            durationMs: Date.now() - startTime
-          };
+          return { stdout: output, stderr: '', exitCode: 0, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
-      getInfo: async (sandbox: CodesandboxSandbox): Promise<SandboxInfo> => {
-        return {
-          id: sandbox.id,
-          provider: 'codesandbox',
-          runtime: 'node', // CodeSandbox default
-          status: 'running',
-          createdAt: new Date(),
-          timeout: 300000,
-          metadata: {
-            cluster: sandbox.cluster,
-            bootupType: sandbox.bootupType,
-            isUpToDate: sandbox.isUpToDate
-          }
-        };
-      },
+      getInfo: async (sandbox: CodesandboxSandbox): Promise<SandboxInfo> => ({
+        id: sandbox.id,
+        provider: 'codesandbox',
+        status: 'running',
+        createdAt: new Date(),
+        timeout: 300000,
+        metadata: { cluster: sandbox.cluster, bootupType: sandbox.bootupType, isUpToDate: sandbox.isUpToDate }
+      }),
 
       getUrl: async (sandbox: CodesandboxSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         const protocol = options.protocol || 'https';
-        // CodeSandbox provides URLs in the format: https://{sandbox-id}.{cluster}.csb.app:{port}
-        // Use the actual CodeSandbox URL format
         return `${protocol}://${sandbox.id}.${sandbox.cluster}.csb.app:${options.port}`;
       },
 
-      // Filesystem operations using CodeSandbox client.fs API
       filesystem: {
         readFile: async (sandbox: CodesandboxSandbox, path: string): Promise<string> => {
-          // Connect to the sandbox client and use client.fs.readTextFile()
           const client = await sandbox.connect();
-          return await client.fs.readTextFile(path);
+          return client.fs.readTextFile(path);
         },
-
         writeFile: async (sandbox: CodesandboxSandbox, path: string, content: string): Promise<void> => {
-          // Connect to the sandbox client and use client.fs.writeTextFile()
           const client = await sandbox.connect();
           await client.fs.writeTextFile(path, content);
         },
-
         mkdir: async (sandbox: CodesandboxSandbox, path: string): Promise<void> => {
-          // CodeSandbox doesn't have a direct mkdir API, use commands to create directory
           const client = await sandbox.connect();
           await client.commands.run(`mkdir -p "${path}"`);
         },
-
         readdir: async (sandbox: CodesandboxSandbox, path: string): Promise<FileEntry[]> => {
-          // Connect to the sandbox client and use client.fs.readdir()
           const client = await sandbox.connect();
           const entries = await client.fs.readdir(path);
-
           return entries.map((entry: any) => ({
             name: entry.name,
             type: entry.isDirectory ? 'directory' as const : 'file' as const,
@@ -277,114 +148,47 @@ export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig,
             modified: entry.lastModified ? new Date(entry.lastModified) : new Date()
           }));
         },
-
         exists: async (sandbox: CodesandboxSandbox, path: string): Promise<boolean> => {
-          // CodeSandbox doesn't have a direct exists API, use ls command to check
           const client = await sandbox.connect();
-          try {
-            await client.commands.run(`ls "${path}"`);
-            return true;
-          } catch {
-            return false;
-          }
+          try { await client.commands.run(`ls "${path}"`); return true; } catch { return false; }
         },
-
         remove: async (sandbox: CodesandboxSandbox, path: string): Promise<void> => {
-          // Connect to the sandbox client and use client.fs.remove()
           const client = await sandbox.connect();
           await client.fs.remove(path);
         }
       },
 
-      // Provider-specific typed getInstance method
-      getInstance: (sandbox: CodesandboxSandbox): CodesandboxSandbox => {
-        return sandbox;
-      },
-
+      getInstance: (sandbox: CodesandboxSandbox): CodesandboxSandbox => sandbox,
     },
 
     snapshot: {
       create: async (config: CodesandboxConfig, sandboxId: string, options?: { name?: string }) => {
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.CSB_API_KEY) || '';
-
-        if (!apiKey) {
-          throw new Error(
-            `Missing CodeSandbox API key. Provide 'apiKey' in config or set CSB_API_KEY environment variable.`
-          );
-        }
-
+        if (!apiKey) throw new Error(`Missing CodeSandbox API key.`);
         const sdk = new CodeSandbox(apiKey);
-
         try {
-          // Resume the sandbox first, then hibernate to create a snapshot
           const sandbox = await sdk.sandboxes.resume(sandboxId);
-
-          // Hibernate creates a checkpoint/snapshot of the sandbox
-          const hibernateSandbox = sandbox as HibernateCapableSandbox;
-          await hibernateSandbox.hibernate();
-
-          // The hibernated sandbox becomes a snapshot we can fork
-          return {
-            id: sandbox.id,
-            provider: 'codesandbox',
-            createdAt: new Date(),
-            metadata: {
-              name: options?.name,
-              bootupType: sandbox.bootupType
-            }
-          };
+          await (sandbox as HibernateCapableSandbox).hibernate();
+          return { id: sandbox.id, provider: 'codesandbox', createdAt: new Date(), metadata: { name: options?.name, bootupType: sandbox.bootupType } };
         } catch (error) {
-          throw new Error(
-            `Failed to create CodeSandbox snapshot: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create CodeSandbox snapshot: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
-
-      list: async (_config: CodesandboxConfig) => {
-        throw new Error(
-          `CodeSandbox provider does not support listing snapshots. Use the dashboard to manage snapshots.`
-        );
-      },
-
+      list: async (_config: CodesandboxConfig) => { throw new Error(`CodeSandbox provider does not support listing snapshots.`); },
       delete: async (config: CodesandboxConfig, snapshotId: string) => {
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.CSB_API_KEY) || '';
-
-        if (!apiKey) {
-          throw new Error(
-            `Missing CodeSandbox API key. Provide 'apiKey' in config or set CSB_API_KEY environment variable.`
-          );
-        }
-
+        if (!apiKey) throw new Error(`Missing CodeSandbox API key.`);
         const sdk = new CodeSandbox(apiKey);
-
-        try {
-          // Shutdown the snapshot (hibernated sandbox)
-          await sdk.sandboxes.shutdown(snapshotId);
-        } catch (error) {
-          // Ignore if not found
-        }
+        try { await sdk.sandboxes.shutdown(snapshotId); } catch { /* ignore */ }
       }
     },
 
-    // Templates in CodeSandbox are handled via templateId on create
     template: {
       create: async (_config: CodesandboxConfig, _options: { name: string }) => {
-        throw new Error(
-          `CodeSandbox templates must be created via the CodeSandbox dashboard or CLI. Use templateId in sandbox.create() to specify a template.`
-        );
+        throw new Error(`CodeSandbox templates must be created via the dashboard.`);
       },
-
-      list: async (_config: CodesandboxConfig) => {
-        throw new Error(
-          `CodeSandbox provider does not support listing templates via API. Use the dashboard to manage templates.`
-        );
-      },
-
-      delete: async (_config: CodesandboxConfig, _templateId: string) => {
-        throw new Error(
-          `CodeSandbox templates must be deleted via the CodeSandbox dashboard or CLI.`
-        );
-      }
+      list: async (_config: CodesandboxConfig) => { throw new Error(`CodeSandbox provider does not support listing templates via API.`); },
+      delete: async (_config: CodesandboxConfig, _templateId: string) => { throw new Error(`CodeSandbox templates must be deleted via the dashboard.`); }
     }
   }
 });

--- a/packages/computesdk/src/__tests__/test-utils.ts
+++ b/packages/computesdk/src/__tests__/test-utils.ts
@@ -5,14 +5,13 @@
  */
 
 import { vi } from 'vitest'
-import type { FileEntry, Runtime, CodeResult, CommandResult } from '../types/index.js'
+import type { FileEntry, CodeResult, CommandResult } from '../types/index.js'
 import type { SandboxInfo } from '../types/index.js'
 
 // Note: Provider and ProviderSandbox are defined in @computesdk/provider (mother package)
 // For testing the grandmother package (computesdk), we create minimal mock interfaces
 interface Provider {
   readonly name: string
-  getSupportedRuntimes(): Runtime[]
   readonly sandbox: {
     create(options?: any): Promise<ProviderSandbox>
     getById(sandboxId: string): Promise<ProviderSandbox | null>
@@ -40,9 +39,6 @@ interface ProviderSandbox {
     remove(path: string): Promise<void>
   }
 }
-
-/** Standard mock runtime support for testing */
-export const MOCK_SUPPORTED_RUNTIMES: Runtime[] = ['node', 'python']
 
 /**
  * Mock sandbox implementation for testing
@@ -78,7 +74,6 @@ export class MockSandbox implements ProviderSandbox {
     return {
       id: this.sandboxId,
       provider: this.provider,
-      runtime: 'node',
       status: 'running',
       createdAt: new Date(),
       timeout: 30000
@@ -102,13 +97,13 @@ export class MockSandbox implements ProviderSandbox {
     async readFile(path: string): Promise<string> {
       return `Mock file content from ${path}`
     },
-    async writeFile(path: string, content: string): Promise<void> {
+    async writeFile(_path: string, _content: string): Promise<void> {
       // Mock implementation
     },
-    async mkdir(path: string): Promise<void> {
+    async mkdir(_path: string): Promise<void> {
       // Mock implementation
     },
-    async readdir(path: string): Promise<FileEntry[]> {
+    async readdir(_path: string): Promise<FileEntry[]> {
       return [
         {
           name: 'test.txt',
@@ -118,15 +113,13 @@ export class MockSandbox implements ProviderSandbox {
         }
       ]
     },
-    async exists(path: string): Promise<boolean> {
+    async exists(_path: string): Promise<boolean> {
       return true
     },
-    async remove(path: string): Promise<void> {
+    async remove(_path: string): Promise<void> {
       // Mock implementation
     }
   }
-
-
 }
 
 /**
@@ -135,17 +128,13 @@ export class MockSandbox implements ProviderSandbox {
 export class MockProvider implements Provider {
   readonly name = 'mock'
 
-  getSupportedRuntimes(): Runtime[] {
-    return MOCK_SUPPORTED_RUNTIMES
-  }
-
   readonly sandbox = {
-    create: async (options?: any): Promise<ProviderSandbox> => {
+    create: async (_options?: any): Promise<ProviderSandbox> => {
       const sandbox = new MockSandbox()
       ;(sandbox as any)._mockProvider = this
       return sandbox
     },
-    getById: async (sandboxId: string): Promise<ProviderSandbox | null> => {
+    getById: async (_sandboxId: string): Promise<ProviderSandbox | null> => {
       const sandbox = new MockSandbox()
       ;(sandbox as any)._mockProvider = this
       return sandbox
@@ -155,7 +144,7 @@ export class MockProvider implements Provider {
       ;(sandbox as any)._mockProvider = this
       return [sandbox]
     },
-    destroy: async (sandboxId: string): Promise<void> => {
+    destroy: async (_sandboxId: string): Promise<void> => {
       // Mock destroy
     }
   }
@@ -168,7 +157,6 @@ export function createMockProvider(overrides?: Partial<Provider>): Provider {
   const mockProvider = new MockProvider()
   return {
     ...mockProvider,
-    getSupportedRuntimes: () => MOCK_SUPPORTED_RUNTIMES,
     ...overrides
   }
 }

--- a/packages/computesdk/src/index.ts
+++ b/packages/computesdk/src/index.ts
@@ -22,7 +22,6 @@
 // so provider-agnostic code has a canonical type name to reference.
 export type {
   Sandbox as SandboxInterface,
-  Runtime,
   CodeResult,
   CommandResult,
   SandboxInfo,

--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -6,11 +6,6 @@
  */
 
 /**
- * Supported runtime environments
- */
-export type Runtime = 'node' | 'python' | 'deno' | 'bun';
-
-/**
  * Code execution result
  */
 export interface CodeResult {
@@ -37,8 +32,6 @@ export interface SandboxInfo {
   id: string;
   /** Provider hosting the sandbox */
   provider: string;
-  /** Runtime environment in the sandbox */
-  runtime: Runtime;
   /** Current status of the sandbox */
   status: 'running' | 'stopped' | 'error';
   /** When the sandbox was created */

--- a/packages/daytona/src/index.ts
+++ b/packages/daytona/src/index.ts
@@ -1,14 +1,11 @@
 /**
  * Daytona Provider - Factory-based Implementation
- * 
- * Code execution only provider using the factory pattern.
- * Reduces ~300 lines of boilerplate to ~80 lines of core logic.
  */
 
 import { Daytona, Sandbox as DaytonaSandbox } from '@daytonaio/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 /**
  * Daytona-specific configuration options
@@ -16,8 +13,8 @@ import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOpti
 export interface DaytonaConfig {
   /** Daytona API key - if not provided, will fallback to DAYTONA_API_KEY environment variable */
   apiKey?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'python', 'node') */
+  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
 }
@@ -29,9 +26,7 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
   name: 'daytona',
   methods: {
     sandbox: {
-      // Collection operations (compute.sandbox.*)
       create: async (config: DaytonaConfig, options?: CreateSandboxOptions) => {
-        // Validate API key
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.DAYTONA_API_KEY) || '';
 
         if (!apiKey) {
@@ -40,19 +35,13 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
           );
         }
 
-        const runtime = options?.runtime || config.runtime || 'node';
+        const runtime = (options as any)?.runtime || config.runtime || 'node';
         const timeout = options?.timeout ?? config.timeout;
 
         try {
-          // Initialize Daytona client
           const daytona = new Daytona({ apiKey: apiKey });
 
-          let session: DaytonaSandbox;
-          let sandboxId: string;
-
-          // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: _runtime,
             timeout: _timeout,
             envs,
             name,
@@ -65,158 +54,106 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
             ...providerOptions
           } = options || {};
 
-            // Build create params from options
-            // Daytona SDK uses envVars (not envs), labels (not metadata)
-            const createParams: Record<string, any> = {
-              language: runtime === 'python' ? 'python' : 'javascript',
-              ...providerOptions, // Spread provider-specific options (e.g., resources, public, autoStopInterval)
-            };
-
-            // Remap ComputeSDK fields to Daytona SDK fields
-            if (envs && Object.keys(envs).length > 0) {
-              createParams.envVars = envs;
-            }
-
-            if (name) {
-              createParams.name = name;
-            }
-
-            // Pass metadata as labels (Daytona uses labels: Record<string, string>)
-            if (metadata && typeof metadata === 'object') {
-              const labels: Record<string, string> = {};
-              for (const [k, v] of Object.entries(metadata)) {
-                labels[k] = typeof v === 'string' ? v : JSON.stringify(v);
-              }
-              createParams.labels = labels;
-            }
-
-            // If templateId or snapshotId is provided, use it as the source
-            const sourceId = templateId || snapshotId;
-            if (sourceId) {
-              createParams.snapshot = sourceId;
-            }
-
-            // Daytona SDK accepts timeout in seconds as a second argument
-            const createOptions = timeout
-              ? { timeout: Math.ceil(timeout / 1000) }
-              : undefined;
-
-          session = await daytona.create(createParams as any, createOptions);
-          sandboxId = session.id;
-
-          return {
-            sandbox: session,
-            sandboxId
+          const createParams: Record<string, any> = {
+            language: runtime === 'python' ? 'python' : 'javascript',
+            ...providerOptions,
           };
+
+          if (envs && Object.keys(envs).length > 0) {
+            createParams.envVars = envs;
+          }
+
+          if (name) {
+            createParams.name = name;
+          }
+
+          if (metadata && typeof metadata === 'object') {
+            const labels: Record<string, string> = {};
+            for (const [k, v] of Object.entries(metadata)) {
+              labels[k] = typeof v === 'string' ? v : JSON.stringify(v);
+            }
+            createParams.labels = labels;
+          }
+
+          const sourceId = templateId || snapshotId;
+          if (sourceId) {
+            createParams.snapshot = sourceId;
+          }
+
+          const createOptions = timeout
+            ? { timeout: Math.ceil(timeout / 1000) }
+            : undefined;
+
+          const session = await daytona.create(createParams as any, createOptions);
+          const sandboxId = session.id;
+
+          return { sandbox: session, sandboxId };
         } catch (error) {
           if (error instanceof Error) {
             if (error.message.includes('unauthorized') || error.message.includes('API key')) {
-              throw new Error(
-                `Daytona authentication failed. Please check your DAYTONA_API_KEY environment variable. Get your API key from https://daytona.io/`
-              );
+              throw new Error(`Daytona authentication failed. Please check your DAYTONA_API_KEY environment variable.`);
             }
             if (error.message.includes('quota') || error.message.includes('limit')) {
-              throw new Error(
-                `Daytona quota exceeded. Please check your usage at https://daytona.io/`
-              );
+              throw new Error(`Daytona quota exceeded. Please check your usage at https://daytona.io/`);
             }
           }
-          throw new Error(
-            `Failed to create Daytona sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create Daytona sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: DaytonaConfig, sandboxId: string) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-
         try {
           const daytona = new Daytona({ apiKey: apiKey });
           const session = await daytona.get(sandboxId);
-
-          return {
-            sandbox: session,
-            sandboxId
-          };
+          return { sandbox: session, sandboxId };
         } catch (error) {
-          // Sandbox not found is expected -- return null per the interface contract
           if (error instanceof Error && (error.message.includes('not found') || error.message.includes('404'))) {
             return null;
           }
-          // Propagate unexpected errors (auth failures, network issues, etc.)
-          throw new Error(
-            `Failed to get Daytona sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get Daytona sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       list: async (config: DaytonaConfig) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-
         try {
           const daytona = new Daytona({ apiKey: apiKey });
           const result = await daytona.list();
-
-          return result.items.map((session: any) => ({
-            sandbox: session,
-            sandboxId: session.id
-          }));
+          return result.items.map((session: any) => ({ sandbox: session, sandboxId: session.id }));
         } catch (error) {
-          throw new Error(
-            `Failed to list Daytona sandboxes: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to list Daytona sandboxes: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       destroy: async (config: DaytonaConfig, sandboxId: string) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-
         try {
           const daytona = new Daytona({ apiKey: apiKey });
           const sandbox = await daytona.get(sandboxId);
           await sandbox.delete();
         } catch (error) {
-          // If the sandbox is already gone (404), that's fine for destroy semantics
           if (error instanceof Error && (error.message.includes('not found') || error.message.includes('404'))) {
             return;
           }
-          // Propagate all other errors (auth failures, network issues, etc.)
-          throw new Error(
-            `Failed to destroy Daytona sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to destroy Daytona sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Instance operations (sandbox.*)
-
       runCommand: async (sandbox: DaytonaSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
-
         try {
-          // Build command with options
           let fullCommand = command;
-          
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
             const envPrefix = Object.entries(options.env)
               .map(([k, v]) => `${k}="${escapeShellArg(v)}"`)
               .join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
-          
-          // Handle working directory
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-          
-          // Handle background execution
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
+          if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
 
-          // Execute command using Daytona's process.executeCommand method
           const response = await sandbox.process.executeCommand(fullCommand);
-
           return {
             stdout: response.result || '',
             stderr: '',
@@ -224,9 +161,7 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
             durationMs: Date.now() - startTime
           };
         } catch (error) {
-          throw new Error(
-            `Daytona command execution failed: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Daytona command execution failed: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
@@ -234,151 +169,80 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
         return {
           id: sandbox.id,
           provider: 'daytona',
-          runtime: 'python', // Daytona default
           status: 'running',
           createdAt: new Date(),
           timeout: 300000,
-          metadata: {
-            daytonaSandboxId: sandbox.id
-          }
+          metadata: { daytonaSandboxId: sandbox.id }
         };
       },
 
       getUrl: async (sandbox: DaytonaSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         try {
-          // Use Daytona's built-in getPreviewLink method
           const previewInfo = await sandbox.getPreviewLink(options.port);
           let url = previewInfo.url;
-          
-          // If a specific protocol is requested, replace the URL's protocol
           if (options.protocol) {
             const urlObj = new URL(url);
             urlObj.protocol = options.protocol + ':';
             url = urlObj.toString();
           }
-          
           return url;
         } catch (error) {
-          throw new Error(
-            `Failed to get Daytona preview URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get Daytona preview URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Filesystem operations via terminal commands
       filesystem: {
         readFile: async (sandbox: DaytonaSandbox, path: string): Promise<string> => {
-          try {
-            const response = await sandbox.process.executeCommand(`cat "${path}"`);
-            if (response.exitCode !== 0) {
-              throw new Error(`File not found or cannot be read: ${path}`);
-            }
-            return response.result || '';
-          } catch (error) {
-            throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const response = await sandbox.process.executeCommand(`cat "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`File not found or cannot be read: ${path}`);
+          return response.result || '';
         },
-
         writeFile: async (sandbox: DaytonaSandbox, path: string, content: string): Promise<void> => {
-          try {
-            // Use base64 encoding to safely handle special characters, newlines, and binary content
-            const encoded = Buffer.from(content).toString('base64');
-            const response = await sandbox.process.executeCommand(`echo "${encoded}" | base64 -d > "${path}"`);
-            if (response.exitCode !== 0) {
-              throw new Error(`Failed to write to file: ${path}`);
-            }
-          } catch (error) {
-            throw new Error(`Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const encoded = Buffer.from(content).toString('base64');
+          const response = await sandbox.process.executeCommand(`echo "${encoded}" | base64 -d > "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`Failed to write to file: ${path}`);
         },
-
         mkdir: async (sandbox: DaytonaSandbox, path: string): Promise<void> => {
-          try {
-            const response = await sandbox.process.executeCommand(`mkdir -p "${path}"`);
-            if (response.exitCode !== 0) {
-              throw new Error(`Failed to create directory: ${path}`);
-            }
-          } catch (error) {
-            throw new Error(`Failed to create directory ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const response = await sandbox.process.executeCommand(`mkdir -p "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`Failed to create directory: ${path}`);
         },
-
         readdir: async (sandbox: DaytonaSandbox, path: string): Promise<FileEntry[]> => {
-          try {
-            const response = await sandbox.process.executeCommand(`ls -la "${path}"`);
-            if (response.exitCode !== 0) {
-              throw new Error(`Directory not found or cannot be read: ${path}`);
+          const response = await sandbox.process.executeCommand(`ls -la "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`Directory not found or cannot be read: ${path}`);
+          const lines = response.result.split('\n').filter((l: string) => l.trim());
+          const entries: FileEntry[] = [];
+          for (const line of lines) {
+            if (line.startsWith('total ') || line.endsWith(' .') || line.endsWith(' ..')) continue;
+            const parts = line.trim().split(/\s+/);
+            if (parts.length >= 9) {
+              entries.push({
+                name: parts.slice(8).join(' '),
+                type: parts[0].startsWith('d') ? 'directory' as const : 'file' as const,
+                size: parseInt(parts[4]) || 0,
+                modified: new Date()
+              });
             }
-
-            // Parse ls -la output into FileEntry objects
-            const lines = response.result.split('\n').filter(line => line.trim());
-            const entries: FileEntry[] = [];
-
-            for (const line of lines) {
-              // Skip total line and current/parent directory entries
-              if (line.startsWith('total ') || line.endsWith(' .') || line.endsWith(' ..')) {
-                continue;
-              }
-
-              // Parse ls -la format: permissions links owner group size date time name
-              const parts = line.trim().split(/\s+/);
-              if (parts.length >= 9) {
-                const permissions = parts[0];
-                const name = parts.slice(8).join(' '); // Handle filenames with spaces
-                const isDirectory = permissions.startsWith('d');
-                const size = parseInt(parts[4]) || 0;
-
-                entries.push({
-                  name,
-                  type: isDirectory ? 'directory' as const : 'file' as const,
-                  size,
-                  modified: new Date() // ls -la date parsing is complex, use current time
-                });
-              }
-            }
-
-            return entries;
-          } catch (error) {
-            throw new Error(`Failed to read directory ${path}: ${error instanceof Error ? error.message : String(error)}`);
           }
+          return entries;
         },
-
         exists: async (sandbox: DaytonaSandbox, path: string): Promise<boolean> => {
-          try {
-            const response = await sandbox.process.executeCommand(`test -e "${path}"`);
-            return response.exitCode === 0;
-          } catch (error) {
-            // If command execution fails, assume file doesn't exist
-            return false;
-          }
+          const response = await sandbox.process.executeCommand(`test -e "${path}"`);
+          return response.exitCode === 0;
         },
-
         remove: async (sandbox: DaytonaSandbox, path: string): Promise<void> => {
-          try {
-            const response = await sandbox.process.executeCommand(`rm -rf "${path}"`);
-            if (response.exitCode !== 0) {
-              throw new Error(`Failed to remove: ${path}`);
-            }
-          } catch (error) {
-            throw new Error(`Failed to remove ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const response = await sandbox.process.executeCommand(`rm -rf "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`Failed to remove: ${path}`);
         }
       },
 
-      // Provider-specific typed getInstance method
-      getInstance: (sandbox: DaytonaSandbox): DaytonaSandbox => {
-        return sandbox;
-      },
-
+      getInstance: (sandbox: DaytonaSandbox): DaytonaSandbox => sandbox,
     },
 
     snapshot: {
       create: async (config: DaytonaConfig, sandboxId: string, options?: { name?: string }) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         const daytona = new Daytona({ apiKey: apiKey });
-
         try {
-          // Note: Using 'any' cast as we are using internal service property
           const snapshot = await (daytona as any).snapshots.create({
             workspaceId: sandboxId,
             name: options?.name || `snapshot-${Date.now()}`
@@ -388,60 +252,31 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
           throw new Error(`Failed to create Daytona snapshot: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
-
       list: async (config: DaytonaConfig) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         const daytona = new Daytona({ apiKey: apiKey });
-
-        try {
-          const result = await (daytona as any).snapshots.list();
-          return result;
-        } catch (error) {
-          return [];
-        }
+        try { return await (daytona as any).snapshots.list(); } catch { return []; }
       },
-
       delete: async (config: DaytonaConfig, snapshotId: string) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         const daytona = new Daytona({ apiKey: apiKey });
-
-        try {
-          // Note: Daytona SDK might not expose delete directly or it might be 'remove'
-          // We'll try the common pattern
-          await (daytona as any).snapshots.delete(snapshotId);
-        } catch (error) {
-          // Ignore if not found
-        }
+        try { await (daytona as any).snapshots.delete(snapshotId); } catch { /* ignore */ }
       }
     },
 
-    // Templates in Daytona are effectively Snapshots
     template: {
-      create: async (config: DaytonaConfig, options: { name: string }) => {
-         throw new Error('To create a template in Daytona, create a snapshot from a running sandbox using snapshot.create()');
+      create: async (_config: DaytonaConfig, _options: { name: string }) => {
+        throw new Error('To create a template in Daytona, create a snapshot from a running sandbox using snapshot.create()');
       },
-
       list: async (config: DaytonaConfig) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         const daytona = new Daytona({ apiKey: apiKey });
-
-        try {
-          const result = await (daytona as any).snapshots.list();
-          return result;
-        } catch (error) {
-          return [];
-        }
+        try { return await (daytona as any).snapshots.list(); } catch { return []; }
       },
-
       delete: async (config: DaytonaConfig, templateId: string) => {
         const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         const daytona = new Daytona({ apiKey: apiKey });
-
-        try {
-          await (daytona as any).snapshots.delete(templateId);
-        } catch (error) {
-          // Ignore if not found
-        }
+        try { await (daytona as any).snapshots.delete(templateId); } catch { /* ignore */ }
       }
     }
   }

--- a/packages/declaw/src/index.ts
+++ b/packages/declaw/src/index.ts
@@ -11,7 +11,6 @@ import { Sandbox as DeclawSandbox } from '@declaw/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type {
-  Runtime,
   CommandResult,
   SandboxInfo,
   CreateSandboxOptions,
@@ -27,8 +26,8 @@ export interface DeclawConfig {
   apiKey?: string;
   /** API domain, e.g. `api.declaw.ai`. Falls back to `DECLAW_DOMAIN` env var. */
   domain?: string;
-  /** Default runtime environment. */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'node', 'python'). */
+  runtime?: string;
   /** Default create-time timeout in milliseconds. */
   timeout?: number;
 }
@@ -75,7 +74,6 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
         // Declaw-specific options (security policies, network policies, etc.)
         // without accidentally shadowing them.
         const {
-          runtime: _runtime,
           timeout: requestedTimeoutMs,
           envs,
           name: _name,
@@ -233,7 +231,6 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
         return {
           id,
           provider: 'declaw',
-          runtime: 'node',
           status: 'running',
           createdAt: new Date(),
           timeout: 300_000,

--- a/packages/declaw/src/index.ts
+++ b/packages/declaw/src/index.ts
@@ -2,9 +2,6 @@
  * Declaw Provider
  *
  * Wraps `@declaw/sdk` to expose the ComputeSDK provider interface.
- * Declaw runs Firecracker microVMs with a built-in security stack
- * (PII scanning, prompt-injection defense, TLS-intercepting egress
- * proxy, per-sandbox policies).
  */
 
 import { Sandbox as DeclawSandbox } from '@declaw/sdk';
@@ -18,51 +15,29 @@ import type {
   RunCommandOptions,
 } from '@computesdk/provider';
 
-/**
- * Declaw-specific configuration options.
- */
 export interface DeclawConfig {
   /** Declaw API key. Falls back to `DECLAW_API_KEY` env var. */
   apiKey?: string;
   /** API domain, e.g. `api.declaw.ai`. Falls back to `DECLAW_DOMAIN` env var. */
   domain?: string;
-  /** Default runtime environment (e.g. 'node', 'python'). */
-  runtime?: string;
   /** Default create-time timeout in milliseconds. */
   timeout?: number;
 }
 
-/**
- * Create a Declaw provider instance.
- *
- * @example
- * ```ts
- * import { declaw } from '@computesdk/declaw';
- * const compute = declaw({ apiKey: process.env.DECLAW_API_KEY });
- * const sandbox = await compute.sandbox.create();
- * await sandbox.runCommand('node -v');
- * await sandbox.destroy();
- * ```
- */
 export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
   name: 'declaw',
   methods: {
     sandbox: {
-      // Collection operations
       create: async (config: DeclawConfig, options?: CreateSandboxOptions) => {
         const apiKey =
           config.apiKey ||
           (typeof process !== 'undefined' && process.env?.DECLAW_API_KEY) ||
           '';
         if (!apiKey) {
-          throw new Error(
-            `Missing Declaw API key. Provide 'apiKey' in config or set DECLAW_API_KEY. Get a key at https://declaw.ai/`,
-          );
+          throw new Error(`Missing Declaw API key. Provide 'apiKey' in config or set DECLAW_API_KEY.`);
         }
         if (!apiKey.startsWith('dcl_')) {
-          throw new Error(
-            `Invalid Declaw API key format. Keys should start with 'dcl_'.`,
-          );
+          throw new Error(`Invalid Declaw API key format. Keys should start with 'dcl_'.`);
         }
 
         const domain =
@@ -70,9 +45,6 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
           (typeof process !== 'undefined' && process.env?.DECLAW_DOMAIN) ||
           undefined;
 
-        // Destructure known ComputeSDK fields so we can forward the rest as
-        // Declaw-specific options (security policies, network policies, etc.)
-        // without accidentally shadowing them.
         const {
           timeout: requestedTimeoutMs,
           envs,
@@ -84,52 +56,31 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
           ...providerOptions
         } = options || {};
 
-        // Declaw `timeout` is seconds; ComputeSDK passes ms.
         const ttMs = requestedTimeoutMs ?? config.timeout ?? 300_000;
         const timeoutSec = Math.max(1, Math.ceil(ttMs / 1000));
-
-        // Declaw default template alias `base` carries a minimal Linux rootfs;
-        // `node` includes Node.js 20 for ComputeSDK's `node -v` health check.
-        // Callers can override via `templateId`.
         const template = templateId || 'node';
 
         try {
           const sandbox = await DeclawSandbox.create({
-            template,
-            timeout: timeoutSec,
-            apiKey,
-            domain,
-            metadata,
-            envs,
-            ...providerOptions,
+            template, timeout: timeoutSec, apiKey, domain, metadata, envs, ...providerOptions,
           });
           const sandboxId = (sandbox as any).sandboxId ?? (sandbox as any).sandbox_id;
-          if (!sandboxId) {
-            throw new Error('Declaw create() returned sandbox without an ID');
-          }
+          if (!sandboxId) throw new Error('Declaw create() returned sandbox without an ID');
           return { sandbox, sandboxId };
         } catch (error) {
           if (error instanceof Error) {
             const msg = error.message.toLowerCase();
             if (msg.includes('unauthorized') || msg.includes('api key') || msg.includes('401')) {
-              throw new Error(
-                `Declaw authentication failed. Check your DECLAW_API_KEY. Get a key at https://declaw.ai/`,
-              );
+              throw new Error(`Declaw authentication failed. Check your DECLAW_API_KEY.`);
             }
             if (msg.includes('402') || msg.includes('insufficient balance')) {
-              throw new Error(
-                `Declaw wallet balance is insufficient. Top up at https://declaw.ai/`,
-              );
+              throw new Error(`Declaw wallet balance is insufficient. Top up at https://declaw.ai/`);
             }
             if (msg.includes('429') || msg.includes('concurrent') || msg.includes('rate limit')) {
-              throw new Error(
-                `Declaw concurrency/rate limit reached: ${error.message}`,
-              );
+              throw new Error(`Declaw concurrency/rate limit reached: ${error.message}`);
             }
           }
-          throw new Error(
-            `Failed to create Declaw sandbox: ${error instanceof Error ? error.message : String(error)}`,
-          );
+          throw new Error(`Failed to create Declaw sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
@@ -139,9 +90,7 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
         try {
           const sandbox = await DeclawSandbox.connect(sandboxId, { apiKey, domain });
           return { sandbox, sandboxId };
-        } catch {
-          return null;
-        }
+        } catch { return null; }
       },
 
       list: async (config: DeclawConfig) => {
@@ -157,14 +106,10 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
             try {
               const sandbox = await DeclawSandbox.connect(id, { apiKey, domain });
               out.push({ sandbox, sandboxId: id });
-            } catch {
-              // Skip rows that are already dead or no longer reachable.
-            }
+            } catch { /* skip */ }
           }
           return out;
-        } catch {
-          return [];
-        }
+        } catch { return []; }
       },
 
       destroy: async (config: DeclawConfig, sandboxId: string) => {
@@ -173,115 +118,59 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
         try {
           const sandbox = await DeclawSandbox.connect(sandboxId, { apiKey, domain });
           await sandbox.kill();
-        } catch {
-          // Idempotent: sandbox may already be gone.
-        }
+        } catch { /* idempotent */ }
       },
 
-      runCommand: async (
-        sandbox: DeclawSandbox,
-        command: string,
-        options?: RunCommandOptions,
-      ): Promise<CommandResult> => {
+      runCommand: async (sandbox: DeclawSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
-
         let fullCommand = command;
         if (options?.env && Object.keys(options.env).length > 0) {
-          const envPrefix = Object.entries(options.env)
-            .map(([k, v]) => `${k}="${escapeShellArg(v)}"`)
-            .join(' ');
+          const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(v)}"`).join(' ');
           fullCommand = `${envPrefix} ${fullCommand}`;
         }
-        if (options?.cwd) {
-          fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-        }
-        if (options?.background) {
-          fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-        }
+        if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+        if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
 
         try {
           const result = await sandbox.commands.run(fullCommand);
-          return {
-            stdout: result.stdout,
-            stderr: result.stderr,
-            exitCode: result.exitCode,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode, durationMs: Date.now() - startTime };
         } catch (error) {
           const wrapped: any = (error as any)?.result;
-          if (wrapped) {
-            return {
-              stdout: wrapped.stdout || '',
-              stderr: wrapped.stderr || '',
-              exitCode: wrapped.exitCode ?? 1,
-              durationMs: Date.now() - startTime,
-            };
-          }
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          if (wrapped) return { stdout: wrapped.stdout || '', stderr: wrapped.stderr || '', exitCode: wrapped.exitCode ?? 1, durationMs: Date.now() - startTime };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
       getInfo: async (sandbox: DeclawSandbox): Promise<SandboxInfo> => {
         const id = (sandbox as any).sandboxId ?? (sandbox as any).sandbox_id ?? 'declaw-unknown';
-        return {
-          id,
-          provider: 'declaw',
-          status: 'running',
-          createdAt: new Date(),
-          timeout: 300_000,
-          metadata: { declawSandboxId: id },
-        };
+        return { id, provider: 'declaw', status: 'running', createdAt: new Date(), timeout: 300_000, metadata: { declawSandboxId: id } };
       },
 
-      getUrl: async (
-        sandbox: DeclawSandbox,
-        options: { port: number; protocol?: string },
-      ): Promise<string> => {
+      getUrl: async (sandbox: DeclawSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         try {
           const host = (sandbox as any).getHost(options.port);
           const protocol = options.protocol || 'https';
           return `${protocol}://${host}`;
         } catch (error) {
-          throw new Error(
-            `Failed to get Declaw host for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`,
-          );
+          throw new Error(`Failed to get Declaw host for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Filesystem support maps to @declaw/sdk's Filesystem module.
       filesystem: {
-        readFile: async (sandbox: DeclawSandbox, path: string): Promise<string> => {
-          return await (sandbox as any).files.read(path);
-        },
-        writeFile: async (sandbox: DeclawSandbox, path: string, content: string): Promise<void> => {
-          await (sandbox as any).files.write(path, content);
-        },
-        mkdir: async (sandbox: DeclawSandbox, path: string): Promise<void> => {
-          await (sandbox as any).files.makeDir(path);
-        },
+        readFile: async (sandbox: DeclawSandbox, path: string): Promise<string> => (sandbox as any).files.read(path),
+        writeFile: async (sandbox: DeclawSandbox, path: string, content: string): Promise<void> => { await (sandbox as any).files.write(path, content); },
+        mkdir: async (sandbox: DeclawSandbox, path: string): Promise<void> => { await (sandbox as any).files.makeDir(path); },
         readdir: async (sandbox: DeclawSandbox, path: string): Promise<FileEntry[]> => {
           const entries = await (sandbox as any).files.list(path);
           return entries.map((entry: any) => ({
             name: entry.name,
-            type:
-              entry.isDir || entry.isDirectory || entry.type === 'directory'
-                ? ('directory' as const)
-                : ('file' as const),
+            type: entry.isDir || entry.isDirectory || entry.type === 'directory' ? 'directory' as const : 'file' as const,
             size: entry.size ?? 0,
             modified: new Date(entry.lastModified ?? entry.modified ?? Date.now()),
           }));
         },
-        exists: async (sandbox: DeclawSandbox, path: string): Promise<boolean> => {
-          return await (sandbox as any).files.exists(path);
-        },
-        remove: async (sandbox: DeclawSandbox, path: string): Promise<void> => {
-          await (sandbox as any).files.remove(path);
-        },
+        exists: async (sandbox: DeclawSandbox, path: string): Promise<boolean> => (sandbox as any).files.exists(path),
+        remove: async (sandbox: DeclawSandbox, path: string): Promise<void> => { await (sandbox as any).files.remove(path); },
       },
     },
   },

--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -2,8 +2,6 @@ import Docker from 'dockerode';
 import { PassThrough } from 'stream';
 import { defineProvider } from '@computesdk/provider';
 import type {
-  Runtime,
-  CodeResult,
   CommandResult,
   RunCommandOptions,
   CreateSandboxOptions,
@@ -31,10 +29,8 @@ function pick<T>(val: T | undefined, fallback: T): T {
 async function ensureImage(docker: Docker, image: DockerImage): Promise<void> {
   const policy = image.pullPolicy ?? 'ifNotPresent';
   if (policy === 'never') return;
-
   const images = await docker.listImages();
   const hasImage = images.some(img => (img.RepoTags || []).includes(image.name));
-
   if (policy === 'always' || (policy === 'ifNotPresent' && !hasImage)) {
     await new Promise<void>((resolve, reject) => {
       const cb = (err: any, stream?: NodeJS.ReadableStream) => {
@@ -54,7 +50,6 @@ async function waitUntilRunning(container: Docker.Container, timeoutMs = 4000) {
     const s = await container.inspect();
     if (s.State?.Running) return;
   } catch { /* ignore */ }
-
   while (Date.now() - start < timeoutMs) {
     const s = await container.inspect();
     if (s.State?.Running) return;
@@ -69,19 +64,15 @@ async function runExec(
   attachTTY = false
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   await waitUntilRunning(handle.container);
-
   const exec = await handle.container.exec({
     Cmd: ['/bin/sh', '-c', shellCommand],
     AttachStdout: true,
     AttachStderr: true,
     Tty: attachTTY,
   });
-
   const stream = (await exec.start({ hijack: true, stdin: false })) as NodeJS.ReadableStream;
-
   let stdout = '';
   let stderr = '';
-
   await new Promise<void>((resolve, reject) => {
     if (attachTTY) {
       stream.on('data', (chunk: Buffer) => (stdout += chunk.toString('utf8')));
@@ -97,10 +88,8 @@ async function runExec(
     stream.on('end', resolve);
     stream.on('error', reject);
   });
-
   const inspect = await exec.inspect();
-  const exitCode = inspect.ExitCode ?? 0;
-  return { stdout, stderr, exitCode };
+  return { stdout, stderr, exitCode: inspect.ExitCode ?? 0 };
 }
 
 function toHostBindings(ports?: PortBindings) {
@@ -109,10 +98,7 @@ function toHostBindings(ports?: PortBindings) {
   const bindings: Record<string, Array<{ HostPort?: string; HostIp?: string }>> = {};
   for (const key of Object.keys(ports)) {
     exposed[key] = {};
-    bindings[key] = (ports as any)[key].map((p: any) => ({
-      HostPort: p.hostPort ? String(p.hostPort) : undefined,
-      HostIp: p.hostIP,
-    }));
+    bindings[key] = (ports as any)[key].map((p: any) => ({ HostPort: p.hostPort ? String(p.hostPort) : undefined, HostIp: p.hostIP }));
   }
   return { ExposedPorts: exposed, PortBindings: bindings };
 }
@@ -120,16 +106,12 @@ function toHostBindings(ports?: PortBindings) {
 function dockerHostNameFromEnv(): string {
   const hostEnv = process.env.DOCKER_HOST;
   if (hostEnv?.startsWith('tcp://')) {
-    try {
-      const u = new URL(hostEnv);
-      return u.hostname || 'localhost';
-    } catch { /* noop */ }
+    try { return new URL(hostEnv).hostname || 'localhost'; } catch { /* noop */ }
   }
   return 'localhost';
 }
 
-function pickImageForRuntime(runtime: Runtime, configured?: DockerImage): DockerImage {
-  // If user supplied an image that already matches, use it. Otherwise pick a sensible default.
+function pickImageForRuntime(runtime: string, configured?: DockerImage): DockerImage {
   if (configured?.name) {
     if (runtime === 'python' && /python|conda|pypy/i.test(configured.name)) return configured;
     if (runtime === 'node' && /node/i.test(configured.name)) return configured;
@@ -147,30 +129,23 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
     sandbox: {
       create: async (config: DockerConfig, options?: CreateSandboxOptions) => {
         const cfg: DockerConfig = { ...defaultDockerConfig, ...config };
-        const effectiveRuntime: Runtime = (options?.runtime ?? cfg.runtime ?? 'python') as Runtime;
+        const effectiveRuntime: string = ((options as any)?.runtime ?? cfg.runtime ?? 'python') as string;
 
         if (effectiveRuntime !== 'python' && effectiveRuntime !== 'node') {
           throw new Error(`Docker provider supports only 'python' or 'node'. Received: ${String(effectiveRuntime)}`);
         }
 
         const docker = new Docker(cfg.connection as any);
-
-        // Choose image based on runtime if needed
         const chosenImage = pickImageForRuntime(effectiveRuntime, cfg.image);
         await ensureImage(docker, chosenImage);
 
-        // Merge environment variables: config.container.env < options.envs
         const mergedEnv = { ...cfg.container?.env, ...options?.envs };
-
-        // Build container create options
         const hb = toHostBindings(cfg.container?.ports);
         const createOptions = {
           Image: chosenImage.name,
           Tty: pick(cfg.container?.tty, false),
           OpenStdin: pick(cfg.container?.openStdin, false),
           Labels: {
-            // User metadata is spread first with a namespaced prefix so it
-            // cannot overwrite the reserved discovery/runtime labels below.
             ...(options?.metadata ? Object.fromEntries(
               Object.entries(options.metadata).map(([k, v]) => [`com.computesdk.meta.${k}`, typeof v === 'string' ? v : JSON.stringify(v)])
             ) : {}),
@@ -181,9 +156,9 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
           Env: Object.keys(mergedEnv).length > 0
             ? Object.entries(mergedEnv).map(([k, v]) => `${k}=${v}`)
             : undefined,
-          Cmd: KEEPALIVE_CMD, // keep container alive
+          Cmd: KEEPALIVE_CMD,
           HostConfig: {
-            AutoRemove: cfg.container?.autoRemove ?? false, // keep around for exec/FS ops
+            AutoRemove: cfg.container?.autoRemove ?? false,
             Binds: cfg.container?.binds,
             NetworkMode: cfg.container?.networkMode,
             Privileged: cfg.container?.privileged,
@@ -193,24 +168,12 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
               ? { Type: cfg.container.logDriver, Config: cfg.container.logOpts || {} }
               : undefined,
             Resources: cfg.container?.resources,
-            DeviceRequests: cfg.container?.gpus
-              ? [
-                {
-                  Driver: 'nvidia',
-                  Count:
-                    cfg.container.gpus === 'all'
-                      ? -1
-                      : typeof cfg.container.gpus === 'number'
-                        ? cfg.container.gpus
-                        : 1,
-                  DeviceIDs:
-                    typeof cfg.container.gpus === 'string' && cfg.container.gpus !== 'all'
-                      ? [String(cfg.container.gpus)]
-                      : undefined,
-                  Capabilities: [['gpu']],
-                },
-              ]
-              : undefined,
+            DeviceRequests: cfg.container?.gpus ? [{
+              Driver: 'nvidia',
+              Count: cfg.container.gpus === 'all' ? -1 : typeof cfg.container.gpus === 'number' ? cfg.container.gpus : 1,
+              DeviceIDs: typeof cfg.container.gpus === 'string' && cfg.container.gpus !== 'all' ? [String(cfg.container.gpus)] : undefined,
+              Capabilities: [['gpu']],
+            }] : undefined,
             ...(hb ? { PortBindings: hb.PortBindings } : {}),
           },
           ...(hb ? { ExposedPorts: hb.ExposedPorts } : {}),
@@ -220,16 +183,12 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
         const container = await docker.createContainer(createOptions);
         await container.start(cfg.startOptions || {});
         await waitUntilRunning(container);
-
         const inspect = await container.inspect();
         const handle: DockerSandboxHandle = {
-          docker,
-          container,
-          containerId: inspect.Id,
+          docker, container, containerId: inspect.Id,
           image: inspect.Config?.Image ?? chosenImage.name,
           createdAt: new Date(inspect.Created || Date.now()),
         };
-
         return { sandbox: handle, sandboxId: handle.containerId };
       },
 
@@ -238,41 +197,19 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
         try {
           const container = docker.getContainer(sandboxId);
           const info = await container.inspect();
-          return {
-            sandbox: <DockerSandboxHandle>{
-              docker,
-              container,
-              containerId: sandboxId,
-              image: info.Config?.Image ?? '',
-              createdAt: new Date(info.Created || Date.now()),
-            },
-            sandboxId,
-          };
-        } catch {
-          return null;
-        }
+          return { sandbox: { docker, container, containerId: sandboxId, image: info.Config?.Image ?? '', createdAt: new Date(info.Created || Date.now()) } as DockerSandboxHandle, sandboxId };
+        } catch { return null; }
       },
 
       list: async (config: DockerConfig) => {
         const docker = new Docker((config || defaultDockerConfig).connection as any);
         try {
-          const items = await docker.listContainers({
-            all: true,
-            filters: { label: [LABEL_KEY] } as any,
-          });
+          const items = await docker.listContainers({ all: true, filters: { label: [LABEL_KEY] } as any });
           return items.map(ci => ({
-            sandbox: <DockerSandboxHandle>{
-              docker,
-              container: docker.getContainer(ci.Id),
-              containerId: ci.Id,
-              image: ci.Image,
-              createdAt: new Date((ci as any).Created * 1000),
-            },
+            sandbox: { docker, container: docker.getContainer(ci.Id), containerId: ci.Id, image: ci.Image, createdAt: new Date((ci as any).Created * 1000) } as DockerSandboxHandle,
             sandboxId: ci.Id,
           }));
-        } catch {
-          return [];
-        }
+        } catch { return []; }
       },
 
       destroy: async (config: DockerConfig, sandboxId: string) => {
@@ -281,26 +218,13 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
           const c = docker.getContainer(sandboxId);
           try { await c.stop({ t: 5 } as any); } catch { /* stopped */ }
           await c.remove({ force: true });
-        } catch {
-          // ok if already gone
-        }
+        } catch { /* ok if already gone */ }
       },
 
-      runCommand: async (
-        handle: DockerSandboxHandle,
-        command: string,
-        options?: RunCommandOptions
-      ): Promise<CommandResult> => {
+      runCommand: async (handle: DockerSandboxHandle, command: string, _options?: RunCommandOptions): Promise<CommandResult> => {
         const start = Date.now();
-
         const { stdout, stderr, exitCode } = await runExec(handle, command);
-
-        return {
-          stdout,
-          stderr,
-          exitCode,
-          durationMs: Date.now() - start,
-        };
+        return { stdout, stderr, exitCode, durationMs: Date.now() - start };
       },
 
       getInfo: async (handle: DockerSandboxHandle): Promise<SandboxInfo> => {
@@ -309,13 +233,13 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
         return {
           id: handle.containerId,
           provider: PROVIDER,
-          runtime: (info.Config?.Labels?.[LABEL_RUNTIME] as Runtime) || 'python',
           status: state.Running ? 'running' : 'stopped',
           createdAt: new Date(info.Created || handle.createdAt),
           timeout: 300000,
           metadata: {
             image: info.Config?.Image,
             name: info.Name,
+            runtime: info.Config?.Labels?.[LABEL_RUNTIME],
           },
         };
       },
@@ -324,22 +248,16 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
         const info = await handle.container.inspect();
         const protocol = options.protocol || 'http';
         const portKeyTcp = `${options.port}/tcp`;
-
         const ports = info.NetworkSettings?.Ports || {};
         const bindings = ports[portKeyTcp] || ports[`${options.port}/udp`] || [];
-
         let host = dockerHostNameFromEnv();
         let hostPort = String(options.port);
-
         if (Array.isArray(bindings) && bindings.length > 0) {
           hostPort = bindings[0].HostPort || hostPort;
         } else {
-          const ip =
-            info.NetworkSettings?.IPAddress ||
-            Object.values(info.NetworkSettings?.Networks || {})[0]?.IPAddress;
+          const ip = info.NetworkSettings?.IPAddress || Object.values(info.NetworkSettings?.Networks || {})[0]?.IPAddress;
           if (ip) host = ip;
         }
-
         return `${protocol}://${host}:${hostPort}`;
       },
 
@@ -350,26 +268,19 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
           if (exitCode !== 0) throw new Error(stderr || `File not found: ${path}`);
           return Buffer.from(stdout, 'base64').toString('utf8');
         },
-
         writeFile: async (handle: DockerSandboxHandle, path: string, content: string): Promise<void> => {
           const b64 = Buffer.from(content, 'utf8').toString('base64');
           const cmd = `mkdir -p $(dirname ${JSON.stringify(path)}) && echo "${b64}" | base64 -d > ${JSON.stringify(path)}`;
           const { exitCode, stderr } = await runExec(handle, cmd);
           if (exitCode !== 0) throw new Error(stderr || `Failed to write: ${path}`);
         },
-
         mkdir: async (handle: DockerSandboxHandle, path: string): Promise<void> => {
           const { exitCode, stderr } = await runExec(handle, `mkdir -p ${JSON.stringify(path)}`);
           if (exitCode !== 0) throw new Error(stderr || `Failed to mkdir: ${path}`);
         },
-
         readdir: async (handle: DockerSandboxHandle, path: string): Promise<FileEntry[]> => {
-          const { stdout, exitCode, stderr } = await runExec(
-            handle,
-            `if [ -d ${JSON.stringify(path)} ]; then ls -la ${JSON.stringify(path)}; else exit 1; fi`
-          );
+          const { stdout, exitCode, stderr } = await runExec(handle, `if [ -d ${JSON.stringify(path)} ]; then ls -la ${JSON.stringify(path)}; else exit 1; fi`);
           if (exitCode !== 0) throw new Error(stderr || `Not a directory: ${path}`);
-
           const lines = stdout.split('\n').slice(1);
           const entries: FileEntry[] = [];
           for (const line of lines) {
@@ -377,23 +288,14 @@ export const docker = defineProvider<DockerSandboxHandle, DockerConfig>({
             if (parts.length < 9) continue;
             const name = parts.slice(8).join(' ');
             if (name === '.' || name === '..') continue;
-            const isDir = parts[0].startsWith('d');
-            const size = Number(parts[4]) || 0;
-            entries.push({
-              name,
-              type: isDir ? 'directory' as const : 'file' as const,
-              size,
-              modified: new Date(),
-            });
+            entries.push({ name, type: parts[0].startsWith('d') ? 'directory' as const : 'file' as const, size: Number(parts[4]) || 0, modified: new Date() });
           }
           return entries;
         },
-
         exists: async (handle: DockerSandboxHandle, path: string): Promise<boolean> => {
           const { exitCode } = await runExec(handle, `test -e ${JSON.stringify(path)}`);
           return exitCode === 0;
         },
-
         remove: async (handle: DockerSandboxHandle, path: string): Promise<void> => {
           const { exitCode, stderr } = await runExec(handle, `rm -rf ${JSON.stringify(path)}`);
           if (exitCode !== 0) throw new Error(stderr || `Failed to remove: ${path}`);

--- a/packages/docker/src/types/types.ts
+++ b/packages/docker/src/types/types.ts
@@ -13,7 +13,6 @@ import type {
 } from 'dockerode';
 
 import type {
-  Runtime,
   FileEntry,
   RunCommandOptions,
   CreateSandboxOptions,
@@ -62,7 +61,7 @@ export interface ResourceLimits {
   pidsLimit?: number;
 }
 
-/** Declarative container defaults that we’ll translate into dockerode create options */
+/** Declarative container defaults that we'll translate into dockerode create options */
 export interface ContainerDefaults {
   user?: string;
   workdir?: string;
@@ -84,7 +83,8 @@ export interface ContainerDefaults {
 /** Provider-level configuration for Docker */
 export interface DockerConfig {
   connection?: DockerConnection;
-  runtime?: Runtime; // 'python' | 'node'
+  /** Default image runtime identifier, e.g. 'python' or 'node' */
+  runtime?: string;
   timeout?: number;
   image: DockerImage;
   container?: ContainerDefaults;

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -8,7 +8,7 @@
 import { Sandbox as E2BSandbox } from 'e2b';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Runtime, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 type E2BExecutionResult = { stdout?: string; stderr?: string; exitCode?: number };
 type E2BFileEntry = {
@@ -33,8 +33,8 @@ type E2BSandboxStatics = typeof E2BSandbox & {
 export interface E2BConfig {
   /** E2B API key - if not provided, will fallback to E2B_API_KEY environment variable */
   apiKey?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'node', 'python') */
+  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
 }
@@ -76,7 +76,6 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
 
           // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: _runtime,
             timeout: _timeout,
             envs,
             name: _name,
@@ -251,7 +250,6 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
         return {
           id: sandbox.sandboxId || 'e2b-unknown',
           provider: 'e2b',
-          runtime: 'python', // E2B default
           status: 'running',
           createdAt: new Date(),
           timeout: 300000,

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -1,8 +1,5 @@
 /**
  * E2B Provider - Factory-based Implementation
- * 
- * Full-featured provider with filesystem support using the factory pattern.
- * Reduces ~400 lines of boilerplate to ~100 lines of core logic.
  */
 
 import { Sandbox as E2BSandbox } from 'e2b';
@@ -27,268 +24,137 @@ type E2BSandboxStatics = typeof E2BSandbox & {
   deleteTemplate?: (snapshotId: string, options: { apiKey?: string }) => Promise<unknown>;
 };
 
-/**
- * E2B-specific configuration options
- */
 export interface E2BConfig {
   /** E2B API key - if not provided, will fallback to E2B_API_KEY environment variable */
   apiKey?: string;
-  /** Default runtime environment (e.g. 'node', 'python') */
-  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
 }
 
-
-
-/**
- * Create an E2B provider instance using the factory pattern
- */
 export const e2b = defineProvider<E2BSandbox, E2BConfig>({
   name: 'e2b',
   methods: {
     sandbox: {
-      // Collection operations (map to compute.sandbox.*)
       create: async (config: E2BConfig, options?: CreateSandboxOptions) => {
-        // Validate API key
         const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.E2B_API_KEY) || '';
 
         if (!apiKey) {
-          throw new Error(
-            `Missing E2B API key. Provide 'apiKey' in config or set E2B_API_KEY environment variable. Get your API key from https://e2b.dev/`
-          );
+          throw new Error(`Missing E2B API key. Provide 'apiKey' in config or set E2B_API_KEY environment variable.`);
         }
 
-        // Validate API key format
         if (!apiKey.startsWith('e2b_')) {
-          throw new Error(
-            `Invalid E2B API key format. E2B API keys should start with 'e2b_'. Check your E2B_API_KEY environment variable.`
-          );
+          throw new Error(`Invalid E2B API key format. E2B API keys should start with 'e2b_'.`);
         }
 
-
-        // options.timeout takes precedence over config.timeout
         const timeout = options?.timeout ?? config.timeout ?? 300000;
 
         try {
           let sandbox: E2BSandbox;
           let sandboxId: string;
 
-          // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            timeout: _timeout,
-            envs,
-            name: _name,
-            metadata,
-            templateId,
-            snapshotId,
-            sandboxId: _sandboxId,
-            namespace: _namespace,
-            directory: _directory,
-            ...providerOptions
+            timeout: _timeout, envs, name: _name, metadata, templateId, snapshotId,
+            sandboxId: _sandboxId, namespace: _namespace, directory: _directory, ...providerOptions
           } = options || {};
 
-            // Build create options, spreading provider-specific options (e.g., domain)
-            const createOpts: Record<string, any> = {
-              apiKey: apiKey,
-              timeoutMs: timeout,
-              envs,
-              metadata,
-              ...providerOptions, // Spread provider-specific options (e.g., domain)
-            };
+          const createOpts: Record<string, any> = { apiKey, timeoutMs: timeout, envs, metadata, ...providerOptions };
 
-          // Create new E2B session
-          // E2B supports both templateId and snapshotId (snapshotId maps to template)
           const templateOrSnapshot = templateId || snapshotId;
           if (templateOrSnapshot) {
             sandbox = await E2BSandbox.create(templateOrSnapshot, createOpts);
           } else {
             sandbox = await E2BSandbox.create(createOpts);
           }
-          if (!sandbox.sandboxId) {
-            throw new Error('E2B create() returned sandbox without an ID');
-          }
+          if (!sandbox.sandboxId) throw new Error('E2B create() returned sandbox without an ID');
           sandboxId = sandbox.sandboxId;
 
-          return {
-            sandbox,
-            sandboxId
-          };
+          return { sandbox, sandboxId };
         } catch (error) {
           if (error instanceof Error) {
             if (error.message.includes('unauthorized') || error.message.includes('API key')) {
-              throw new Error(
-                `E2B authentication failed. Please check your E2B_API_KEY environment variable. Get your API key from https://e2b.dev/`
-              );
+              throw new Error(`E2B authentication failed. Please check your E2B_API_KEY environment variable.`);
             }
             if (error.message.includes('quota') || error.message.includes('limit')) {
-              throw new Error(
-                `E2B quota exceeded. Please check your usage at https://e2b.dev/`
-              );
+              throw new Error(`E2B quota exceeded. Please check your usage at https://e2b.dev/`);
             }
           }
-          throw new Error(
-            `Failed to create E2B sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create E2B sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: E2BConfig, sandboxId: string) => {
         const apiKey = config.apiKey || process.env.E2B_API_KEY!;
-
         try {
-          const sandbox = await E2BSandbox.connect(sandboxId, {
-            apiKey: apiKey,
-          });
-
-          return {
-            sandbox,
-            sandboxId
-          };
-        } catch (error) {
-          // Sandbox doesn't exist or can't be accessed
-          return null;
-        }
+          const sandbox = await E2BSandbox.connect(sandboxId, { apiKey });
+          return { sandbox, sandboxId };
+        } catch { return null; }
       },
 
       list: async (config: E2BConfig) => {
         const apiKey = config.apiKey || process.env.E2B_API_KEY!;
-
         try {
-          const paginator = E2BSandbox.list({
-            apiKey: apiKey,
-          });
-          // Get first page of results using nextItems
+          const paginator = E2BSandbox.list({ apiKey });
           const items = await paginator.nextItems();
           return items.map((sandbox) => {
             const listedSandbox = sandbox as unknown as E2BSandbox & { id?: string; sandboxId?: string };
             const sandboxId = listedSandbox.id || listedSandbox.sandboxId || 'e2b-unknown';
-            return {
-              sandbox: listedSandbox,
-              sandboxId,
-            };
+            return { sandbox: listedSandbox, sandboxId };
           });
-        } catch (error) {
-          // Return empty array if listing fails
-          return [];
-        }
+        } catch { return []; }
       },
 
       destroy: async (config: E2BConfig, sandboxId: string) => {
         const apiKey = config.apiKey || process.env.E2B_API_KEY!;
-
         try {
-          const sandbox = await E2BSandbox.connect(sandboxId, {
-            apiKey: apiKey,
-          });
+          const sandbox = await E2BSandbox.connect(sandboxId, { apiKey });
           await sandbox.kill();
-        } catch (error) {
-          // Sandbox might already be destroyed or doesn't exist
-          // This is acceptable for destroy operations
-        }
+        } catch { /* already destroyed */ }
       },
-
-      // Instance operations (map to individual Sandbox methods)
 
       runCommand: async (sandbox: E2BSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
-
         try {
-          // Build command with options (E2B doesn't support these natively, so we wrap with shell)
           let fullCommand = command;
-          
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env)
-              .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
-              .join(' ');
+            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`).join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
-          
-          // Handle working directory
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-          
-          // Handle background execution
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
-
+          if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           const execution = await sandbox.commands.run(fullCommand);
-
-          return {
-            stdout: execution.stdout,
-            stderr: execution.stderr,
-            exitCode: execution.exitCode,
-            durationMs: Date.now() - startTime
-          };
+          return { stdout: execution.stdout, stderr: execution.stderr, exitCode: execution.exitCode, durationMs: Date.now() - startTime };
         } catch (error) {
-          // E2B throws errors for non-zero exit codes
-          // Extract the actual result from the error if available
           const result = (error as { result?: E2BExecutionResult })?.result;
-          if (result) {
-            return {
-              stdout: result.stdout || '',
-              stderr: result.stderr || '',
-              exitCode: result.exitCode || 1,
-              durationMs: Date.now() - startTime
-            };
-          }
-          
-          // Fallback for other errors (command not found, etc.)
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime
-          };
+          if (result) return { stdout: result.stdout || '', stderr: result.stderr || '', exitCode: result.exitCode || 1, durationMs: Date.now() - startTime };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
-      getInfo: async (sandbox: E2BSandbox): Promise<SandboxInfo> => {
-        return {
-          id: sandbox.sandboxId || 'e2b-unknown',
-          provider: 'e2b',
-          status: 'running',
-          createdAt: new Date(),
-          timeout: 300000,
-          metadata: {
-            e2bSessionId: sandbox.sandboxId
-          }
-        };
-      },
+      getInfo: async (sandbox: E2BSandbox): Promise<SandboxInfo> => ({
+        id: sandbox.sandboxId || 'e2b-unknown',
+        provider: 'e2b',
+        status: 'running',
+        createdAt: new Date(),
+        timeout: 300000,
+        metadata: { e2bSessionId: sandbox.sandboxId }
+      }),
 
       getUrl: async (sandbox: E2BSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         try {
-          // Use E2B's built-in getHost method for accurate host information
           const host = sandbox.getHost(options.port);
           const protocol = options.protocol || 'https';
           return `${protocol}://${host}`;
         } catch (error) {
-          throw new Error(
-            `Failed to get E2B host for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get E2B host for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Optional filesystem methods - E2B has full filesystem support
       filesystem: {
-        readFile: async (sandbox: E2BSandbox, path: string): Promise<string> => {
-          return await sandbox.files.read(path);
-        },
-
-        writeFile: async (sandbox: E2BSandbox, path: string, content: string): Promise<void> => {
-          await sandbox.files.write(path, content);
-        },
-
-        mkdir: async (sandbox: E2BSandbox, path: string): Promise<void> => {
-          await sandbox.files.makeDir(path);
-        },
-
+        readFile: async (sandbox: E2BSandbox, path: string): Promise<string> => sandbox.files.read(path),
+        writeFile: async (sandbox: E2BSandbox, path: string, content: string): Promise<void> => { await sandbox.files.write(path, content); },
+        mkdir: async (sandbox: E2BSandbox, path: string): Promise<void> => { await sandbox.files.makeDir(path); },
         readdir: async (sandbox: E2BSandbox, path: string): Promise<FileEntry[]> => {
           const entries = await sandbox.files.list(path);
-
           return entries.map((entry: E2BFileEntry) => ({
             name: entry.name,
             type: (entry.isDir || entry.isDirectory) ? 'directory' as const : 'file' as const,
@@ -296,118 +162,66 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
             modified: new Date(entry.lastModified || Date.now())
           }));
         },
-
-        exists: async (sandbox: E2BSandbox, path: string): Promise<boolean> => {
-          return await sandbox.files.exists(path);
-        },
-
-        remove: async (sandbox: E2BSandbox, path: string): Promise<void> => {
-          await sandbox.files.remove(path);
-        }
+        exists: async (sandbox: E2BSandbox, path: string): Promise<boolean> => sandbox.files.exists(path),
+        remove: async (sandbox: E2BSandbox, path: string): Promise<void> => { await sandbox.files.remove(path); }
       },
 
-      // Provider-specific typed getInstance method
-      getInstance: (sandbox: E2BSandbox): E2BSandbox => {
-        return sandbox;
-      },
-
+      getInstance: (sandbox: E2BSandbox): E2BSandbox => sandbox,
     },
 
     snapshot: {
       create: async (config: E2BConfig, sandboxId: string, options?: { name?: string }) => {
         const apiKey = config.apiKey || process.env.E2B_API_KEY!;
-        
         try {
-          // Reconnect to the sandbox to snapshot it
           const sandbox = await E2BSandbox.connect(sandboxId, { apiKey });
-          
-          // Note: createSnapshot is a feature referenced in E2B docs for saving running state
-          // It typically returns a template ID that can be used to spawn new sandboxes
-          // We cast to any to avoid type issues if the installed SDK version is slightly older
-          // but the feature is available on the API
           const snapshotSandbox = sandbox as SnapshotCapableE2BSandbox;
-          const snapshotResult = await snapshotSandbox.createSnapshot({
-            name: options?.name
-          });
-
-          // Handle different potential return shapes (ID string or object with ID)
+          const snapshotResult = await snapshotSandbox.createSnapshot({ name: options?.name });
           const snapshotId = typeof snapshotResult === 'string' ? snapshotResult : snapshotResult.id || snapshotResult.templateId;
-
-          return {
-            id: snapshotId,
-            provider: 'e2b',
-            createdAt: new Date(),
-            metadata: {
-              name: options?.name
-            }
-          };
+          return { id: snapshotId, provider: 'e2b', createdAt: new Date(), metadata: { name: options?.name } };
         } catch (error) {
           throw new Error(`Failed to create E2B snapshot: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
-
       list: async (config: E2BConfig) => {
-        // Listing snapshots in E2B is effectively listing templates
-        // since snapshots create templates
         try {
-          // Attempt to list templates/snapshots via SDK static method if available
-          // or return empty if not supported in this SDK version
           const e2bStatic = E2BSandbox as E2BSandboxStatics;
           if (typeof e2bStatic.listTemplates === 'function') {
             return await e2bStatic.listTemplates({ apiKey: config.apiKey || process.env.E2B_API_KEY });
           }
           return [];
-        } catch (error) {
-          return [];
-        }
+        } catch { return []; }
       },
-
       delete: async (config: E2BConfig, snapshotId: string) => {
         try {
-          // Attempt to delete template/snapshot
           const e2bStatic = E2BSandbox as E2BSandboxStatics;
           if (typeof e2bStatic.deleteTemplate === 'function') {
             await e2bStatic.deleteTemplate(snapshotId, { apiKey: config.apiKey || process.env.E2B_API_KEY });
           }
-        } catch (error) {
-          // Ignore
-        }
+        } catch { /* ignore */ }
       }
     },
 
-    // In E2B, Snapshots create Templates. They are interchangeable concepts for spawning.
     template: {
-      create: async (config: E2BConfig, options: { name: string }) => {
-         throw new Error('To create a template in E2B, create a snapshot from a running sandbox using snapshot.create(), or use the E2B CLI to build from a Dockerfile.');
+      create: async (_config: E2BConfig, _options: { name: string }) => {
+        throw new Error('To create a template in E2B, create a snapshot from a running sandbox using snapshot.create(), or use the E2B CLI to build from a Dockerfile.');
       },
-
       list: async (config: E2BConfig) => {
         const apiKey = config.apiKey || process.env.E2B_API_KEY!;
         try {
           const e2bStatic = E2BSandbox as E2BSandboxStatics;
-          if (typeof e2bStatic.listTemplates === 'function') {
-            return await e2bStatic.listTemplates({ apiKey });
-          }
+          if (typeof e2bStatic.listTemplates === 'function') return await e2bStatic.listTemplates({ apiKey });
           return [];
-        } catch (error) {
-          return [];
-        }
+        } catch { return []; }
       },
-
       delete: async (config: E2BConfig, templateId: string) => {
         const apiKey = config.apiKey || process.env.E2B_API_KEY!;
         try {
           const e2bStatic = E2BSandbox as E2BSandboxStatics;
-          if (typeof e2bStatic.deleteTemplate === 'function') {
-            await e2bStatic.deleteTemplate(templateId, { apiKey });
-          }
-        } catch (error) {
-          // Ignore
-        }
+          if (typeof e2bStatic.deleteTemplate === 'function') await e2bStatic.deleteTemplate(templateId, { apiKey });
+        } catch { /* ignore */ }
       }
     }
   }
 });
 
-// Export E2B sandbox type for explicit typing
 export type { Sandbox as E2BSandbox } from 'e2b';

--- a/packages/fly/src/index.ts
+++ b/packages/fly/src/index.ts
@@ -9,7 +9,7 @@
 
 import { defineProvider } from '@computesdk/provider';
 
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
 
 /**
  * Fly.io sandbox interface
@@ -164,7 +164,6 @@ export const fly = defineProvider<FlyMachine, FlyConfig>({
 
           // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: optRuntime,
             timeout: optTimeout,
             envs,
             name,
@@ -176,6 +175,8 @@ export const fly = defineProvider<FlyMachine, FlyConfig>({
             directory: _directory,
             ...providerOptions
           } = options || {};
+
+          const optRuntime = (options as any)?.runtime as string | undefined;
 
           // 2. Determine the image based on runtime
           const image = optRuntime 
@@ -411,11 +412,11 @@ export const fly = defineProvider<FlyMachine, FlyConfig>({
         throw new Error('Fly.io runCommand method not implemented yet');
       },
 
-      getInfo: async (sandbox: FlyMachine) => {
+      getInfo: async (_sandbox: FlyMachine): Promise<SandboxInfo> => {
         throw new Error('Fly.io getInfo method not implemented yet');
       },
 
-      getUrl: async (sandbox: FlyMachine, options: { port: number; protocol?: string }) => {
+      getUrl: async (_sandbox: FlyMachine, _options: { port: number; protocol?: string }) => {
         throw new Error('Fly.io getUrl method not implemented yet');
       },
     },

--- a/packages/freestyle/src/index.ts
+++ b/packages/freestyle/src/index.ts
@@ -2,38 +2,15 @@ import { Freestyle, VmSpec, type Vm } from "freestyle-sandboxes";
 import { VmNodeJs } from "@freestyle-sh/with-nodejs";
 import { VmPython } from "@freestyle-sh/with-python";
 import { defineProvider, escapeShellArg } from "@computesdk/provider";
-import type { Runtime } from "@computesdk/provider";
 
 export type { Freestyle as FreestyleSandbox } from "freestyle-sandboxes";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-/**
- * Freestyle provider configuration for ComputeSDK.
- * Runs code in full Linux microVMs via the Freestyle VM API.
- */
 export interface FreestyleConfig {
-  /**
-   * Freestyle API key.
-   * Falls back to the FREESTYLE_API_KEY environment variable if not provided.
-   */
   apiKey?: string;
-
-  /**
-   * Default runtime hint used to auto-detect the language when not specified.
-   * @default "node"
-   */
-  runtime?: Runtime;
-
-  /**
-   * Timeout in milliseconds for shell commands (`runCommand`).
-   * Note: `runCode` does not support timeouts in the Freestyle SDK.
-   * @default 30000
-   */
+  /** Default runtime hint (e.g. 'node', 'python') */
+  runtime?: string;
   timeout?: number;
 }
-
-// ─── Internal sandbox handle ──────────────────────────────────────────────────
 
 interface FreestyleSandboxHandle {
   client: Freestyle;
@@ -43,16 +20,7 @@ interface FreestyleSandboxHandle {
   sandboxId: string;
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-const RUNTIME_SPEC = new VmSpec({
-  with: {
-    js: new VmNodeJs(),
-    python: new VmPython(),
-  },
-});
-
-// Cache snapshot ensures per API key so we only build once
+const RUNTIME_SPEC = new VmSpec({ with: { js: new VmNodeJs(), python: new VmPython() } });
 const snapshotCache = new Map<string, Promise<void>>();
 
 async function ensureSnapshot(client: Freestyle, apiKey: string): Promise<void> {
@@ -60,96 +28,38 @@ async function ensureSnapshot(client: Freestyle, apiKey: string): Promise<void> 
     const promise = client.vms.snapshots
       .ensure({ spec: RUNTIME_SPEC })
       .then(() => {})
-      .catch((err) => {
-        snapshotCache.delete(apiKey);
-        throw err;
-      });
+      .catch((err) => { snapshotCache.delete(apiKey); throw err; });
     snapshotCache.set(apiKey, promise);
   }
   return snapshotCache.get(apiKey)!;
 }
 
 function getApiKey(config: FreestyleConfig): string {
-  const key =
-    config.apiKey ||
-    (typeof process !== "undefined" && process.env?.FREESTYLE_API_KEY) ||
-    "";
-
+  const key = config.apiKey || (typeof process !== "undefined" && process.env?.FREESTYLE_API_KEY) || "";
   if (!key) {
     throw new Error(
       "Missing Freestyle API key. Provide 'apiKey' in config or set FREESTYLE_API_KEY " +
         "environment variable. Get your API key from https://dash.freestyle.sh"
     );
   }
-
   return key;
 }
 
 function resolveConfig(config: FreestyleConfig): Required<FreestyleConfig> {
-  return {
-    apiKey: getApiKey(config),
-    runtime: config.runtime ?? "node",
-    timeout: config.timeout ?? 30_000,
-  };
+  return { apiKey: getApiKey(config), runtime: config.runtime ?? "node", timeout: config.timeout ?? 30_000 };
 }
 
-/**
- * Detect whether a piece of code looks like Python.
- * Mirrors the same heuristic used by the e2b provider.
- */
-function detectRuntime(code: string, hint?: Runtime, fallback?: Runtime): Runtime {
-  if (hint) return hint;
-  const isPython =
-    code.includes("print(") ||
-    code.includes("import ") ||
-    code.includes("def ") ||
-    code.includes("sys.") ||
-    code.includes("json.") ||
-    code.includes("__") ||
-    code.includes('f"') ||
-    code.includes("f'") ||
-    code.includes("raise ");
-  return isPython ? "python" : (fallback ?? "node");
-}
-
-// ─── Provider ─────────────────────────────────────────────────────────────────
-
-/**
- * Freestyle provider for ComputeSDK.
- * Creates full Linux microVMs for isolated code execution with Node.js and Python support.
- *
- * @example
- * import { freestyle } from "@computesdk/freestyle";
- *
- * const provider = freestyle({ apiKey: process.env.FREESTYLE_API_KEY });
- * const sandbox = await provider.sandbox.create();
- * const result = await sandbox.runCode('console.log("Hello!")');
- * console.log(result.output); // "Hello!"
- * await sandbox.destroy();
- */
 export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>({
   name: "freestyle",
-
   methods: {
     sandbox: {
-      // ── Collection operations ─────────────────────────────────────────────
-
       create: async (config, _options) => {
         const resolved = resolveConfig(config);
         const client = new Freestyle({ apiKey: resolved.apiKey });
-
         await ensureSnapshot(client, resolved.apiKey);
-
         const { vmId, vm } = await client.vms.create({ spec: RUNTIME_SPEC });
         const sandboxId = `freestyle-vm-${vmId}`;
-
-        const handle: FreestyleSandboxHandle = {
-          client,
-          config: resolved,
-          vm: vm as any,
-          vmId,
-          sandboxId,
-        };
+        const handle: FreestyleSandboxHandle = { client, config: resolved, vm: vm as any, vmId, sandboxId };
         return { sandbox: handle, sandboxId };
       },
 
@@ -160,27 +70,17 @@ export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>
           throw new Error(`Invalid sandbox ID: expected "freestyle-vm-" prefix, got "${sandboxId}"`);
         }
         const vmId = sandboxId.slice("freestyle-vm-".length);
-
         try {
           const vm = client.vms.ref({ vmId, spec: RUNTIME_SPEC });
           await vm.getInfo();
-          const handle: FreestyleSandboxHandle = {
-            client,
-            config: resolved,
-            vm: vm as any,
-            vmId,
-            sandboxId,
-          };
+          const handle: FreestyleSandboxHandle = { client, config: resolved, vm: vm as any, vmId, sandboxId };
           return { sandbox: handle, sandboxId };
-        } catch {
-          return null;
-        }
+        } catch { return null; }
       },
 
       list: async (config) => {
         const resolved = resolveConfig(config);
         const client = new Freestyle({ apiKey: resolved.apiKey });
-
         try {
           const result = await client.vms.list();
           const vms = (result as any).vms ?? (result as any) ?? [];
@@ -189,18 +89,10 @@ export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>
             const vmId = entry.vmId ?? entry.id;
             const sandboxId = `freestyle-vm-${vmId}`;
             const vm = client.vms.ref({ vmId, spec: RUNTIME_SPEC });
-            const handle: FreestyleSandboxHandle = {
-              client,
-              config: resolved,
-              vm: vm as any,
-              vmId,
-              sandboxId,
-            };
+            const handle: FreestyleSandboxHandle = { client, config: resolved, vm: vm as any, vmId, sandboxId };
             return { sandbox: handle, sandboxId };
           });
-        } catch {
-          return [];
-        }
+        } catch { return []; }
       },
 
       destroy: async (config, sandboxId) => {
@@ -210,39 +102,20 @@ export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>
           throw new Error(`Invalid sandbox ID: expected "freestyle-vm-" prefix, got "${sandboxId}"`);
         }
         const vmId = sandboxId.slice("freestyle-vm-".length);
-        try {
-          await client.vms.delete({ vmId });
-        } catch {
-          // VM may already be gone
-        }
+        try { await client.vms.delete({ vmId }); } catch { /* VM may already be gone */ }
       },
-
-      // ── Instance operations ───────────────────────────────────────────────
 
       runCommand: async (handle, command, options) => {
         const startTime = Date.now();
         let fullCommand = command;
-
         if (options?.env && Object.keys(options.env).length > 0) {
-          const envPrefix = Object.entries(options.env)
-            .map(([k, v]) => `${k}="${escapeShellArg(v)}"`)
-            .join(" ");
+          const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(v)}"`).join(" ");
           fullCommand = `${envPrefix} ${fullCommand}`;
         }
-
-        if (options?.cwd) {
-          fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-        }
-
-        if (options?.background) {
-          fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-        }
-
+        if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+        if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
         try {
-          const execResult = await handle.vm.exec({
-            command: fullCommand,
-            timeoutMs: handle.config.timeout,
-          });
+          const execResult = await handle.vm.exec({ command: fullCommand, timeoutMs: handle.config.timeout });
           return {
             stdout: (execResult as any).stdout ?? "",
             stderr: (execResult as any).stderr ?? "",
@@ -259,23 +132,17 @@ export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>
               durationMs: Date.now() - startTime,
             };
           }
-          return {
-            stdout: "",
-            stderr: err instanceof Error ? err.message : String(err),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: "", stderr: err instanceof Error ? err.message : String(err), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
       getInfo: async (handle) => ({
         id: handle.sandboxId,
         provider: "freestyle",
-        runtime: handle.config.runtime,
         status: "running",
         createdAt: new Date(),
         timeout: handle.config.timeout,
-        metadata: { freestyleVmId: handle.vmId },
+        metadata: { freestyleVmId: handle.vmId, runtime: handle.config.runtime },
       }),
 
       getUrl: async (handle, options) => {
@@ -285,29 +152,13 @@ export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>
 
       getInstance: (handle) => handle,
 
-      // ── Filesystem (native Freestyle fs API) ──────────────────────────────
-
       filesystem: {
-        readFile: async (handle, path) => {
-          return await handle.vm.fs.readTextFile(path);
-        },
-
-        writeFile: async (handle, path, content) => {
-          await handle.vm.fs.writeTextFile(path, content);
-        },
-
-        mkdir: async (handle, path) => {
-          await handle.vm.fs.mkdir(path, true);
-        },
-
+        readFile: async (handle, path) => handle.vm.fs.readTextFile(path),
+        writeFile: async (handle, path, content) => { await handle.vm.fs.writeTextFile(path, content); },
+        mkdir: async (handle, path) => { await handle.vm.fs.mkdir(path, true); },
         readdir: async (handle, path, runCommand) => {
-          // Use shell-based readdir for richer metadata (size, type, modified)
-          const result = await runCommand(
-            handle,
-            `ls -la "${escapeShellArg(path)}" 2>/dev/null || echo ""`
-          );
+          const result = await runCommand(handle, `ls -la "${escapeShellArg(path)}" 2>/dev/null || echo ""`);
           if (result.exitCode !== 0) return [];
-
           return result.stdout
             .split("\n")
             .filter((line) => line.trim() && !line.startsWith("total"))
@@ -316,25 +167,12 @@ export const freestyle = defineProvider<FreestyleSandboxHandle, FreestyleConfig>
               const permissions = parts[0] ?? "";
               const name = parts.slice(8).join(' ') || parts[parts.length - 1] || '';
               const size = parseInt(parts[4] ?? "0", 10);
-              return {
-                name,
-                type: (permissions.startsWith("d")
-                  ? "directory"
-                  : "file") as "directory" | "file",
-                size: isNaN(size) ? 0 : size,
-                modified: new Date(),
-              };
+              return { name, type: (permissions.startsWith("d") ? "directory" : "file") as "directory" | "file", size: isNaN(size) ? 0 : size, modified: new Date() };
             })
             .filter((e) => e.name !== "." && e.name !== "..");
         },
-
-        exists: async (handle, path) => {
-          return await handle.vm.fs.exists(path);
-        },
-
-        remove: async (handle, path) => {
-          await handle.vm.fs.remove(path, true);
-        },
+        exists: async (handle, path) => handle.vm.fs.exists(path),
+        remove: async (handle, path) => { await handle.vm.fs.remove(path, true); },
       },
     },
   },

--- a/packages/hopx/src/index.ts
+++ b/packages/hopx/src/index.ts
@@ -14,10 +14,8 @@
 import { Sandbox as HopxSandbox } from '@hopx-ai/sdk';
 import { defineProvider } from '@computesdk/provider';
 import type {
-  CodeResult,
   CommandResult,
   SandboxInfo,
-  Runtime,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions
@@ -29,8 +27,6 @@ import type {
 export interface HopxConfig {
   /** HopX API key - if not provided, will fallback to HOPX_API_KEY environment variable */
   apiKey?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
   /** Execution timeout in milliseconds */
   timeout?: number;
   /** Template name for sandbox creation (e.g., 'code-interpreter') */
@@ -79,7 +75,6 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
 
           // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: _runtime,
             timeout: _timeout,
             envs,
             name,
@@ -223,13 +218,6 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
       },
 
       /**
-       * Execute code in the sandbox
-       * 
-       * Uses sandbox.runCode() with auto-detected runtime.
-       * Maps ComputeSDK runtime ('node'/'python') to HopX language ('javascript'/'python').
-       */
-
-      /**
        * Execute a shell command in the sandbox
        * 
        * Uses sandbox.commands.run() to execute shell commands.
@@ -302,7 +290,6 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
           return {
             id: sandbox.sandboxId,
             provider: 'hopx',
-            runtime: 'python', // HopX default runtime
             status: (info.status as 'running' | 'stopped' | 'error') || 'running',
             createdAt: info.createdAt ? new Date(info.createdAt) : new Date(),
             timeout: info.timeoutSeconds ? info.timeoutSeconds * 1000 : 300000,
@@ -318,7 +305,6 @@ export const hopx = defineProvider<HopxSandbox, HopxConfig>({
           return {
             id: sandbox.sandboxId,
             provider: 'hopx',
-            runtime: 'python',
             status: 'running',
             createdAt: new Date(),
             timeout: 300000,

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -2,59 +2,30 @@
  * just-bash Provider - Factory-based Implementation
  *
  * Local sandboxed bash execution using the just-bash package.
- * Provides a virtual filesystem and bash shell environment
- * without requiring any external services or containers.
- *
- * Features:
- * - Pure TypeScript bash interpreter (no real processes)
- * - In-memory virtual filesystem
- * - Python support via pyodide (optional)
- * - Shell command execution with 60+ built-in commands
- * - No authentication required - runs entirely locally
  */
 
 import { Bash } from 'just-bash';
-import type { BashExecResult, BashOptions } from 'just-bash';
+import type { BashOptions } from 'just-bash';
 import { nanoid } from 'nanoid';
 import { defineProvider } from '@computesdk/provider';
 import type {
-  CodeResult,
   CommandResult,
   SandboxInfo,
-  Runtime,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions,
 } from 'computesdk';
 
-/**
- * just-bash-specific configuration options
- */
 export interface JustBashConfig {
-  /** Enable Python support via pyodide (disabled by default) */
   python?: boolean;
-  /** Initial files to populate in the virtual filesystem */
   files?: BashOptions['files'];
-  /** Initial environment variables */
   env?: Record<string, string>;
-  /** Working directory (defaults to /home/user) */
   cwd?: string;
-  /**
-   * Custom filesystem implementation.
-   * Defaults to InMemoryFs. Use OverlayFs for copy-on-write over a real directory,
-   * ReadWriteFs for direct disk access, or MountableFs to combine multiple filesystems.
-   */
   fs?: BashOptions['fs'];
-  /**
-   * Custom commands to register alongside built-in commands.
-   * Created with `defineCommand()` from just-bash.
-   */
   customCommands?: BashOptions['customCommands'];
-  /** Network configuration for commands like curl */
   network?: BashOptions['network'];
 }
 
-/** Internal sandbox state */
 interface JustBashSandbox {
   bash: Bash;
   id: string;
@@ -62,230 +33,108 @@ interface JustBashSandbox {
   config: JustBashConfig;
 }
 
-/** Active sandboxes registry */
 const activeSandboxes = new Map<string, JustBashSandbox>();
 
-/**
- * Create a just-bash provider instance using the factory pattern
- *
- * just-bash provides local sandboxed bash execution with:
- * - Virtual filesystem (in-memory)
- * - 60+ built-in commands (cat, grep, sed, awk, jq, etc.)
- * - Python support via pyodide
- * - No external dependencies or authentication required
- */
 const _provider = defineProvider<JustBashSandbox, JustBashConfig>({
   name: 'just-bash',
   methods: {
     sandbox: {
-      /**
-       * Create a new just-bash sandbox
-       */
       create: async (config: JustBashConfig, options?: CreateSandboxOptions) => {
         const sandboxId = `just-bash-${nanoid(10)}`;
-
+        const usePython = config.python ?? ((options as any)?.runtime === 'python');
         const bash = new Bash({
           files: config.files,
-          env: {
-            ...config.env,
-            ...options?.envs,
-          },
+          env: { ...config.env, ...options?.envs },
           cwd: config.cwd || '/home/user',
-          python: config.python ?? (options?.runtime === 'python'),
+          python: usePython,
           fs: config.fs,
           customCommands: config.customCommands,
           network: config.network,
         });
-
-        const sandbox: JustBashSandbox = {
-          bash,
-          id: sandboxId,
-          createdAt: new Date(),
-          config,
-        };
-
+        const sandbox: JustBashSandbox = { bash, id: sandboxId, createdAt: new Date(), config: { ...config, python: usePython } };
         activeSandboxes.set(sandboxId, sandbox);
         return { sandbox, sandboxId };
       },
 
-      /**
-       * Get an existing just-bash sandbox by ID
-       */
       getById: async (_config: JustBashConfig, sandboxId: string) => {
         const sandbox = activeSandboxes.get(sandboxId);
         if (!sandbox) return null;
         return { sandbox, sandboxId };
       },
 
-      /**
-       * List all active just-bash sandboxes
-       */
-      list: async (_config: JustBashConfig) => {
-        return Array.from(activeSandboxes.entries()).map(([sandboxId, sandbox]) => ({
-          sandbox,
-          sandboxId,
-        }));
-      },
+      list: async (_config: JustBashConfig) =>
+        Array.from(activeSandboxes.entries()).map(([sandboxId, sandbox]) => ({ sandbox, sandboxId })),
 
-      /**
-       * Destroy a just-bash sandbox
-       */
       destroy: async (_config: JustBashConfig, sandboxId: string) => {
         activeSandboxes.delete(sandboxId);
       },
 
-      /**
-       * Execute code in the sandbox
-       *
-       * For Python: executes via the built-in python3 command (pyodide)
-       * For Node/JS: wraps code in a bash script that evaluates it
-       */
-
-      /**
-       * Execute a shell command in the sandbox
-       */
       runCommand: async (sandbox: JustBashSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
         try {
           const execOptions: { env?: Record<string, string>; cwd?: string } = {};
-
-          if (options?.env && Object.keys(options.env).length > 0) {
-            execOptions.env = options.env;
-          }
-
-          if (options?.cwd) {
-            execOptions.cwd = options.cwd;
-          }
-
-          const result = await sandbox.bash.exec(
-            command,
-            Object.keys(execOptions).length > 0 ? execOptions : undefined
-          );
-
-          return {
-            stdout: result.stdout || '',
-            stderr: result.stderr || '',
-            exitCode: result.exitCode,
-            durationMs: Date.now() - startTime,
-          };
+          if (options?.env && Object.keys(options.env).length > 0) execOptions.env = options.env;
+          if (options?.cwd) execOptions.cwd = options.cwd;
+          const result = await sandbox.bash.exec(command, Object.keys(execOptions).length > 0 ? execOptions : undefined);
+          return { stdout: result.stdout || '', stderr: result.stderr || '', exitCode: result.exitCode, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
-      /**
-       * Get sandbox information
-       */
-      getInfo: async (sandbox: JustBashSandbox): Promise<SandboxInfo> => {
-        return {
-          id: sandbox.id,
-          provider: 'just-bash',
-          runtime: sandbox.config.python ? 'python' : 'node',
-          status: 'running',
-          createdAt: sandbox.createdAt,
-          timeout: 0, // No timeout - local execution
-          metadata: {
-            type: 'local',
-            cwd: sandbox.bash.getCwd(),
-          },
-        };
-      },
+      getInfo: async (sandbox: JustBashSandbox): Promise<SandboxInfo> => ({
+        id: sandbox.id,
+        provider: 'just-bash',
+        status: 'running',
+        createdAt: sandbox.createdAt,
+        timeout: 0,
+        metadata: { type: 'local', cwd: sandbox.bash.getCwd(), python: sandbox.config.python },
+      }),
 
-      /**
-       * Get URL for a port - not supported for local execution
-       */
       getUrl: async (_sandbox: JustBashSandbox, options: { port: number; protocol?: string }): Promise<string> => {
-        throw new Error(
-          `just-bash is a local sandbox without network capabilities. Cannot expose port ${options.port}.`
-        );
+        throw new Error(`just-bash is a local sandbox without network capabilities. Cannot expose port ${options.port}.`);
       },
 
-      /**
-       * Filesystem operations using the just-bash virtual filesystem
-       */
       filesystem: {
-        readFile: async (sandbox: JustBashSandbox, path: string, _runCommand): Promise<string> => {
-          return sandbox.bash.readFile(path);
-        },
-
+        readFile: async (sandbox: JustBashSandbox, path: string, _runCommand): Promise<string> =>
+          sandbox.bash.readFile(path),
         writeFile: async (sandbox: JustBashSandbox, path: string, content: string, _runCommand): Promise<void> => {
-          // Ensure parent directory exists
           const parentDir = path.substring(0, path.lastIndexOf('/')) || '/';
-          if (parentDir !== '/') {
-            await sandbox.bash.exec(`mkdir -p ${parentDir}`);
-          }
+          if (parentDir !== '/') await sandbox.bash.exec(`mkdir -p ${parentDir}`);
           await sandbox.bash.writeFile(path, content);
         },
-
         mkdir: async (sandbox: JustBashSandbox, path: string, _runCommand): Promise<void> => {
           const result = await sandbox.bash.exec(`mkdir -p ${path}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
         },
-
         readdir: async (sandbox: JustBashSandbox, path: string, _runCommand): Promise<FileEntry[]> => {
           const result = await sandbox.bash.exec(`ls -la ${path}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
-          }
-
+          if (result.exitCode !== 0) throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
           const entries: FileEntry[] = [];
-          const lines = result.stdout.trim().split('\n');
-
-          for (const line of lines) {
-            // Skip total line and empty lines
+          for (const line of result.stdout.trim().split('\n')) {
             if (!line || line.startsWith('total')) continue;
-
             const parts = line.split(/\s+/);
             if (parts.length < 9) continue;
-
-            const permissions = parts[0];
             const name = parts.slice(8).join(' ');
-
-            // Skip . and ..
             if (name === '.' || name === '..') continue;
-
-            entries.push({
-              name,
-              type: permissions.startsWith('d') ? 'directory' as const : 'file' as const,
-              size: parseInt(parts[4], 10) || 0,
-              modified: new Date(),
-            });
+            entries.push({ name, type: parts[0].startsWith('d') ? 'directory' as const : 'file' as const, size: parseInt(parts[4], 10) || 0, modified: new Date() });
           }
-
           return entries;
         },
-
         exists: async (sandbox: JustBashSandbox, path: string, _runCommand): Promise<boolean> => {
           const result = await sandbox.bash.exec(`test -f ${path} || test -d ${path}`);
           return result.exitCode === 0;
         },
-
         remove: async (sandbox: JustBashSandbox, path: string, _runCommand): Promise<void> => {
           const result = await sandbox.bash.exec(`rm -rf ${path}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to remove ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to remove ${path}: ${result.stderr}`);
         },
       },
 
-      /**
-       * Get the native JustBashSandbox instance for advanced usage
-       */
-      getInstance: (sandbox: JustBashSandbox): JustBashSandbox => {
-        return sandbox;
-      },
+      getInstance: (sandbox: JustBashSandbox): JustBashSandbox => sandbox,
     },
   },
 });
 
 export const justBash = (config: JustBashConfig = {}) => _provider(config);
-
-// Export types
 export type { JustBashSandbox };

--- a/packages/lambda/src/__tests__/index.test.ts
+++ b/packages/lambda/src/__tests__/index.test.ts
@@ -28,7 +28,6 @@ describe('Lambda Provider', () => {
       });
 
       expect(provider.name).toBe('lambda');
-      expect(typeof provider.getSupportedRuntimes).toBe('function');
     });
   });
 
@@ -92,11 +91,10 @@ describe('Lambda Provider', () => {
 
   describe('Error handling', () => {
     it('should handle configuration errors gracefully', () => {
-      expect(() => lambda({})).not.toThrow(); // Provider creation should not throw
+      expect(() => lambda({})).not.toThrow();
       
       const provider = lambda({});
       
-      // The error should be thrown when attempting to use the provider methods
       expect(async () => {
         await provider.sandbox.create();
       }).rejects.toThrow();

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,41 +1,9 @@
 /**
  * Lambda Provider - Factory-based Implementation
- * 
- * Curl Command to start instance with Node:Alpine
- * curl --request POST \
-  --url 'https://cloud.lambda.ai/api/v1/instance-operations/launch' \
-  --header 'Authorization: Bearer LAMBDA_API_KEY' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "region_name": LAMBDA_REGION_NAME,
-    "instance_type_name": LAMBDA_INSTANCE_TYPE_NAME,
-    "ssh_key_names": ["LAMBDA_SSH_KEY_NAME"],
-    "name": "node-alpine-instance",
-    "user_data": "#!/bin/bash\napt-get update\napt-get install -y docker.io\nsystemctl start docker\nsystemctl enable docker\ndocker pull node:alpine\ndocker run -d --name node-app node:alpine tail -f /dev/null"
-  }'
-  *
-  * Curl Command to list instances
-  * curl --request GET \
-  --url 'https://cloud.lambda.ai/api/v1/instances' \
-  --header 'Authorization: Bearer LAMBDA_API_KEY'
-  *
-  * Curl Command to getById()
-  * curl --request GET \
-  --url 'https://cloud.lambda.ai/api/v1/instances/<INSTANCE-ID>' \
-  --header 'Authorization: Bearer LAMBDA_API_KEY'
-  *
-  * Curl Command to Destroy Instance (terminate)
-  * curl --request POST \
-  --url 'https://cloud.lambda.ai/api/v1/instance-operations/terminate' \
-  --header 'Authorization: Bearer LAMBDA_API_KEY' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "instance_ids": ["<YOUR-INSTANCE-ID>"]
-  }'
  */
 
 import { defineProvider } from '@computesdk/provider';
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 /**
  * Lambda sandbox interface
@@ -101,7 +69,6 @@ const handleLambdaAPIError = (response: Response, data?: any) => {
   if (!response.ok) {
     let errorMessage;
     if (data?.error) {
-      // Handle Lambda API error format: { "error": { "code": "...", "message": "...", "suggestion": "..." } }
       if (typeof data.error === 'object' && data.error.message) {
         errorMessage = `${data.error.message}${data.error.suggestion ? ` ${data.error.suggestion}` : ''} (${data.error.code || 'unknown'})`;
       } else {
@@ -113,7 +80,6 @@ const handleLambdaAPIError = (response: Response, data?: any) => {
     throw new Error(`Lambda API error: ${errorMessage}`);
   }
 };
-
 
 export const fetchLambda = async (
   apiKey: string,
@@ -135,14 +101,9 @@ export const fetchLambda = async (
   });
 
   const data = await response.json();
-
-  // Handle Lambda API errors
   handleLambdaAPIError(response, data);
-
   return data;
 };
-
-
 
 /**
  * Create a Lambda provider instance using the factory pattern
@@ -151,12 +112,12 @@ export const lambda = defineProvider<LambdaSandbox, LambdaConfig>({
   name: 'lambda',
   methods: {
     sandbox: {
-      // Collection operations (compute.sandbox.*)
       create: async (config: LambdaConfig, options?: CreateSandboxOptions) => {
         const { apiKey, regionName, instanceTypeName, sshKeyName } = getAndValidateCredentials(config);
 
         try {
-          const dockerImage = options?.runtime === 'node' ? 'node:alpine' : 'python:alpine';
+          const runtime = (options as any)?.runtime;
+          const dockerImage = runtime === 'python' ? 'python:alpine' : 'node:alpine';
           const userData = `#!/bin/bash
 apt-get update
 apt-get install -y docker.io
@@ -169,7 +130,7 @@ docker run -d --name compute-app ${dockerImage} tail -f /dev/null`;
             region_name: regionName,
             instance_type_name: instanceTypeName,
             ssh_key_names: [sshKeyName],
-            name: `compute-${options?.runtime || 'node'}-instance`,
+            name: `compute-${runtime || 'node'}-instance`,
             user_data: userData
           };
 
@@ -178,29 +139,17 @@ docker run -d --name compute-app ${dockerImage} tail -f /dev/null`;
             body: launchBody
           });
           
-          // Lambda API returns instance_ids as an array
           const instanceIds = responseData?.data?.instance_ids;
           if (!instanceIds || !Array.isArray(instanceIds) || instanceIds.length === 0) {
             throw new Error(`No instance IDs returned from Lambda API. Full response: ${JSON.stringify(responseData)}`);
           }
 
-          // Take the first instance ID (should only be one for single instance creation)
           const instanceId = instanceIds[0];
+          const lambdaSandbox: LambdaSandbox = { instanceId, regionName, instanceTypeName };
 
-          const lambdaSandbox: LambdaSandbox = {
-            instanceId,
-            regionName,
-            instanceTypeName,
-          };
-
-          return {
-            sandbox: lambdaSandbox,
-            sandboxId: instanceId
-          };
+          return { sandbox: lambdaSandbox, sandboxId: instanceId };
         } catch (error) {
-          throw new Error(
-            `Failed to create Lambda sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create Lambda sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
@@ -209,35 +158,16 @@ docker run -d --name compute-app ${dockerImage} tail -f /dev/null`;
 
         try {
           const responseData = await fetchLambda(apiKey, LAMBDA_API_ENDPOINTS.GET_INSTANCE(sandboxId));
-          
-          // Lambda API returns the instance directly in data (single instance, not array)
           const instance = responseData?.data;
-          if (!instance) {
-            return null;
-          }
-          
-          if (!instance.id) {
-            throw new Error('Instance data is missing ID from Lambda response');
-          }
+          if (!instance || !instance.id) return null;
 
-          const lambdaSandbox: LambdaSandbox = {
-            instanceId: instance.id,
-            regionName,
-            instanceTypeName,
-          };
-
-          return {
-            sandbox: lambdaSandbox,
-            sandboxId: instance.id
-          };
+          const lambdaSandbox: LambdaSandbox = { instanceId: instance.id, regionName, instanceTypeName };
+          return { sandbox: lambdaSandbox, sandboxId: instance.id };
         } catch (error) {
-          // Return null for 404s (instance not found)
           if (error instanceof Error && (error.message.includes('404') || error.message.includes('Not Found'))) {
             return null;
           }
-          throw new Error(
-            `Failed to get Lambda sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get Lambda sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
       
@@ -246,55 +176,32 @@ docker run -d --name compute-app ${dockerImage} tail -f /dev/null`;
 
         try {
           const responseData = await fetchLambda(apiKey, LAMBDA_API_ENDPOINTS.LIST_INSTANCES);
-          
-          // Lambda API returns instances directly in data array
           const instances = responseData?.data || [];
-          
+
           if (!Array.isArray(instances)) {
             throw new Error(`Expected instances array, got: ${typeof instances}`);
           }
-          
-          // Transform each instance into the expected format
-          const sandboxes = instances.map((instance: any) => {
-            const lambdaSandbox: LambdaSandbox = {
-              instanceId: instance.id,
-              regionName,
-              instanceTypeName,
-            };
 
-            return {
-              sandbox: lambdaSandbox,
-              sandboxId: instance.id
-            };
-          });
-
-          return sandboxes;
+          return instances.map((instance: any) => ({
+            sandbox: { instanceId: instance.id, regionName, instanceTypeName } as LambdaSandbox,
+            sandboxId: instance.id
+          }));
         } catch (error) {
-          throw new Error(
-            `Failed to list Lambda sandboxes: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to list Lambda sandboxes: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       destroy: async (config: LambdaConfig, sandboxId: string) => {
         const { apiKey } = getAndValidateCredentials(config);
-
         try {
-          const terminateBody = {
-            instance_ids: [sandboxId]
-          };
-
           await fetchLambda(apiKey, LAMBDA_API_ENDPOINTS.TERMINATE_INSTANCES, {
             method: 'POST',
-            body: terminateBody
+            body: { instance_ids: [sandboxId] }
           });
         } catch (error) {
-          // For destroy operations, we typically don't throw if the instance is already gone
           console.warn(`Lambda destroy warning: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
-
-      // Instance operations (minimal stubs - not implemented yet)
 
       runCommand: async (_sandbox: LambdaSandbox, _command: string, _options?: RunCommandOptions) => {
         throw new Error('Lambda runCommand method not implemented yet');
@@ -307,7 +214,6 @@ docker run -d --name compute-app ${dockerImage} tail -f /dev/null`;
       getUrl: async (_sandbox: LambdaSandbox, _options: { port: number; protocol?: string }) => {
         throw new Error('Lambda getUrl method not implemented yet');
       },
-
     },
   },
 });

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -3,14 +3,11 @@
  * 
  * Full-featured provider with serverless sandbox execution using the factory pattern.
  * Leverages Modal's JavaScript SDK for real sandbox management.
- * 
- * Note: Modal's JavaScript SDK is in alpha. This implementation provides a working
- * foundation but may need updates as the Modal API evolves.
  */
 
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Runtime, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 // Import Modal SDK
 import { App, Sandbox, initializeClient } from 'modal';
@@ -23,8 +20,8 @@ export interface ModalConfig {
   tokenId?: string;
   /** Modal API token secret - if not provided, will fallback to MODAL_TOKEN_SECRET environment variable */
   tokenSecret?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'node', 'python') */
+  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
   /** Modal environment (sandbox or main) */
@@ -81,7 +78,7 @@ interface ModalSandbox {
 /**
  * Detect runtime from code content
  */
-function detectRuntime(code: string): Runtime {
+function detectRuntime(code: string): string {
   // Strong Node.js indicators
   if (code.includes('console.log') || 
       code.includes('process.') ||
@@ -89,7 +86,7 @@ function detectRuntime(code: string): Runtime {
       code.includes('module.exports') ||
       code.includes('__dirname') ||
       code.includes('__filename') ||
-      code.includes('throw new Error') ||  // JavaScript error throwing
+      code.includes('throw new Error') ||
       code.includes('new Error(')) {
     return 'node';
   }
@@ -106,7 +103,6 @@ function detectRuntime(code: string): Runtime {
     return 'python';
   }
 
-  // Default to Node.js for Modal (now using Node.js base image)
   return 'node';
 }
 
@@ -141,7 +137,6 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
 
             // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {
-              runtime: _runtime,
               timeout: optTimeout,
               envs,
               name,
@@ -151,9 +146,10 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
               sandboxId: _sandboxId,
               namespace: _namespace,
               directory: _directory,
-              ports: optPorts,
               ...providerOptions
             } = options || {};
+
+            const optPorts = (options as any)?.ports as number[] | undefined;
             
             const createSandbox = app.createSandbox.bind(app);
             type ModalImageArg = Parameters<typeof createSandbox>[0];
@@ -179,13 +175,11 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
             }
             
             // Configure sandbox options
-            // Modal SDK uses: env, timeoutMs, name, workdir, unencryptedPorts, gpu, cpu, etc.
             const sandboxOptions: Record<string, unknown> = {
-              ...providerOptions, // Spread provider-specific options (e.g., gpu, cpu, memoryMiB, workdir, secrets, volumes)
+              ...providerOptions,
             };
             
-            // Configure ports if provided (using unencrypted ports by default)
-            // options.ports takes precedence over config.ports
+            // Configure ports if provided
             const ports = optPorts ?? config.ports;
             if (ports && ports.length > 0) {
               sandboxOptions.unencryptedPorts = ports;
@@ -275,7 +269,6 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
           }
         } catch (error) {
           // Sandbox might already be terminated or doesn't exist
-          // This is acceptable for destroy operations
         }
       },
 
@@ -285,10 +278,8 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
         const startTime = Date.now();
 
         try {
-          // Build command with options
           let fullCommand = command;
           
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
             const envPrefix = Object.entries(options.env)
               .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
@@ -296,23 +287,19 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
           
-          // Handle working directory
           if (options?.cwd) {
             fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
           }
           
-          // Handle background execution
           if (options?.background) {
             fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           }
           
-          // Execute using shell to handle complex commands
           const process = await modalSandbox.sandbox.exec(['sh', '-c', fullCommand], {
             stdout: 'pipe',
             stderr: 'pipe'
           });
 
-          // Use working stream reading pattern from debug
           const [stdout, stderr] = await Promise.all([
             process.stdout.readText(),
             process.stderr.readText()
@@ -337,36 +324,32 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
       },
 
       getInfo: async (modalSandbox: ModalSandbox): Promise<SandboxInfo> => {
-        // Get actual sandbox status using Modal's poll method
         let status: 'running' | 'stopped' | 'error' = 'running';
         try {
           const pollResult = await modalSandbox.sandbox.poll();
           if (pollResult !== null) {
-            // Sandbox has finished
             status = pollResult === 0 ? 'stopped' : 'error';
           }
         } catch (error) {
-          // If polling fails, assume running
           status = 'running';
         }
 
         return {
           id: modalSandbox.sandboxId,
           provider: 'modal',
-          runtime: 'node', // Modal default (now using Node.js)
           status,
           createdAt: new Date(),
           timeout: 300000,
           metadata: {
             modalSandboxId: modalSandbox.sandboxId,
-            realModalImplementation: true
+            realModalImplementation: true,
+            runtime: 'node',
           }
         };
       },
 
       getUrl: async (modalSandbox: ModalSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         try {
-          // Use Modal's built-in tunnels method to get tunnel information
           const tunnels = await modalSandbox.sandbox.tunnels();
           const tunnel = tunnels[options.port];
           
@@ -376,7 +359,6 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
           
           let url = tunnel.url;
           
-          // If a specific protocol is requested, replace the URL's protocol
           if (options.protocol) {
             const urlObj = new URL(url);
             urlObj.protocol = options.protocol + ':';
@@ -395,24 +377,20 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
       filesystem: {
         readFile: async (modalSandbox: ModalSandbox, path: string): Promise<string> => {
           try {
-            // Use Modal's file open API to read files
             const file = await modalSandbox.sandbox.open(path);
             
-            // Read the entire file content
             let content = '';
             if (file && typeof file.read === 'function') {
               const data = await file.read();
               content = typeof data === 'string' ? data : new TextDecoder().decode(data);
             }
             
-            // Close the file if it has a close method
             if (file && typeof file.close === 'function') {
               await file.close();
             }
             
             return content;
           } catch (error) {
-            // Fallback to using cat command with working stream pattern
             try {
               const process = await modalSandbox.sandbox.exec(['cat', path], {
                 stdout: 'pipe',
@@ -430,7 +408,7 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
                 throw new Error(`cat failed: ${stderr}`);
               }
 
-              return content.trim(); // Remove extra newlines
+              return content.trim();
             } catch (fallbackError) {
               throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
             }
@@ -439,20 +417,16 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
 
         writeFile: async (modalSandbox: ModalSandbox, path: string, content: string): Promise<void> => {
           try {
-            // Use Modal's file open API to write files
             const file = await modalSandbox.sandbox.open(path);
             
-            // Write content to the file
             if (file && typeof file.write === 'function') {
               await file.write(new TextEncoder().encode(content));
             }
             
-            // Close the file if it has a close method
             if (file && typeof file.close === 'function') {
               await file.close();
             }
           } catch (error) {
-            // Fallback to using shell command with proper escaping
             try {
               const process = await modalSandbox.sandbox.exec(['sh', '-c', `printf '%s' "${content.replace(/"/g, '\\"')}" > "${path}"`], {
                 stdout: 'pipe',
@@ -499,7 +473,6 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
 
         readdir: async (modalSandbox: ModalSandbox, path: string): Promise<FileEntry[]> => {
           try {
-            // Use simple -l flag for BusyBox compatibility (Alpine/node:20-alpine uses BusyBox ls)
             const process = await modalSandbox.sandbox.exec(['ls', '-la', path], {
               stdout: 'pipe',
               stderr: 'pipe'
@@ -516,7 +489,7 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
               throw new Error(`ls failed: ${stderr}`);
             }
 
-            const lines = output.split('\n').slice(1); // Skip header
+            const lines = output.split('\n').slice(1);
 
             return lines
               .filter((line: string) => line.trim())
@@ -587,20 +560,13 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
 
         try {
           initializeClient({ tokenId, tokenSecret });
-          // We need to reconnect to the sandbox to snapshot it
-          // Note: sandbox.snapshotFilesystem() is an instance method on the Sandbox object
-          // But we only have the ID here.
-          // We need to re-instantiate the sandbox object from the ID.
-          
           const sandbox = await Sandbox.fromId(sandboxId);
           
           const snapshotSandbox = sandbox as unknown as ModalSnapshotCapableSandbox;
           const image = await snapshotSandbox.snapshotFilesystem();
           
-          // Return the image object. The user can use this image to create new sandboxes.
-          // We wrap it in a structure that looks like a snapshot
           return {
-            id: image.objectId || `img-${Date.now()}`, // Best effort ID
+            id: image.objectId || `img-${Date.now()}`,
             image: image,
             provider: 'modal',
             createdAt: new Date()
@@ -611,13 +577,14 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
       },
 
       list: async (_config: ModalConfig) => {
-        // Modal doesn't have a simple "list snapshots" API yet that maps 1:1
         return [];
       },
 
-      delete: async (_config: ModalConfig, snapshotId: string) => {
+      delete: async (_config: ModalConfig, _snapshotId: string) => {
         // No-op for now
       }
     }
   }
 });
+
+export { detectRuntime };

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -1,53 +1,25 @@
 /**
  * Modal Provider - Factory-based Implementation
- * 
- * Full-featured provider with serverless sandbox execution using the factory pattern.
- * Leverages Modal's JavaScript SDK for real sandbox management.
  */
 
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-// Import Modal SDK
 import { App, Sandbox, initializeClient } from 'modal';
 
-/**
- * Modal-specific configuration options
- */
 export interface ModalConfig {
-  /** Modal API token ID - if not provided, will fallback to MODAL_TOKEN_ID environment variable */
   tokenId?: string;
-  /** Modal API token secret - if not provided, will fallback to MODAL_TOKEN_SECRET environment variable */
   tokenSecret?: string;
-  /** Default runtime environment (e.g. 'node', 'python') */
-  runtime?: string;
-  /** Execution timeout in milliseconds */
   timeout?: number;
-  /** Modal environment (sandbox or main) */
   environment?: string;
-  /** Ports to expose */
   ports?: number[];
 }
 
-type ModalExecPipe = {
-  readText: () => Promise<string>;
-};
-
-type ModalExecProcess = {
-  stdout: ModalExecPipe;
-  stderr: ModalExecPipe;
-  wait: () => Promise<number>;
-};
-
-type ModalFileHandle = {
-  read?: () => Promise<string | Uint8Array>;
-  write?: (content: Uint8Array) => Promise<void>;
-  close?: () => Promise<void>;
-};
-
+type ModalExecPipe = { readText: () => Promise<string>; };
+type ModalExecProcess = { stdout: ModalExecPipe; stderr: ModalExecPipe; wait: () => Promise<number>; };
+type ModalFileHandle = { read?: () => Promise<string | Uint8Array>; write?: (content: Uint8Array) => Promise<void>; close?: () => Promise<void>; };
 type ModalTunnel = { url: string };
-
 type ModalNativeSandbox = {
   sandboxId: string;
   exec: (args: string[], options?: Record<string, unknown>) => Promise<ModalExecProcess>;
@@ -56,66 +28,20 @@ type ModalNativeSandbox = {
   open: (path: string) => Promise<ModalFileHandle>;
   terminate?: () => Promise<void>;
 };
-
 type ModalSnapshotImage = { objectId?: string };
+type ModalSnapshotCapableSandbox = ModalNativeSandbox & { snapshotFilesystem: () => Promise<ModalSnapshotImage>; };
+type ModalSandboxStatics = typeof Sandbox & { fromSnapshot?: (snapshotId: string) => Promise<unknown>; };
 
-type ModalSnapshotCapableSandbox = ModalNativeSandbox & {
-  snapshotFilesystem: () => Promise<ModalSnapshotImage>;
-};
-
-type ModalSandboxStatics = typeof Sandbox & {
-  fromSnapshot?: (snapshotId: string) => Promise<unknown>;
-};
-
-/**
- * Modal sandbox interface - wraps Modal's Sandbox class
- */
 interface ModalSandbox {
   sandbox: ModalNativeSandbox;
   sandboxId: string;
 }
 
-/**
- * Detect runtime from code content
- */
-function detectRuntime(code: string): string {
-  // Strong Node.js indicators
-  if (code.includes('console.log') || 
-      code.includes('process.') ||
-      code.includes('require(') ||
-      code.includes('module.exports') ||
-      code.includes('__dirname') ||
-      code.includes('__filename') ||
-      code.includes('throw new Error') ||
-      code.includes('new Error(')) {
-    return 'node';
-  }
-
-  // Strong Python indicators
-  if (code.includes('print(') ||
-      code.includes('import ') ||
-      code.includes('def ') ||
-      code.includes('sys.') ||
-      code.includes('json.') ||
-      code.includes('f"') ||
-      code.includes("f'") ||
-      code.includes('raise ')) {
-    return 'python';
-  }
-
-  return 'node';
-}
-
-/**
- * Create a Modal provider instance using the factory pattern
- */
 export const modal = defineProvider<ModalSandbox, ModalConfig>({
   name: 'modal',
   methods: {
     sandbox: {
-      // Collection operations (map to compute.sandbox.*)
       create: async (config: ModalConfig, options?: CreateSandboxOptions) => {
-        // Validate API credentials
         const tokenId = config.tokenId || (typeof process !== 'undefined' && process.env?.MODAL_TOKEN_ID) || '';
         const tokenSecret = config.tokenSecret || (typeof process !== 'undefined' && process.env?.MODAL_TOKEN_SECRET) || '';
 
@@ -126,200 +52,110 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
         }
 
         try {
-          // Initialize Modal client with credentials
           initializeClient({ tokenId, tokenSecret });
 
           let sandbox: ModalNativeSandbox;
           let sandboxId: string;
 
-          // Create new Modal sandbox
           const app = await App.lookup('computesdk-modal', { createIfMissing: true });
 
-            // Destructure known ComputeSDK fields, collect the rest for passthrough
-            const {
-              timeout: optTimeout,
-              envs,
-              name,
-              metadata: _metadata,
-              templateId,
-              snapshotId,
-              sandboxId: _sandboxId,
-              namespace: _namespace,
-              directory: _directory,
-              ...providerOptions
-            } = options || {};
+          const {
+            timeout: optTimeout,
+            envs,
+            name,
+            metadata: _metadata,
+            templateId,
+            snapshotId,
+            sandboxId: _sandboxId,
+            namespace: _namespace,
+            directory: _directory,
+            ...providerOptions
+          } = options || {};
 
-            const optPorts = (options as any)?.ports as number[] | undefined;
-            
-            const createSandbox = app.createSandbox.bind(app);
-            type ModalImageArg = Parameters<typeof createSandbox>[0];
-            let image: ModalImageArg;
-            // Modal supports snapshotId and templateId (both map to image)
-            const sourceId = snapshotId || templateId;
-            if (sourceId) {
-              // Create from snapshot/template
-              try {
-                const snapshotFactory = Sandbox as ModalSandboxStatics;
-                if (typeof snapshotFactory.fromSnapshot !== 'function') {
-                  throw new Error('Modal SDK does not expose fromSnapshot in this version');
-                }
-                const snapshot = await snapshotFactory.fromSnapshot(sourceId) as ModalImageArg;
-                image = snapshot;
-              } catch (e) {
-                // Fallback: try to treat it as a registry image
-                image = await app.imageFromRegistry(sourceId); 
+          const optPorts = (options as any)?.ports as number[] | undefined;
+          
+          const createSandbox = app.createSandbox.bind(app);
+          type ModalImageArg = Parameters<typeof createSandbox>[0];
+          let image: ModalImageArg;
+          const sourceId = snapshotId || templateId;
+          if (sourceId) {
+            try {
+              const snapshotFactory = Sandbox as ModalSandboxStatics;
+              if (typeof snapshotFactory.fromSnapshot !== 'function') {
+                throw new Error('Modal SDK does not expose fromSnapshot in this version');
               }
-            } else {
-              // Default to Node.js (more appropriate for a Node.js SDK)
-              image = await app.imageFromRegistry('node:20');
+              const snapshot = await snapshotFactory.fromSnapshot(sourceId) as ModalImageArg;
+              image = snapshot;
+            } catch (e) {
+              image = await app.imageFromRegistry(sourceId); 
             }
-            
-            // Configure sandbox options
-            const sandboxOptions: Record<string, unknown> = {
-              ...providerOptions,
-            };
-            
-            // Configure ports if provided
-            const ports = optPorts ?? config.ports;
-            if (ports && ports.length > 0) {
-              sandboxOptions.unencryptedPorts = ports;
-            }
-            
-            // options.timeout takes precedence over config.timeout
-            const timeout = optTimeout ?? config.timeout;
-            if (timeout) {
-              sandboxOptions.timeoutMs = timeout;
-            }
-
-            // Remap envs to env (Modal uses 'env')
-            if (envs && Object.keys(envs).length > 0) {
-              sandboxOptions.env = envs;
-            }
-
-            // Pass sandbox name
-            if (name) {
-              sandboxOptions.name = name;
-            }
-            
+          } else {
+            image = await app.imageFromRegistry('node:20');
+          }
+          
+          const sandboxOptions: Record<string, unknown> = { ...providerOptions };
+          const ports = optPorts ?? config.ports;
+          if (ports && ports.length > 0) sandboxOptions.unencryptedPorts = ports;
+          const timeout = optTimeout ?? config.timeout;
+          if (timeout) sandboxOptions.timeoutMs = timeout;
+          if (envs && Object.keys(envs).length > 0) sandboxOptions.env = envs;
+          if (name) sandboxOptions.name = name;
+          
           sandbox = await app.createSandbox(image, sandboxOptions);
           sandboxId = sandbox.sandboxId;
 
-          const modalSandbox: ModalSandbox = {
-            sandbox,
-            sandboxId
-          };
-
-          return {
-            sandbox: modalSandbox,
-            sandboxId
-          };
+          return { sandbox: { sandbox, sandboxId }, sandboxId };
         } catch (error) {
           if (error instanceof Error) {
             if (error.message.includes('unauthorized') || error.message.includes('credentials')) {
-              throw new Error(
-                `Modal authentication failed. Please check your MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables. Get your credentials from https://modal.com/`
-              );
+              throw new Error(`Modal authentication failed. Please check your MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables.`);
             }
             if (error.message.includes('quota') || error.message.includes('limit')) {
-              throw new Error(
-                `Modal quota exceeded. Please check your usage at https://modal.com/`
-              );
+              throw new Error(`Modal quota exceeded. Please check your usage at https://modal.com/`);
             }
           }
-          throw new Error(
-            `Failed to create Modal sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create Modal sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: ModalConfig, sandboxId: string) => {
         const tokenId = config.tokenId || process.env.MODAL_TOKEN_ID!;
         const tokenSecret = config.tokenSecret || process.env.MODAL_TOKEN_SECRET!;
-
         try {
           initializeClient({ tokenId, tokenSecret });
           const sandbox = await Sandbox.fromId(sandboxId);
-
-          const modalSandbox: ModalSandbox = {
-            sandbox,
-            sandboxId
-          };
-
-          return {
-            sandbox: modalSandbox,
-            sandboxId
-          };
-        } catch (error) {
-          // Sandbox doesn't exist or can't be accessed
-          return null;
-        }
+          return { sandbox: { sandbox, sandboxId }, sandboxId };
+        } catch { return null; }
       },
 
       list: async (_config: ModalConfig) => {
-        throw new Error(
-          `Modal provider does not support listing sandboxes. Modal sandboxes are managed individually through the Modal console. Use getById to reconnect to specific sandboxes by ID.`
-        );
+        throw new Error(`Modal provider does not support listing sandboxes.`);
       },
 
       destroy: async (_config: ModalConfig, sandboxId: string) => {
         try {
           const sandbox = await Sandbox.fromId(sandboxId);
-          if (sandbox && typeof sandbox.terminate === 'function') {
-            await sandbox.terminate();
-          }
-        } catch (error) {
-          // Sandbox might already be terminated or doesn't exist
-        }
+          if (sandbox && typeof sandbox.terminate === 'function') await sandbox.terminate();
+        } catch { /* already terminated */ }
       },
-
-      // Instance operations (map to individual Sandbox methods)
 
       runCommand: async (modalSandbox: ModalSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
-
         try {
           let fullCommand = command;
-          
           if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env)
-              .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
-              .join(' ');
+            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`).join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
+          if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-          
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
-          
-          const process = await modalSandbox.sandbox.exec(['sh', '-c', fullCommand], {
-            stdout: 'pipe',
-            stderr: 'pipe'
-          });
-
-          const [stdout, stderr] = await Promise.all([
-            process.stdout.readText(),
-            process.stderr.readText()
-          ]);
-
+          const process = await modalSandbox.sandbox.exec(['sh', '-c', fullCommand], { stdout: 'pipe', stderr: 'pipe' });
+          const [stdout, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
           const exitCode = await process.wait();
-
-          return {
-            stdout: stdout || '',
-            stderr: stderr || '',
-            exitCode: exitCode || 0,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: stdout || '', stderr: stderr || '', exitCode: exitCode || 0, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
@@ -327,12 +163,8 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
         let status: 'running' | 'stopped' | 'error' = 'running';
         try {
           const pollResult = await modalSandbox.sandbox.poll();
-          if (pollResult !== null) {
-            status = pollResult === 0 ? 'stopped' : 'error';
-          }
-        } catch (error) {
-          status = 'running';
-        }
+          if (pollResult !== null) status = pollResult === 0 ? 'stopped' : 'error';
+        } catch { status = 'running'; }
 
         return {
           id: modalSandbox.sandboxId,
@@ -340,11 +172,7 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
           status,
           createdAt: new Date(),
           timeout: 300000,
-          metadata: {
-            modalSandboxId: modalSandbox.sandboxId,
-            realModalImplementation: true,
-            runtime: 'node',
-          }
+          metadata: { modalSandboxId: modalSandbox.sandboxId, realModalImplementation: true, runtime: 'node' }
         };
       },
 
@@ -352,239 +180,106 @@ export const modal = defineProvider<ModalSandbox, ModalConfig>({
         try {
           const tunnels = await modalSandbox.sandbox.tunnels();
           const tunnel = tunnels[options.port];
-          
-          if (!tunnel) {
-            throw new Error(`No tunnel found for port ${options.port}. Available ports: ${Object.keys(tunnels).join(', ')}`);
-          }
-          
+          if (!tunnel) throw new Error(`No tunnel found for port ${options.port}. Available ports: ${Object.keys(tunnels).join(', ')}`);
           let url = tunnel.url;
-          
-          if (options.protocol) {
-            const urlObj = new URL(url);
-            urlObj.protocol = options.protocol + ':';
-            url = urlObj.toString();
-          }
-          
+          if (options.protocol) { const urlObj = new URL(url); urlObj.protocol = options.protocol + ':'; url = urlObj.toString(); }
           return url;
         } catch (error) {
-          throw new Error(
-            `Failed to get Modal tunnel URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get Modal tunnel URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Optional filesystem methods - Modal supports filesystem operations
       filesystem: {
         readFile: async (modalSandbox: ModalSandbox, path: string): Promise<string> => {
           try {
             const file = await modalSandbox.sandbox.open(path);
-            
             let content = '';
             if (file && typeof file.read === 'function') {
               const data = await file.read();
               content = typeof data === 'string' ? data : new TextDecoder().decode(data);
             }
-            
-            if (file && typeof file.close === 'function') {
-              await file.close();
-            }
-            
+            if (file && typeof file.close === 'function') await file.close();
             return content;
           } catch (error) {
             try {
-              const process = await modalSandbox.sandbox.exec(['cat', path], {
-                stdout: 'pipe',
-                stderr: 'pipe'
-              });
-
-              const [content, stderr] = await Promise.all([
-                process.stdout.readText(),
-                process.stderr.readText()
-              ]);
-
+              const process = await modalSandbox.sandbox.exec(['cat', path], { stdout: 'pipe', stderr: 'pipe' });
+              const [content, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
               const exitCode = await process.wait();
-
-              if (exitCode !== 0) {
-                throw new Error(`cat failed: ${stderr}`);
-              }
-
+              if (exitCode !== 0) throw new Error(`cat failed: ${stderr}`);
               return content.trim();
-            } catch (fallbackError) {
+            } catch {
               throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
             }
           }
         },
-
         writeFile: async (modalSandbox: ModalSandbox, path: string, content: string): Promise<void> => {
           try {
             const file = await modalSandbox.sandbox.open(path);
-            
-            if (file && typeof file.write === 'function') {
-              await file.write(new TextEncoder().encode(content));
-            }
-            
-            if (file && typeof file.close === 'function') {
-              await file.close();
-            }
+            if (file && typeof file.write === 'function') await file.write(new TextEncoder().encode(content));
+            if (file && typeof file.close === 'function') await file.close();
           } catch (error) {
             try {
-              const process = await modalSandbox.sandbox.exec(['sh', '-c', `printf '%s' "${content.replace(/"/g, '\\"')}" > "${path}"`], {
-                stdout: 'pipe',
-                stderr: 'pipe'
-              });
-
-              const [, stderr] = await Promise.all([
-                process.stdout.readText(),
-                process.stderr.readText()
-              ]);
-
+              const process = await modalSandbox.sandbox.exec(['sh', '-c', `printf '%s' "${content.replace(/"/g, '\\"')}" > "${path}"`], { stdout: 'pipe', stderr: 'pipe' });
+              const [, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
               const exitCode = await process.wait();
-
-              if (exitCode !== 0) {
-                throw new Error(`write failed: ${stderr}`);
-              }
-            } catch (fallbackError) {
+              if (exitCode !== 0) throw new Error(`write failed: ${stderr}`);
+            } catch {
               throw new Error(`Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)}`);
             }
           }
         },
-
         mkdir: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
-          try {
-            const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], {
-              stdout: 'pipe',
-              stderr: 'pipe'
-            });
-
-            const [, stderr] = await Promise.all([
-              process.stdout.readText(),
-              process.stderr.readText()
-            ]);
-
-            const exitCode = await process.wait();
-
-            if (exitCode !== 0) {
-              throw new Error(`mkdir failed: ${stderr}`);
-            }
-          } catch (error) {
-            throw new Error(`Failed to create directory ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], { stdout: 'pipe', stderr: 'pipe' });
+          const [, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
+          const exitCode = await process.wait();
+          if (exitCode !== 0) throw new Error(`mkdir failed: ${stderr}`);
         },
-
         readdir: async (modalSandbox: ModalSandbox, path: string): Promise<FileEntry[]> => {
-          try {
-            const process = await modalSandbox.sandbox.exec(['ls', '-la', path], {
-              stdout: 'pipe',
-              stderr: 'pipe'
-            });
-
-            const [output, stderr] = await Promise.all([
-              process.stdout.readText(),
-              process.stderr.readText()
-            ]);
-
-            const exitCode = await process.wait();
-
-            if (exitCode !== 0) {
-              throw new Error(`ls failed: ${stderr}`);
-            }
-
-            const lines = output.split('\n').slice(1);
-
-            return lines
-              .filter((line: string) => line.trim())
-              .map((line: string) => {
-                const parts = line.trim().split(/\s+/);
-                const permissions = parts[0] || '';
-                const size = parseInt(parts[4]) || 0;
-                const dateStr = (parts[5] || '') + ' ' + (parts[6] || '');
-                const date = dateStr.trim() ? new Date(dateStr) : new Date();
-                const name = parts.slice(8).join(' ') || parts[parts.length - 1] || 'unknown';
-
-                return {
-                  name,
-                  type: permissions.startsWith('d') ? 'directory' as const : 'file' as const,
-                  size,
-                  modified: isNaN(date.getTime()) ? new Date() : date
-                };
-              });
-          } catch (error) {
-            throw new Error(`Failed to read directory ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const process = await modalSandbox.sandbox.exec(['ls', '-la', path], { stdout: 'pipe', stderr: 'pipe' });
+          const [output, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
+          const exitCode = await process.wait();
+          if (exitCode !== 0) throw new Error(`ls failed: ${stderr}`);
+          const lines = output.split('\n').slice(1);
+          return lines.filter((l: string) => l.trim()).map((line: string) => {
+            const parts = line.trim().split(/\s+/);
+            const permissions = parts[0] || '';
+            const size = parseInt(parts[4]) || 0;
+            const dateStr = (parts[5] || '') + ' ' + (parts[6] || '');
+            const date = dateStr.trim() ? new Date(dateStr) : new Date();
+            const name = parts.slice(8).join(' ') || parts[parts.length - 1] || 'unknown';
+            return { name, type: permissions.startsWith('d') ? 'directory' as const : 'file' as const, size, modified: isNaN(date.getTime()) ? new Date() : date };
+          });
         },
-
         exists: async (modalSandbox: ModalSandbox, path: string): Promise<boolean> => {
-          try {
-            const process = await modalSandbox.sandbox.exec(['test', '-e', path]);
-            const exitCode = await process.wait();
-            return exitCode === 0;
-          } catch (error) {
-            return false;
-          }
+          try { const process = await modalSandbox.sandbox.exec(['test', '-e', path]); return await process.wait() === 0; } catch { return false; }
         },
-
         remove: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
-          try {
-            const process = await modalSandbox.sandbox.exec(['rm', '-rf', path], {
-              stdout: 'pipe',
-              stderr: 'pipe'
-            });
-
-            const [, stderr] = await Promise.all([
-              process.stdout.readText(),
-              process.stderr.readText()
-            ]);
-
-            const exitCode = await process.wait();
-
-            if (exitCode !== 0) {
-              throw new Error(`rm failed: ${stderr}`);
-            }
-          } catch (error) {
-            throw new Error(`Failed to remove ${path}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          const process = await modalSandbox.sandbox.exec(['rm', '-rf', path], { stdout: 'pipe', stderr: 'pipe' });
+          const [, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
+          const exitCode = await process.wait();
+          if (exitCode !== 0) throw new Error(`rm failed: ${stderr}`);
         }
       },
 
-      // Provider-specific typed getInstance method
-      getInstance: (sandbox: ModalSandbox): ModalSandbox => {
-        return sandbox;
-      },
-
+      getInstance: (sandbox: ModalSandbox): ModalSandbox => sandbox,
     },
 
     snapshot: {
-      create: async (config: ModalConfig, sandboxId: string, options?: { name?: string }) => {
+      create: async (config: ModalConfig, sandboxId: string) => {
         const tokenId = config.tokenId || process.env.MODAL_TOKEN_ID!;
         const tokenSecret = config.tokenSecret || process.env.MODAL_TOKEN_SECRET!;
-
         try {
           initializeClient({ tokenId, tokenSecret });
           const sandbox = await Sandbox.fromId(sandboxId);
-          
           const snapshotSandbox = sandbox as unknown as ModalSnapshotCapableSandbox;
           const image = await snapshotSandbox.snapshotFilesystem();
-          
-          return {
-            id: image.objectId || `img-${Date.now()}`,
-            image: image,
-            provider: 'modal',
-            createdAt: new Date()
-          };
+          return { id: image.objectId || `img-${Date.now()}`, image, provider: 'modal', createdAt: new Date() };
         } catch (error) {
           throw new Error(`Failed to create Modal snapshot: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
-
-      list: async (_config: ModalConfig) => {
-        return [];
-      },
-
-      delete: async (_config: ModalConfig, _snapshotId: string) => {
-        // No-op for now
-      }
+      list: async (_config: ModalConfig) => [],
+      delete: async (_config: ModalConfig, _snapshotId: string) => { /* No-op */ }
     }
   }
 });
-
-export { detectRuntime };

--- a/packages/namespace/src/index.ts
+++ b/packages/namespace/src/index.ts
@@ -7,7 +7,7 @@
 
 import * as fs from 'fs/promises';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
 
 /**
  * Namespace sandbox instance
@@ -70,16 +70,10 @@ async function loadTokenFromFile(filePath: string): Promise<string> {
 
 /**
  * Get and validate Namespace credentials from config and environment.
- * Supports:
- *  - config.token (direct bearer token)
- *  - NSC_TOKEN env var (direct bearer token)
- *  - NSC_TOKEN_FILE env var (path to JSON file with bearer_token field)
  */
 export const getAndValidateCredentials = async (config: NamespaceConfig) => {
-  // 1. Direct token from config or env
   let token = config.token || (typeof process !== 'undefined' && process.env?.NSC_TOKEN) || '';
 
-  // 2. If no direct token, try loading from token file
   if (!token) {
     const tokenFile = config.tokenFile || (typeof process !== 'undefined' && process.env?.NSC_TOKEN_FILE) || '';
     if (tokenFile) {
@@ -122,10 +116,7 @@ export const fetchNamespace = async (
   }
 
   const data = await response.json();
-
-  // Standard error handling for all operations
   handleApiErrors(data);
-
   return data;
 };
 
@@ -139,7 +130,6 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
 
   methods: {
     sandbox: {
-      // Collection operations (map to compute.sandbox.*)
       create: async (config: NamespaceConfig, options?: CreateSandboxOptions) => {
         const { token } = await getAndValidateCredentials(config);
         const containerName = config.targetContainerName || 'main-container';
@@ -154,7 +144,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             },
             containers: [{
               name: containerName,
-              image_ref: options?.image ?? 'ubuntu:latest',
+              image_ref: (options as any)?.image ?? 'ubuntu:latest',
               args: ['sleep', 'infinity'],
               ...(options?.envs && Object.keys(options.envs).length > 0 && {
                 environment: options.envs
@@ -169,7 +159,6 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             body: JSON.stringify(requestBody)
           });
 
-          // Extract instance ID from the Namespace API response structure
           if (!responseData.metadata?.instanceId) {
             throw new Error(`Instance ID is undefined. Full response object: ${JSON.stringify(responseData, null, 2)}`);
           }
@@ -186,10 +175,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             createdAt: new Date(),
           };
 
-          return {
-            sandbox,
-            sandboxId: instanceId
-          };
+          return { sandbox, sandboxId: instanceId };
         } catch (error) {
           throw new Error(
             `Failed to create Namespace instance: ${error instanceof Error ? error.message : String(error)}`
@@ -206,33 +192,23 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             body: JSON.stringify({ instance_id: sandboxId })
           });
 
-          // Extract instance ID from the Namespace API response structure
           if (!responseData.metadata?.instanceId) {
             throw new Error('Instance data is missing from Namespace response');
           }
 
           const instanceId = responseData.metadata.instanceId;
-          const commandServiceEndpoint = responseData.extendedMetadata?.commandServiceEndpoint;
-
           const sandbox: NamespaceSandbox = {
             instanceId,
             name: `instance-${instanceId}`,
-            commandServiceEndpoint,
+            commandServiceEndpoint: responseData.extendedMetadata?.commandServiceEndpoint,
             token,
             targetContainerName: config.targetContainerName || 'main-container',
             createdAt: responseData.metadata?.createdAt ? new Date(responseData.metadata.createdAt) : new Date(0),
           };
 
-          return {
-            sandbox,
-            sandboxId: instanceId
-          };
+          return { sandbox, sandboxId: instanceId };
         } catch (error) {
-          // Handle 404 errors by returning null (instance not found)
-          if (error instanceof Error && error.message.includes('404')) {
-            return null;
-          }
-
+          if (error instanceof Error && error.message.includes('404')) return null;
           throw new Error(
             `Failed to get Namespace instance: ${error instanceof Error ? error.message : String(error)}`
           );
@@ -248,29 +224,21 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             body: JSON.stringify({})
           });
 
-          // Extract instances from the response
           const instances = responseData?.instances || [];
 
-          // Filter to instances with valid IDs, then transform
           return instances
             .filter((instanceData: any) => instanceData.instanceId || instanceData.metadata?.instanceId)
             .map((instanceData: any) => {
               const instanceId = instanceData.instanceId || instanceData.metadata.instanceId;
-              const commandServiceEndpoint = instanceData.extendedMetadata?.commandServiceEndpoint;
-
               const sandbox: NamespaceSandbox = {
                 instanceId,
                 name: `instance-${instanceId}`,
-                commandServiceEndpoint,
+                commandServiceEndpoint: instanceData.extendedMetadata?.commandServiceEndpoint,
                 token,
                 targetContainerName: config.targetContainerName || 'main-container',
                 createdAt: instanceData.metadata?.createdAt ? new Date(instanceData.metadata.createdAt) : new Date(0),
               };
-
-              return {
-                sandbox,
-                sandboxId: instanceId
-              };
+              return { sandbox, sandboxId: instanceId };
             });
         } catch (error) {
           throw new Error(
@@ -292,17 +260,13 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
           });
 
           if (data.error) {
-            // Log errors but don't throw for destroy operations
             console.warn(`Namespace destroy warning: ${data.error}`);
           }
         } catch (error) {
-          // For destroy operations, we log warnings rather than throwing
-          // since the resource may already be gone
           console.warn(`Namespace destroy warning: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
-      // Command execution via Namespace CommandService
       runCommand: async (sandbox: NamespaceSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         if (!sandbox.commandServiceEndpoint) {
           throw new Error('Command service endpoint not available. The instance may not support command execution.');
@@ -311,10 +275,8 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
         const startTime = Date.now();
 
         try {
-          // Build the full command with options
           let fullCommand = command;
 
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
             const envPrefix = Object.entries(options.env)
               .map(([k, v]) => `${k}=${escapeShellArg(v)}`)
@@ -322,17 +284,14 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
 
-          // Handle working directory
           if (options?.cwd) {
             fullCommand = `cd ${escapeShellArg(options.cwd)} && ${fullCommand}`;
           }
 
-          // Handle background execution
           if (options?.background) {
             fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           }
 
-          // Call CommandService RunCommandSync via Connect protocol
           const result = await fetchNamespace(
             sandbox.token,
             COMMAND_SERVICE.RUN_COMMAND_SYNC,
@@ -348,45 +307,33 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             },
             sandbox.commandServiceEndpoint
           ) as {
-            stdout?: string; // base64-encoded
-            stderr?: string; // base64-encoded
+            stdout?: string;
+            stderr?: string;
             exitCode?: number;
           };
 
-          // Decode base64-encoded stdout/stderr, falling back to raw string on invalid data
           const decodeBase64 = (data?: string): string => {
             if (!data) return '';
-            try {
-              return Buffer.from(data, 'base64').toString();
-            } catch {
-              return data;
-            }
+            try { return Buffer.from(data, 'base64').toString(); } catch { return data; }
           };
-          const stdout = decodeBase64(result.stdout);
-          const stderr = decodeBase64(result.stderr);
 
           return {
-            stdout,
-            stderr,
+            stdout: decodeBase64(result.stdout),
+            stderr: decodeBase64(result.stderr),
             exitCode: result.exitCode ?? 0,
             durationMs: Date.now() - startTime
           };
         } catch (error) {
-          // Re-throw infrastructure errors (network, auth, API) so they propagate
-          // rather than being masked as command execution failures
           throw new Error(
             `Namespace command execution failed: ${error instanceof Error ? error.message : String(error)}`
           );
         }
       },
 
-      // Not supported - throw as no-op
-
       getInfo: async (sandbox: NamespaceSandbox): Promise<SandboxInfo> => {
         return {
           id: sandbox.instanceId,
           provider: 'namespace',
-          runtime: 'node',
           status: 'running',
           createdAt: sandbox.createdAt,
           timeout: 0,
@@ -397,14 +344,11 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
         };
       },
 
-      // Not supported - throw as no-op
       getUrl: async (_sandbox: NamespaceSandbox, _options: { port: number; protocol?: string }): Promise<string> => {
         throw new Error('Namespace provider does not support getUrl.');
       },
 
-      getInstance: (sandbox: NamespaceSandbox): NamespaceSandbox => {
-        return sandbox;
-      },
+      getInstance: (sandbox: NamespaceSandbox): NamespaceSandbox => sandbox,
     }
   }
 });

--- a/packages/provider/src/__tests__/createCompute.test.ts
+++ b/packages/provider/src/__tests__/createCompute.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { createCompute } from '../compute.js'
 import type { CommandResult, SandboxInfo } from '../types/index.js'
-import type { Runtime } from 'computesdk'
-
-const MOCK_SUPPORTED_RUNTIMES: Runtime[] = ['node', 'python']
 
 type MockSandboxInstance = {
   setTimeout: ReturnType<typeof vi.fn>
@@ -20,7 +17,6 @@ function createMockProvider(name: string) {
 
   return {
     name,
-    getSupportedRuntimes: () => MOCK_SUPPORTED_RUNTIMES,
     sandbox: {
       create: vi.fn().mockResolvedValue({
         sandboxId: 'test-123',
@@ -34,7 +30,6 @@ function createMockProvider(name: string) {
         getInfo: vi.fn().mockResolvedValue({
           id: 'test-123',
           provider: name,
-          runtime: 'python' as Runtime,
           status: 'running',
           createdAt: new Date(),
           timeout: 300000,
@@ -85,16 +80,12 @@ describe('createCompute function', () => {
 
     const sandbox = await compute.sandbox.create()
 
-    // Should be properly typed and return the provider-specific instance
-    // Note: In real usage with defineProvider<E2BSandbox>, getInstance() returns E2BSandbox
-    // Here we narrow to the mock shape used in this test.
     const instance = sandbox.getInstance() as MockSandboxInstance
 
     expect(instance).toBeTruthy()
     expect(typeof instance.setTimeout).toBe('function')
     expect(typeof instance.specialMethod).toBe('function')
 
-    // Should be able to call provider-specific methods
     instance.setTimeout(5000)
     expect(instance.setTimeout).toHaveBeenCalledWith(5000)
 
@@ -149,7 +140,6 @@ describe('createCompute function', () => {
       defaultProvider: mockProvider1
     })
 
-    // setConfig should return a new typed compute instance
     const compute2 = compute1.setConfig({
       defaultProvider: mockProvider2
     })

--- a/packages/provider/src/__tests__/factory.test.ts
+++ b/packages/provider/src/__tests__/factory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { defineProvider } from '../factory.js'
-import type { Runtime, CommandResult, SandboxInfo } from '../types/index.js'
+import type { CommandResult, SandboxInfo } from '../types/index.js'
 
 describe('Factory', () => {
   describe('defineProvider', () => {
@@ -25,7 +25,6 @@ describe('Factory', () => {
         getInfo: vi.fn().mockResolvedValue({
           id: 'test-123',
           provider: 'mock',
-          runtime: 'python' as Runtime,
           status: 'running',
           createdAt: new Date(),
           timeout: 300000,
@@ -74,7 +73,6 @@ describe('Factory', () => {
         getInfo: vi.fn().mockResolvedValue({
           id: 'test-123',
           provider: 'mock',
-          runtime: 'python' as Runtime,
           status: 'running',
           createdAt: new Date(),
           timeout: 300000
@@ -131,7 +129,6 @@ describe('Factory', () => {
         getInfo: vi.fn().mockResolvedValue({
           id: 'test-456',
           provider: 'mock',
-          runtime: 'python' as Runtime,
           status: 'running',
           createdAt: new Date(),
           timeout: 300000

--- a/packages/provider/src/factory.ts
+++ b/packages/provider/src/factory.ts
@@ -7,7 +7,6 @@
 
 // Import all types from local types
 import type {
-  Runtime,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions,
@@ -354,12 +353,6 @@ class GeneratedProvider<TSandbox, TConfig, TTemplate, TSnapshot> implements Prov
     if (providerConfig.methods.snapshot) {
       this.snapshot = new GeneratedSnapshotManager(config, providerConfig.methods.snapshot);
     }
-  }
-
-  getSupportedRuntimes(): Runtime[] {
-    // For now, all providers support both node and python
-    // In the future, this could be configurable per provider
-    return ['node', 'python'];
   }
 }
 

--- a/packages/provider/src/types/index.ts
+++ b/packages/provider/src/types/index.ts
@@ -7,7 +7,6 @@
 // Import and re-export universal types from computesdk (grandmother package)
 export type {
   SandboxInterface,
-  Runtime,
   CodeResult,
   CommandResult,
   SandboxInfo,

--- a/packages/provider/src/types/provider.ts
+++ b/packages/provider/src/types/provider.ts
@@ -4,7 +4,7 @@
  * Types related to provider configuration, authentication, and resource management
  */
 
-import type { Runtime, CreateSandboxOptions, SandboxInterface } from 'computesdk';
+import type { CreateSandboxOptions, SandboxInterface } from 'computesdk';
 
 /**
  * Provider Sandbox - what provider implementations return
@@ -123,9 +123,6 @@ export interface Provider<TSandbox = any, TTemplate = any, TSnapshot = any> {
 
   /** Optional snapshot management operations */
   readonly snapshot?: ProviderSnapshotManager<TSnapshot>;
-
-  /** Get the list of supported runtime environments */
-  getSupportedRuntimes(): Runtime[];
 
   // Future resource managers will be added here:
   // readonly blob: ProviderBlobManager;

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -266,13 +266,15 @@ export const runloop = defineProvider<
 
       getInfo: async (sandbox): Promise<SandboxInfo> => {
         const devbox = sandbox;
+        const keepAliveSecs = devbox.launch_parameters.keep_alive_time_seconds;
 
         return {
           id: devbox.id || "runloop-unknown",
           provider: "runloop",
           status: devbox.status as 'running' | 'stopped' | 'error',
           createdAt: new Date(devbox.create_time_ms || Date.now()),
-          timeout: devbox.launch_parameters.keep_alive_time_seconds || 300000,
+          // keep_alive_time_seconds is in seconds; SandboxInfo.timeout is in milliseconds
+          timeout: keepAliveSecs ? keepAliveSecs * 1000 : 300000,
           metadata: {
             runloopDevboxId: devbox.id,
             templateId: devbox.blueprint_id || devbox.snapshot_id,
@@ -302,46 +304,24 @@ export const runloop = defineProvider<
       filesystem: {
         readFile: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<string> => {
           const result = await runCommand(sandbox, `cat "${path}"`);
-          if (result.exitCode !== 0) {
-            throw new Error(`File not found or unreadable: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`File not found or unreadable: ${result.stderr}`);
           return result.stdout;
         },
 
-        writeFile: async (
-          sandbox: RunloopSandbox,
-          path: string,
-          content: string,
-          runCommand: CommandRunner
-        ): Promise<void> => {
+        writeFile: async (sandbox: RunloopSandbox, path: string, content: string, runCommand: CommandRunner): Promise<void> => {
           const encoded = Buffer.from(content).toString('base64');
           const result = await runCommand(sandbox, `sh -c 'echo "${encoded}" | base64 -d > "${path}"'`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to write file ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to write file ${path}: ${result.stderr}`);
         },
 
-        mkdir: async (
-          sandbox: RunloopSandbox,
-          path: string,
-          runCommand: CommandRunner
-        ): Promise<void> => {
+        mkdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {
           const result = await runCommand(sandbox, `mkdir -p "${path}"`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
         },
 
-        readdir: async (
-          sandbox: RunloopSandbox,
-          path: string,
-          runCommand: CommandRunner
-        ): Promise<FileEntry[]> => {
+        readdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<FileEntry[]> => {
           const result = await runCommand(sandbox, `ls -la "${path}"`);
-
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
 
           const lines = (result.stdout || "")
             .split("\n")
@@ -351,7 +331,6 @@ export const runloop = defineProvider<
             const parts = line.trim().split(/\s+/);
             const name = parts[parts.length - 1];
             const isDirectory = line.startsWith("d");
-
             return {
               name,
               type: isDirectory ? 'directory' as const : 'file' as const,
@@ -361,24 +340,14 @@ export const runloop = defineProvider<
           });
         },
 
-        exists: async (
-          sandbox: RunloopSandbox,
-          path: string,
-          runCommand: CommandRunner
-        ): Promise<boolean> => {
+        exists: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<boolean> => {
           const result = await runCommand(sandbox, `test -e "${path}"`);
           return result.exitCode === 0;
         },
 
-        remove: async (
-          sandbox: RunloopSandbox,
-          path: string,
-          runCommand: CommandRunner
-        ): Promise<void> => {
+        remove: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {
           const result = await runCommand(sandbox, `rm -rf "${path}"`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to remove ${path}: ${result.stderr}`);
-          }
+          if (result.exitCode !== 0) throw new Error(`Failed to remove ${path}: ${result.stderr}`);
         },
       },
 
@@ -386,13 +355,9 @@ export const runloop = defineProvider<
     },
 
     template: {
-      create: async (
-        config: RunloopConfig,
-        options: CreateBlueprintTemplateOptions | Runloop.BlueprintCreateParams
-      ) => {
+      create: async (config: RunloopConfig, options: CreateBlueprintTemplateOptions | Runloop.BlueprintCreateParams) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
         if (!apiKey) throw new Error("Missing Runloop API key for blueprint template creation");
-
         const client = new RunloopSDK({ bearerToken: apiKey });
         return client.api.blueprints.create(options);
       },
@@ -400,7 +365,6 @@ export const runloop = defineProvider<
       list: async (config: RunloopConfig, options?: { limit?: number }) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
         if (!apiKey) throw new Error("Missing Runloop API key for listing blueprint templates");
-
         const client = new RunloopSDK({ bearerToken: apiKey });
         const listParams: any = {};
         if (options?.limit) listParams.limit = options.limit;
@@ -411,21 +375,15 @@ export const runloop = defineProvider<
       delete: async (config: RunloopConfig, blueprintId: string) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
         if (!apiKey) throw new Error("Missing Runloop API key for blueprint template deletion");
-
         const client = new RunloopSDK({ bearerToken: apiKey });
         await client.api.blueprints.delete(blueprintId);
       },
     },
 
     snapshot: {
-      create: async (
-        config: RunloopConfig,
-        sandboxId: string,
-        options?: CreateSnapshotOptions
-      ) => {
+      create: async (config: RunloopConfig, sandboxId: string, options?: CreateSnapshotOptions) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
         if (!apiKey) throw new Error("Missing Runloop API key for snapshot creation");
-
         const client = new RunloopSDK({ bearerToken: apiKey });
         const snapshotParams: any = {};
         if (options?.name) snapshotParams.name = options.name;
@@ -433,13 +391,9 @@ export const runloop = defineProvider<
         return client.api.devboxes.snapshotDisk(sandboxId, snapshotParams);
       },
 
-      list: async (
-        config: RunloopConfig,
-        options?: ListSnapshotsOptions
-      ) => {
+      list: async (config: RunloopConfig, options?: ListSnapshotsOptions) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
         if (!apiKey) throw new Error("Missing Runloop API key for listing snapshots");
-
         const client = new RunloopSDK({ bearerToken: apiKey });
         const listParams: any = {};
         if (options?.limit) listParams.limit = options.limit;
@@ -450,7 +404,6 @@ export const runloop = defineProvider<
       delete: async (config: RunloopConfig, snapshotId: string) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
         if (!apiKey) throw new Error("Missing Runloop API key for snapshot deletion");
-
         const client = new RunloopSDK({ bearerToken: apiKey });
         await client.api.devboxes.deleteDiskSnapshot(snapshotId);
       },

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -17,7 +17,6 @@ import type {
 import type {
   CreateSandboxOptions,
   FileEntry,
-  Runtime,
 } from "computesdk";
 
 // Define Runloop-specific types
@@ -91,17 +90,15 @@ export interface CreateBlueprintTemplateOptions {
  * Create a Runloop provider instance using the factory pattern
  */
 export const runloop = defineProvider<
-  RunloopSandbox,             // TSandbox
-  RunloopConfig,              // TConfig
-  RunloopTemplate,            // TTemplate 
-  RunloopSnapshot             // TSnapshot
+  RunloopSandbox,
+  RunloopConfig,
+  RunloopTemplate,
+  RunloopSnapshot
 >({
   name: "runloop",
   methods: {
     sandbox: {
-      // Collection operations (map to compute.sandbox.*)
       create: async (config: RunloopConfig, options?: CreateSandboxOptions) => {
-        // Validate API key
         const apiKey =
           config.apiKey ||
           (typeof process !== "undefined" && process.env?.RUNLOOP_API_KEY) ||
@@ -120,9 +117,7 @@ export const runloop = defineProvider<
             bearerToken: apiKey,
           });
 
-          // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: _runtime,
             timeout: optTimeout,
             envs,
             name,
@@ -135,8 +130,6 @@ export const runloop = defineProvider<
             ...providerOptions
           } = options || {};
 
-          // Convert ms to seconds for Runloop's keep_alive_time_seconds
-          // options.timeout takes precedence over config.timeout
           const effectiveTimeout = optTimeout ?? timeout;
           const keepAliveSeconds = effectiveTimeout
             ? Math.ceil(effectiveTimeout / 1000)
@@ -149,12 +142,10 @@ export const runloop = defineProvider<
             name: name || optSandboxId,
             metadata,
             environment_variables: envs,
-            ...providerOptions, // Spread provider-specific options (e.g., blueprint params, resource_size)
+            ...providerOptions,
           };
 
-          // Use blueprint if specified
           if (templateId) {
-            // Check template prefix to determine parameter type
             if (templateId.startsWith("bpt_")) {
               devboxParams.blueprint_id = templateId;
             } else if (templateId.startsWith("snp_")) {
@@ -166,10 +157,9 @@ export const runloop = defineProvider<
             devboxParams,
           );
 
-          // Create a RunloopSandbox object that contains both devbox and client
           const runloopSandbox: RunloopSandbox = {
-            ...dbx,  // Spread all DevboxView properties
-            client: client  // Add client for method access
+            ...dbx,
+            client: client
           };
 
           return {
@@ -178,8 +168,7 @@ export const runloop = defineProvider<
           };
         } catch (error) {
           throw new Error(
-            `Failed to create Runloop devbox: ${error instanceof Error ? error.message : String(error)
-            }`
+            `Failed to create Runloop devbox: ${error instanceof Error ? error.message : String(error)}`
           );
         }
       },
@@ -188,22 +177,13 @@ export const runloop = defineProvider<
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
 
         try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
+          const client = new RunloopSDK({ bearerToken: apiKey });
           const devbox = await client.api.devboxes.retrieve(sandboxId);
-          const runloopSandbox: RunloopSandbox = {
-            ...devbox,
-            client,
-          };
-
           return {
-            sandbox: runloopSandbox,
+            sandbox: { ...devbox, client } as RunloopSandbox,
             sandboxId,
           };
-        } catch (error) {
-          // Devbox doesn't exist or can't be accessed
+        } catch {
           return null;
         }
       },
@@ -212,22 +192,15 @@ export const runloop = defineProvider<
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
 
         try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
+          const client = new RunloopSDK({ bearerToken: apiKey });
           const response = await client.api.devboxes.list();
           const devboxes = response.devboxes || [];
 
           return devboxes.map((devbox) => ({
-            sandbox: {
-              ...devbox,
-              client,
-            } as RunloopSandbox,
+            sandbox: { ...devbox, client } as RunloopSandbox,
             sandboxId: devbox.id,
           }));
-        } catch (error) {
-          // Return empty array if listing fails
+        } catch {
           return [];
         }
       },
@@ -236,18 +209,12 @@ export const runloop = defineProvider<
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
 
         try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
+          const client = new RunloopSDK({ bearerToken: apiKey });
           await client.api.devboxes.shutdown(sandboxId);
-        } catch (error) {
+        } catch {
           // Devbox might already be destroyed or doesn't exist
-          // This is acceptable for destroy operations
         }
       },
-
-      // Instance operations (map to individual Sandbox methods)
 
       runCommand: async (
         sandbox: RunloopSandbox,
@@ -259,10 +226,8 @@ export const runloop = defineProvider<
         const client = sandbox.client;
 
         try {
-          // Build the full command with options
           let fullCommand = command;
 
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
             const envPrefix = Object.entries(options.env)
               .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
@@ -270,12 +235,10 @@ export const runloop = defineProvider<
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
 
-          // Handle working directory
           if (options?.cwd) {
             fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
           }
 
-          // Handle background execution
           if (options?.background) {
             fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           }
@@ -292,16 +255,11 @@ export const runloop = defineProvider<
             durationMs: Date.now() - startTime,
           };
         } catch (error) {
-          // Re-throw syntax errors
-          if (
-            error instanceof Error &&
-            error.message.includes("Syntax error")
-          ) {
+          if (error instanceof Error && error.message.includes("Syntax error")) {
             throw error;
           }
           throw new Error(
-            `Runloop execution failed: ${error instanceof Error ? error.message : String(error)
-            }`
+            `Runloop execution failed: ${error instanceof Error ? error.message : String(error)}`
           );
         }
       },
@@ -312,13 +270,13 @@ export const runloop = defineProvider<
         return {
           id: devbox.id || "runloop-unknown",
           provider: "runloop",
-          runtime: "node" as Runtime, // Runloop supports multiple runtimes, defaulting to node
           status: devbox.status as 'running' | 'stopped' | 'error',
           createdAt: new Date(devbox.create_time_ms || Date.now()),
           timeout: devbox.launch_parameters.keep_alive_time_seconds || 300000,
           metadata: {
             runloopDevboxId: devbox.id,
             templateId: devbox.blueprint_id || devbox.snapshot_id,
+            runtime: 'node',
             ...devbox.metadata,
           },
         };
@@ -336,27 +294,18 @@ export const runloop = defineProvider<
           return `https://${options.port}-${tunnel.tunnel_key}.tunnel.runloop.ai`;
         } catch (error) {
           throw new Error(
-            `Failed to get Runloop URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)
-            }`
+            `Failed to get Runloop URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`
           );
         }
       },
 
-      // Optional filesystem methods - using Runloop's file operations
       filesystem: {
         readFile: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<string> => {
-          try {
-            const result = await runCommand(sandbox, `cat "${path}"`);
-            if (result.exitCode !== 0) {
-              throw new Error(`File not found or unreadable: ${result.stderr}`);
-            }
-            return result.stdout;
-          } catch (error) {
-            throw new Error(
-              `Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)
-              }`
-            );
+          const result = await runCommand(sandbox, `cat "${path}"`);
+          if (result.exitCode !== 0) {
+            throw new Error(`File not found or unreadable: ${result.stderr}`);
           }
+          return result.stdout;
         },
 
         writeFile: async (
@@ -365,19 +314,10 @@ export const runloop = defineProvider<
           content: string,
           runCommand: CommandRunner
         ): Promise<void> => {
-          try {
-            // Use command-based approach for file writing since API writeFileContents may have issues
-            const encoded = Buffer.from(content).toString('base64');
-            const result = await runCommand(sandbox, `sh -c 'echo "${encoded}" | base64 -d > "${path}"'`);
-
-            if (result.exitCode !== 0) {
-              throw new Error(`Command failed: ${result.stderr}`);
-            }
-          } catch (error) {
-            throw new Error(
-              `Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)
-              }`
-            );
+          const encoded = Buffer.from(content).toString('base64');
+          const result = await runCommand(sandbox, `sh -c 'echo "${encoded}" | base64 -d > "${path}"'`);
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to write file ${path}: ${result.stderr}`);
           }
         },
 
@@ -388,9 +328,7 @@ export const runloop = defineProvider<
         ): Promise<void> => {
           const result = await runCommand(sandbox, `mkdir -p "${path}"`);
           if (result.exitCode !== 0) {
-            throw new Error(
-              `Failed to create directory ${path}: ${result.stderr}`
-            );
+            throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
           }
         },
 
@@ -402,9 +340,7 @@ export const runloop = defineProvider<
           const result = await runCommand(sandbox, `ls -la "${path}"`);
 
           if (result.exitCode !== 0) {
-            throw new Error(
-              `Failed to list directory ${path}: ${result.stderr}`
-            );
+            throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
           }
 
           const lines = (result.stdout || "")
@@ -446,95 +382,41 @@ export const runloop = defineProvider<
         },
       },
 
-      // Provider-specific typed getInstance method
-      getInstance: (sandbox: RunloopSandbox): RunloopSandbox => {
-        return sandbox;
-      },
+      getInstance: (sandbox: RunloopSandbox): RunloopSandbox => sandbox,
     },
 
-    // Template management methods using the new factory pattern
     template: {
       create: async (
         config: RunloopConfig,
         options: CreateBlueprintTemplateOptions | Runloop.BlueprintCreateParams
       ) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
+        if (!apiKey) throw new Error("Missing Runloop API key for blueprint template creation");
 
-        if (!apiKey) {
-          throw new Error(
-            "Missing Runloop API key for blueprint template creation"
-          );
-        }
-
-        try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
-          const blueprint = await client.api.blueprints.create(options);
-          return blueprint;
-        } catch (error) {
-          throw new Error(
-            `Failed to create blueprint template: ${error instanceof Error ? error.message : String(error)
-            }`
-          );
-        }
+        const client = new RunloopSDK({ bearerToken: apiKey });
+        return client.api.blueprints.create(options);
       },
 
       list: async (config: RunloopConfig, options?: { limit?: number }) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
+        if (!apiKey) throw new Error("Missing Runloop API key for listing blueprint templates");
 
-        if (!apiKey) {
-          throw new Error(
-            "Missing Runloop API key for listing blueprint templates"
-          );
-        }
-
-        try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
-          const listParams: any = {};
-          if (options?.limit) {
-            listParams.limit = options.limit;
-          }
-
-          const response = await client.api.blueprints.list(listParams);
-          return response.blueprints || [];
-        } catch (error) {
-          throw new Error(
-            `Failed to list blueprint templates: ${error instanceof Error ? error.message : String(error)
-            }`
-          );
-        }
+        const client = new RunloopSDK({ bearerToken: apiKey });
+        const listParams: any = {};
+        if (options?.limit) listParams.limit = options.limit;
+        const response = await client.api.blueprints.list(listParams);
+        return response.blueprints || [];
       },
 
       delete: async (config: RunloopConfig, blueprintId: string) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
+        if (!apiKey) throw new Error("Missing Runloop API key for blueprint template deletion");
 
-        if (!apiKey) {
-          throw new Error(
-            "Missing Runloop API key for blueprint template deletion"
-          );
-        }
-
-        try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
-          await client.api.blueprints.delete(blueprintId);
-        } catch (error) {
-          throw new Error(
-            `Failed to delete blueprint template ${blueprintId}: ${error instanceof Error ? error.message : String(error)
-            }`
-          );
-        }
+        const client = new RunloopSDK({ bearerToken: apiKey });
+        await client.api.blueprints.delete(blueprintId);
       },
     },
 
-    // Snapshot management methods using the new factory pattern
     snapshot: {
       create: async (
         config: RunloopConfig,
@@ -542,35 +424,13 @@ export const runloop = defineProvider<
         options?: CreateSnapshotOptions
       ) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
+        if (!apiKey) throw new Error("Missing Runloop API key for snapshot creation");
 
-        if (!apiKey) {
-          throw new Error("Missing Runloop API key for snapshot creation");
-        }
-
-        try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
-          const snapshotParams: any = {};
-          if (options?.name) {
-            snapshotParams.name = options.name;
-          }
-          if (options?.metadata) {
-            snapshotParams.metadata = options.metadata;
-          }
-
-          const snapshot = await client.api.devboxes.snapshotDisk(
-            sandboxId,
-            snapshotParams
-          );
-          return snapshot;
-        } catch (error) {
-          throw new Error(
-            `Failed to create snapshot for sandbox ${sandboxId}: ${error instanceof Error ? error.message : String(error)
-            }`
-          );
-        }
+        const client = new RunloopSDK({ bearerToken: apiKey });
+        const snapshotParams: any = {};
+        if (options?.name) snapshotParams.name = options.name;
+        if (options?.metadata) snapshotParams.metadata = options.metadata;
+        return client.api.devboxes.snapshotDisk(sandboxId, snapshotParams);
       },
 
       list: async (
@@ -578,50 +438,21 @@ export const runloop = defineProvider<
         options?: ListSnapshotsOptions
       ) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
+        if (!apiKey) throw new Error("Missing Runloop API key for listing snapshots");
 
-        if (!apiKey) {
-          throw new Error("Missing Runloop API key for listing snapshots");
-        }
-
-        try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
-          const listParams: any = {};
-          if (options?.limit) {
-            listParams.limit = options.limit;
-          }
-
-          const response = await client.api.devboxes.listDiskSnapshots(listParams);
-          return response.snapshots || [];
-        } catch (error) {
-          throw new Error(
-            `Failed to list snapshots: ${error instanceof Error ? error.message : String(error)
-            }`
-          );
-        }
+        const client = new RunloopSDK({ bearerToken: apiKey });
+        const listParams: any = {};
+        if (options?.limit) listParams.limit = options.limit;
+        const response = await client.api.devboxes.listDiskSnapshots(listParams);
+        return response.snapshots || [];
       },
 
       delete: async (config: RunloopConfig, snapshotId: string) => {
         const apiKey = config.apiKey || process.env.RUNLOOP_API_KEY!;
+        if (!apiKey) throw new Error("Missing Runloop API key for snapshot deletion");
 
-        if (!apiKey) {
-          throw new Error("Missing Runloop API key for snapshot deletion");
-        }
-
-        try {
-          const client = new RunloopSDK({
-            bearerToken: apiKey,
-          });
-
-          await client.api.devboxes.deleteDiskSnapshot(snapshotId);
-        } catch (error) {
-          throw new Error(
-            `Failed to delete snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)
-            }`
-          );
-        }
+        const client = new RunloopSDK({ bearerToken: apiKey });
+        await client.api.devboxes.deleteDiskSnapshot(snapshotId);
       },
     },
   },

--- a/packages/secure-exec/src/index.ts
+++ b/packages/secure-exec/src/index.ts
@@ -20,16 +20,12 @@ import { nanoid } from 'nanoid';
 import { defineProvider } from '@computesdk/provider';
 
 import type {
-  Runtime,
-  CodeResult,
   CommandResult,
   SandboxInfo,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions,
 } from '@computesdk/provider';
-
-// ─── Config ───────────────────────────────────────────────────────────────────
 
 export interface SecureExecConfig {
   /** Memory cap for the V8 isolate in MB. Default: 128 */
@@ -40,15 +36,11 @@ export interface SecureExecConfig {
   allowedCommands?: string[];
 }
 
-// ─── Native "sandbox" type ────────────────────────────────────────────────────
-
 export interface SecureExecInstance {
   runtime: NodeRuntime;
   fs: VirtualFileSystem;
   sandboxId: string;
 }
-
-// ─── CommandExecutor ──────────────────────────────────────────────────────────
 
 function buildCommandExecutor(allowedCommands?: string[]): CommandExecutor {
   return {
@@ -56,16 +48,13 @@ function buildCommandExecutor(allowedCommands?: string[]): CommandExecutor {
       if (allowedCommands && !allowedCommands.includes(command)) {
         throw new Error(`Command not in allowlist: ${command}`);
       }
-
       const child = spawn(command, args, {
         cwd: options.cwd === '/root' ? process.cwd() : options.cwd,
         env: { ...process.env, ...(options.env ?? {}) } as Record<string, string>,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
-
       child.stdout.on('data', (chunk: Buffer) => options.onStdout?.(new Uint8Array(chunk)));
       child.stderr.on('data', (chunk: Buffer) => options.onStderr?.(new Uint8Array(chunk)));
-
       return {
         writeStdin: (data) => { child.stdin.write(data); },
         closeStdin: () => { child.stdin.end(); },
@@ -79,8 +68,6 @@ function buildCommandExecutor(allowedCommands?: string[]): CommandExecutor {
   };
 }
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
 function captureStdio() {
   const stdout: string[] = [];
   const stderr: string[] = [];
@@ -91,16 +78,12 @@ function captureStdio() {
   return { stdout, stderr, onStdio };
 }
 
-// ─── Provider ─────────────────────────────────────────────────────────────────
-
 export const secureExec = defineProvider<SecureExecInstance, SecureExecConfig>({
   name: 'secure-exec',
-
   methods: {
     sandbox: {
       create: async (config: SecureExecConfig, options?: CreateSandboxOptions) => {
         const fs = createInMemoryFileSystem();
-
         let v8Runtime;
         try {
           v8Runtime = await createNodeV8Runtime();
@@ -111,48 +94,25 @@ export const secureExec = defineProvider<SecureExecInstance, SecureExecConfig>({
             `Original error: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
-
         const runtime = new NodeRuntime({
           systemDriver: createNodeDriver({
             filesystem: fs,
             commandExecutor: buildCommandExecutor(config.allowedCommands),
-            permissions: {
-              ...allowAllFs,
-              ...allowAllChildProcess,
-            },
-            processConfig: {
-              cwd: '/workspace',
-              env: options?.envs ?? {},
-            },
+            permissions: { ...allowAllFs, ...allowAllChildProcess },
+            processConfig: { cwd: '/workspace', env: options?.envs ?? {} },
           }),
           runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime }),
           memoryLimit: config.memoryLimitMb ?? 128,
           cpuTimeLimitMs: config.cpuTimeLimitMs ?? 30_000,
         });
-
         await fs.mkdir('/workspace');
-
         const sandboxId = `secureexec_${nanoid(10)}`;
-
-        return {
-          sandbox: { runtime, fs, sandboxId },
-          sandboxId,
-        };
+        return { sandbox: { runtime, fs, sandboxId }, sandboxId };
       },
 
-      getById: async (_config: SecureExecConfig, _sandboxId: string) => {
-        return null;
-      },
-
-      list: async (_config: SecureExecConfig) => {
-        return [];
-      },
-
-      destroy: async (_config: SecureExecConfig, _sandboxId: string) => {
-        // Static destroy has no handle to the runtime instance.
-        // Users should call sandbox.destroy() which the framework routes
-        // through the instance. Runtime GC handles cleanup otherwise.
-      },
+      getById: async (_config: SecureExecConfig, _sandboxId: string) => null,
+      list: async (_config: SecureExecConfig) => [],
+      destroy: async (_config: SecureExecConfig, _sandboxId: string) => {},
 
       runCommand: async (
         instance: SecureExecInstance,
@@ -161,24 +121,15 @@ export const secureExec = defineProvider<SecureExecInstance, SecureExecConfig>({
       ): Promise<CommandResult> => {
         const startTime = Date.now();
         const { stdout, stderr, onStdio } = captureStdio();
-
         let fullCommand = command;
-
         if (options?.env && Object.keys(options.env).length > 0) {
           const envPrefix = Object.entries(options.env)
             .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
             .join(' ');
           fullCommand = `${envPrefix} ${fullCommand}`;
         }
-
-        if (options?.cwd) {
-          fullCommand = `cd ${JSON.stringify(options.cwd)} && ${fullCommand}`;
-        }
-
-        if (options?.background) {
-          fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-        }
-
+        if (options?.cwd) fullCommand = `cd ${JSON.stringify(options.cwd)} && ${fullCommand}`;
+        if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
         try {
           const result = await instance.runtime.exec(
             `
@@ -190,75 +141,36 @@ export const secureExec = defineProvider<SecureExecInstance, SecureExecConfig>({
             `,
             { onStdio },
           );
-
-          return {
-            stdout: stdout.join('\n'),
-            stderr: stderr.join('\n'),
-            exitCode: result.code,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode: result.code, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
-      getInfo: async (instance: SecureExecInstance): Promise<SandboxInfo> => {
-        return {
-          id: instance.sandboxId,
-          provider: 'secure-exec',
-          runtime: 'node',
-          status: 'running',
-          createdAt: new Date(),
-          timeout: 0,
-          metadata: { local: true },
-        };
-      },
+      getInfo: async (instance: SecureExecInstance): Promise<SandboxInfo> => ({
+        id: instance.sandboxId,
+        provider: 'secure-exec',
+        status: 'running',
+        createdAt: new Date(),
+        timeout: 0,
+        metadata: { local: true },
+      }),
 
       getUrl: async (
         _instance: SecureExecInstance,
         _options: { port: number; protocol?: string },
       ): Promise<string> => {
-        throw new Error(
-          'getUrl is not supported by secure-exec provider. Sandboxes do not expose network endpoints.',
-        );
+        throw new Error('getUrl is not supported by secure-exec provider.');
       },
 
       filesystem: {
-        readFile: async (
-          { fs }: SecureExecInstance,
-          path: string,
-          _runCommand: unknown,
-        ): Promise<string> => {
-          return fs.readTextFile(path);
-        },
-
-        writeFile: async (
-          { fs }: SecureExecInstance,
-          path: string,
-          content: string,
-          _runCommand: unknown,
-        ): Promise<void> => {
-          await fs.writeFile(path, content);
-        },
-
-        mkdir: async (
-          { fs }: SecureExecInstance,
-          path: string,
-          _runCommand: unknown,
-        ): Promise<void> => {
-          await fs.mkdir(path);
-        },
-
-        readdir: async (
-          { fs }: SecureExecInstance,
-          path: string,
-          _runCommand: unknown,
-        ): Promise<FileEntry[]> => {
+        readFile: async ({ fs }: SecureExecInstance, path: string, _runCommand: unknown): Promise<string> =>
+          fs.readTextFile(path),
+        writeFile: async ({ fs }: SecureExecInstance, path: string, content: string, _runCommand: unknown): Promise<void> =>
+          fs.writeFile(path, content),
+        mkdir: async ({ fs }: SecureExecInstance, path: string, _runCommand: unknown): Promise<void> =>
+          fs.mkdir(path),
+        readdir: async ({ fs }: SecureExecInstance, path: string, _runCommand: unknown): Promise<FileEntry[]> => {
           const entries = await fs.readDirWithTypes(path);
           return entries.map((entry) => ({
             name: entry.name,
@@ -269,31 +181,14 @@ export const secureExec = defineProvider<SecureExecInstance, SecureExecConfig>({
             lastModified: new Date(),
           }));
         },
-
-        exists: async (
-          { fs }: SecureExecInstance,
-          path: string,
-          _runCommand: unknown,
-        ): Promise<boolean> => {
-          return fs.exists(path);
-        },
-
-        remove: async (
-          { fs }: SecureExecInstance,
-          path: string,
-          _runCommand: unknown,
-        ): Promise<void> => {
-          try {
-            await fs.removeFile(path);
-          } catch {
-            await fs.removeDir(path);
-          }
+        exists: async ({ fs }: SecureExecInstance, path: string, _runCommand: unknown): Promise<boolean> =>
+          fs.exists(path),
+        remove: async ({ fs }: SecureExecInstance, path: string, _runCommand: unknown): Promise<void> => {
+          try { await fs.removeFile(path); } catch { await fs.removeDir(path); }
         },
       },
 
-      getInstance: (instance: SecureExecInstance): SecureExecInstance => {
-        return instance;
-      },
+      getInstance: (instance: SecureExecInstance): SecureExecInstance => instance,
     },
   },
 });

--- a/packages/sprites/src/index.ts
+++ b/packages/sprites/src/index.ts
@@ -1,47 +1,31 @@
 /**
  * Sprites Provider - Factory-based Implementation
- *
- * Cloud sandbox provider using the factory pattern.
  */
 
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-/**
- * Sprites sandbox instance returned from the API
- */
 export interface SpritesSandbox {
   id: string;
   status: string;
   [key: string]: any;
 }
 
-/**
- * Sprites-specific configuration options
- */
 export interface SpritesConfig {
   /** Sprites API token - if not provided, will fallback to SPRITES_TOKEN environment variable */
   apiKey?: string;
   /** Base URL for the Sprites API */
   baseUrl?: string;
-  /** Default runtime environment (e.g. 'python', 'node') */
-  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
 }
 
-/**
- * Strip terminal control characters (SOH, etc.) from exec output
- */
 function stripControlChars(str: string): string {
   // eslint-disable-next-line no-control-regex
   return str.replace(/[\x00-\x08\x0e-\x1f]/g, '');
 }
 
-/**
- * Create a Sprites provider instance using the factory pattern
- */
 export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
   name: 'sprites',
   methods: {
@@ -50,23 +34,13 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         const token = config.apiKey || (typeof process !== 'undefined' && process.env?.SPRITES_TOKEN) || '';
         const baseUrl = config.baseUrl || 'https://api.sprites.dev/v1';
 
-        if (!token) {
-          throw new Error(
-            `Missing Sprites API token. Provide 'apiKey' in config or set SPRITES_TOKEN environment variable.`
-          );
-        }
+        if (!token) throw new Error(`Missing Sprites API token. Provide 'apiKey' in config or set SPRITES_TOKEN environment variable.`);
 
         try {
           const {
-            timeout: _timeout,
-            envs,
-            name,
-            metadata,
-            templateId: _templateId,
-            snapshotId: _snapshotId,
-            sandboxId: optSandboxId,
-            namespace: _namespace,
-            directory: _directory,
+            timeout: _timeout, envs, name, metadata,
+            templateId: _templateId, snapshotId: _snapshotId,
+            sandboxId: optSandboxId, namespace: _namespace, directory: _directory,
             ...providerOptions
           } = options || {};
 
@@ -76,27 +50,16 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
             ...providerOptions,
           };
 
-          if (envs && Object.keys(envs).length > 0) {
-            body.env_vars = envs;
-          }
-
-          if (metadata && typeof metadata === 'object') {
-            body.metadata = metadata;
-          }
+          if (envs && Object.keys(envs).length > 0) body.env_vars = envs;
+          if (metadata && typeof metadata === 'object') body.metadata = metadata;
 
           const res = await fetch(`${baseUrl}/sprites`, {
             method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json',
-            },
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
           });
 
-          if (!res.ok) {
-            const text = await res.text();
-            throw new Error(`Sprites API error (${res.status}): ${text}`);
-          }
+          if (!res.ok) { const text = await res.text(); throw new Error(`Sprites API error (${res.status}): ${text}`); }
 
           const data = await res.json() as SpritesSandbox;
           data._token = token;
@@ -104,31 +67,19 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
 
           return { sandbox: data, sandboxId: data.name };
         } catch (error) {
-          if (error instanceof Error && error.message.includes('Sprites API error')) {
-            throw error;
-          }
-          throw new Error(
-            `Failed to create Sprites sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          if (error instanceof Error && error.message.includes('Sprites API error')) throw error;
+          throw new Error(`Failed to create Sprites sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: SpritesConfig, sandboxId: string) => {
         const token = config.apiKey || (typeof process !== 'undefined' && process.env?.SPRITES_TOKEN) || '';
         const baseUrl = config.baseUrl || 'https://api.sprites.dev/v1';
-
         try {
-          const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(sandboxId)}`, {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(sandboxId)}`, { method: 'GET', headers: { 'Authorization': `Bearer ${token}` } });
           if (!res.ok) return null;
-
           const data = await res.json() as SpritesSandbox;
-          data._token = token;
-          data._baseUrl = baseUrl;
-
+          data._token = token; data._baseUrl = baseUrl;
           return { sandbox: data, sandboxId: data.name };
         } catch { return null; }
       },
@@ -136,34 +87,18 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
       list: async (config: SpritesConfig) => {
         const token = config.apiKey || (typeof process !== 'undefined' && process.env?.SPRITES_TOKEN) || '';
         const baseUrl = config.baseUrl || 'https://api.sprites.dev/v1';
-
         try {
-          const res = await fetch(`${baseUrl}/sprites`, {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const res = await fetch(`${baseUrl}/sprites`, { method: 'GET', headers: { 'Authorization': `Bearer ${token}` } });
           if (!res.ok) return [];
-
           const data = await res.json() as SpritesSandbox[];
-          return data.map((sprite: SpritesSandbox) => {
-            sprite._token = token;
-            sprite._baseUrl = baseUrl;
-            return { sandbox: sprite, sandboxId: sprite.name };
-          });
+          return data.map((sprite: SpritesSandbox) => { sprite._token = token; sprite._baseUrl = baseUrl; return { sandbox: sprite, sandboxId: sprite.name }; });
         } catch { return []; }
       },
 
       destroy: async (config: SpritesConfig, sandboxId: string) => {
         const token = config.apiKey || (typeof process !== 'undefined' && process.env?.SPRITES_TOKEN) || '';
         const baseUrl = config.baseUrl || 'https://api.sprites.dev/v1';
-
-        try {
-          await fetch(`${baseUrl}/sprites/${encodeURIComponent(sandboxId)}`, {
-            method: 'DELETE',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-        } catch { /* already destroyed or doesn't exist */ }
+        try { await fetch(`${baseUrl}/sprites/${encodeURIComponent(sandboxId)}`, { method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` } }); } catch { /* ignore */ }
       },
 
       runCommand: async (sandbox: SpritesSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
@@ -175,20 +110,13 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         const delimiter = `__COMPUTESDK_EXIT_${Date.now()}__`;
         let shellCmd = command;
 
-        if (options?.cwd) {
-          shellCmd = `cd ${escapeShellArg(options.cwd)} && ${shellCmd}`;
-        }
-
+        if (options?.cwd) shellCmd = `cd ${escapeShellArg(options.cwd)} && ${shellCmd}`;
         if (options?.env) {
           const safeKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
-          const envPrefix = Object.entries(options.env)
-            .map(([k, v]) => {
-              if (!safeKeyPattern.test(k)) {
-                throw new Error(`Invalid environment variable name: ${k}`);
-              }
-              return `${k}=${escapeShellArg(v)}`;
-            })
-            .join(' ');
+          const envPrefix = Object.entries(options.env).map(([k, v]) => {
+            if (!safeKeyPattern.test(k)) throw new Error(`Invalid environment variable name: ${k}`);
+            return `${k}=${escapeShellArg(v)}`;
+          }).join(' ');
           shellCmd = `${envPrefix} ${shellCmd}`;
         }
 
@@ -201,23 +129,16 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         try {
           const res = await fetch(url.toString(), {
             method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'text/plain',
-            },
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'text/plain' },
             body: shellCmd,
           });
 
           const raw = await res.text();
-
-          if (!res.ok) {
-            return { stdout: '', stderr: raw, exitCode: 1, durationMs: Date.now() - startTime };
-          }
+          if (!res.ok) return { stdout: '', stderr: raw, exitCode: 1, durationMs: Date.now() - startTime };
 
           const delimIdx = raw.lastIndexOf(delimiter);
           let output: string;
           let exitCode: number;
-
           if (delimIdx !== -1) {
             output = stripControlChars(raw.substring(0, delimIdx));
             exitCode = parseInt(raw.substring(delimIdx + delimiter.length).trim(), 10) || 0;
@@ -226,19 +147,9 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
             exitCode = 0;
           }
 
-          return {
-            stdout: exitCode === 0 ? output : '',
-            stderr: exitCode !== 0 ? output : '',
-            exitCode,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: exitCode === 0 ? output : '', stderr: exitCode !== 0 ? output : '', exitCode, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
@@ -246,193 +157,78 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         const token = sandbox._token;
         const baseUrl = sandbox._baseUrl;
         const name = sandbox.name;
-
         try {
-          const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(name)}`, {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(name)}`, { method: 'GET', headers: { 'Authorization': `Bearer ${token}` } });
           if (!res.ok) throw new Error(`Sprites API error (${res.status})`);
-
           const data = await res.json() as Record<string, any>;
-
           return {
-            id: data.id || name,
-            provider: 'sprites',
+            id: data.id || name, provider: 'sprites',
             status: data.status === 'running' ? 'running' : data.status === 'warm' ? 'running' : 'stopped',
-            createdAt: new Date(data.created_at),
-            timeout: 300000,
-            metadata: {
-              name: data.name,
-              organization: data.organization,
-              url: data.url,
-              urlSettings: data.url_settings,
-              lastStartedAt: data.last_started_at,
-              lastActiveAt: data.last_active_at,
-            },
+            createdAt: new Date(data.created_at), timeout: 300000,
+            metadata: { name: data.name, organization: data.organization, url: data.url, urlSettings: data.url_settings, lastStartedAt: data.last_started_at, lastActiveAt: data.last_active_at },
           };
         } catch (error) {
-          throw new Error(
-            `Failed to get Sprites info: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to get Sprites info: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getUrl: async (sandbox: SpritesSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         if (sandbox.url) {
           const protocol = options.protocol || 'https';
-          const baseHost = sandbox.url.replace(/^https?:\/\//, '');
-          return `${protocol}://${baseHost}`;
+          return `${protocol}://${sandbox.url.replace(/^https?:\/\//, '')}`;
         }
-
         const token = sandbox._token;
         const baseUrl = sandbox._baseUrl;
         const name = sandbox.name;
-
-        const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(name)}`, {
-          method: 'GET',
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-
+        const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(name)}`, { method: 'GET', headers: { 'Authorization': `Bearer ${token}` } });
         if (!res.ok) throw new Error(`Failed to get Sprites URL: API error (${res.status})`);
-
         const data = await res.json() as Record<string, any>;
         const protocol = options.protocol || 'https';
-        const host = (data.url || '').replace(/^https?:\/\//, '');
-        return `${protocol}://${host}`;
+        return `${protocol}://${(data.url || '').replace(/^https?:\/\//, '')}`;
       },
 
       filesystem: {
         readFile: async (sandbox: SpritesSandbox, filePath: string): Promise<string> => {
-          const token = sandbox._token;
-          const baseUrl = sandbox._baseUrl;
-          const name = sandbox.name;
-
-          const url = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/read`);
-          url.searchParams.set('path', filePath);
-          url.searchParams.set('workingDir', '/');
-
-          const res = await fetch(url.toString(), {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const url = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/read`);
+          url.searchParams.set('path', filePath); url.searchParams.set('workingDir', '/');
+          const res = await fetch(url.toString(), { method: 'GET', headers: { 'Authorization': `Bearer ${sandbox._token}` } });
           if (!res.ok) throw new Error(`Failed to read file: API error (${res.status})`);
           return res.text();
         },
-
         writeFile: async (sandbox: SpritesSandbox, filePath: string, content: string): Promise<void> => {
-          const token = sandbox._token;
-          const baseUrl = sandbox._baseUrl;
-          const name = sandbox.name;
-
-          const url = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/write`);
-          url.searchParams.set('path', filePath);
-          url.searchParams.set('workingDir', '/');
-          url.searchParams.set('mkdir', 'true');
-
-          const res = await fetch(url.toString(), {
-            method: 'PUT',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/octet-stream',
-            },
-            body: content,
-          });
-
+          const url = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/write`);
+          url.searchParams.set('path', filePath); url.searchParams.set('workingDir', '/'); url.searchParams.set('mkdir', 'true');
+          const res = await fetch(url.toString(), { method: 'PUT', headers: { 'Authorization': `Bearer ${sandbox._token}`, 'Content-Type': 'application/octet-stream' }, body: content });
           if (!res.ok) throw new Error(`Failed to write file: API error (${res.status})`);
         },
-
         mkdir: async (sandbox: SpritesSandbox, dirPath: string): Promise<void> => {
-          const token = sandbox._token;
-          const baseUrl = sandbox._baseUrl;
-          const name = sandbox.name;
-
-          const url = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/write`);
-          url.searchParams.set('path', `${dirPath}/.keep`);
-          url.searchParams.set('workingDir', '/');
-          url.searchParams.set('mkdir', 'true');
-
-          const res = await fetch(url.toString(), {
-            method: 'PUT',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/octet-stream',
-            },
-            body: '',
-          });
-
+          const url = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/write`);
+          url.searchParams.set('path', `${dirPath}/.keep`); url.searchParams.set('workingDir', '/'); url.searchParams.set('mkdir', 'true');
+          const res = await fetch(url.toString(), { method: 'PUT', headers: { 'Authorization': `Bearer ${sandbox._token}`, 'Content-Type': 'application/octet-stream' }, body: '' });
           if (!res.ok) throw new Error(`Failed to create directory: API error (${res.status})`);
         },
-
         readdir: async (sandbox: SpritesSandbox, dirPath: string): Promise<FileEntry[]> => {
-          const token = sandbox._token;
-          const baseUrl = sandbox._baseUrl;
-          const name = sandbox.name;
-
-          const url = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/list`);
-          url.searchParams.set('path', dirPath);
-          url.searchParams.set('workingDir', '/');
-
-          const res = await fetch(url.toString(), {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const url = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/list`);
+          url.searchParams.set('path', dirPath); url.searchParams.set('workingDir', '/');
+          const res = await fetch(url.toString(), { method: 'GET', headers: { 'Authorization': `Bearer ${sandbox._token}` } });
           if (!res.ok) throw new Error(`Failed to list directory: API error (${res.status})`);
-
           const data = await res.json() as { entries: any[]; count: number };
-          return (data.entries || []).map((entry: any) => ({
-            name: entry.name,
-            type: entry.isDir || entry.type === 'directory' ? 'directory' as const : 'file' as const,
-            size: entry.size || 0,
-            modified: new Date(entry.modified || entry.modTime || Date.now()),
-          }));
+          return (data.entries || []).map((entry: any) => ({ name: entry.name, type: entry.isDir || entry.type === 'directory' ? 'directory' as const : 'file' as const, size: entry.size || 0, modified: new Date(entry.modified || entry.modTime || Date.now()) }));
         },
-
         exists: async (sandbox: SpritesSandbox, filePath: string): Promise<boolean> => {
-          const token = sandbox._token;
-          const baseUrl = sandbox._baseUrl;
-          const name = sandbox.name;
-
-          const fileUrl = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/read`);
-          fileUrl.searchParams.set('path', filePath);
-          fileUrl.searchParams.set('workingDir', '/');
-
-          const fileRes = await fetch(fileUrl.toString(), {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const fileUrl = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/read`);
+          fileUrl.searchParams.set('path', filePath); fileUrl.searchParams.set('workingDir', '/');
+          const fileRes = await fetch(fileUrl.toString(), { method: 'GET', headers: { 'Authorization': `Bearer ${sandbox._token}` } });
           if (fileRes.ok) return true;
-
-          const dirUrl = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/list`);
-          dirUrl.searchParams.set('path', filePath);
-          dirUrl.searchParams.set('workingDir', '/');
-
-          const dirRes = await fetch(dirUrl.toString(), {
-            method: 'GET',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const dirUrl = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/list`);
+          dirUrl.searchParams.set('path', filePath); dirUrl.searchParams.set('workingDir', '/');
+          const dirRes = await fetch(dirUrl.toString(), { method: 'GET', headers: { 'Authorization': `Bearer ${sandbox._token}` } });
           return dirRes.ok;
         },
-
         remove: async (sandbox: SpritesSandbox, filePath: string): Promise<void> => {
-          const token = sandbox._token;
-          const baseUrl = sandbox._baseUrl;
-          const name = sandbox.name;
-
-          const url = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/delete`);
-          url.searchParams.set('path', filePath);
-          url.searchParams.set('workingDir', '/');
-
-          const res = await fetch(url.toString(), {
-            method: 'DELETE',
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-
+          const url = new URL(`${sandbox._baseUrl}/sprites/${encodeURIComponent(sandbox.name)}/fs/delete`);
+          url.searchParams.set('path', filePath); url.searchParams.set('workingDir', '/');
+          const res = await fetch(url.toString(), { method: 'DELETE', headers: { 'Authorization': `Bearer ${sandbox._token}` } });
           if (!res.ok) throw new Error(`Failed to delete file: API error (${res.status})`);
         }
       },

--- a/packages/sprites/src/index.ts
+++ b/packages/sprites/src/index.ts
@@ -6,7 +6,7 @@
 
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 /**
  * Sprites sandbox instance returned from the API
@@ -25,8 +25,8 @@ export interface SpritesConfig {
   apiKey?: string;
   /** Base URL for the Sprites API */
   baseUrl?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'python', 'node') */
+  runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
 }
@@ -46,7 +46,6 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
   name: 'sprites',
   methods: {
     sandbox: {
-      // Collection operations (map to compute.sandbox.*)
       create: async (config: SpritesConfig, options?: CreateSandboxOptions) => {
         const token = config.apiKey || (typeof process !== 'undefined' && process.env?.SPRITES_TOKEN) || '';
         const baseUrl = config.baseUrl || 'https://api.sprites.dev/v1';
@@ -58,9 +57,7 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         }
 
         try {
-          // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: _runtime,
             timeout: _timeout,
             envs,
             name,
@@ -76,15 +73,13 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
           const body: Record<string, any> = {
             name: name || optSandboxId || `sprite-${Date.now()}`,
             url_settings: { auth: 'public' },
-            ...providerOptions, // Spread provider-specific options
+            ...providerOptions,
           };
 
-          // Remap envs to env_vars
           if (envs && Object.keys(envs).length > 0) {
             body.env_vars = envs;
           }
 
-          // Pass metadata
           if (metadata && typeof metadata === 'object') {
             body.metadata = metadata;
           }
@@ -104,15 +99,10 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
           }
 
           const data = await res.json() as SpritesSandbox;
-
-          // Attach token and baseUrl so instance methods can use them
           data._token = token;
           data._baseUrl = baseUrl;
 
-          return {
-            sandbox: data,
-            sandboxId: data.name,
-          };
+          return { sandbox: data, sandboxId: data.name };
         } catch (error) {
           if (error instanceof Error && error.message.includes('Sprites API error')) {
             throw error;
@@ -130,26 +120,17 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         try {
           const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(sandboxId)}`, {
             method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
 
-          if (!res.ok) {
-            return null;
-          }
+          if (!res.ok) return null;
 
           const data = await res.json() as SpritesSandbox;
           data._token = token;
           data._baseUrl = baseUrl;
 
-          return {
-            sandbox: data,
-            sandboxId: data.name,
-          };
-        } catch (error) {
-          return null;
-        }
+          return { sandbox: data, sandboxId: data.name };
+        } catch { return null; }
       },
 
       list: async (config: SpritesConfig) => {
@@ -159,27 +140,18 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         try {
           const res = await fetch(`${baseUrl}/sprites`, {
             method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
 
-          if (!res.ok) {
-            return [];
-          }
+          if (!res.ok) return [];
 
           const data = await res.json() as SpritesSandbox[];
           return data.map((sprite: SpritesSandbox) => {
             sprite._token = token;
             sprite._baseUrl = baseUrl;
-            return {
-              sandbox: sprite,
-              sandboxId: sprite.name,
-            };
+            return { sandbox: sprite, sandboxId: sprite.name };
           });
-        } catch (error) {
-          return [];
-        }
+        } catch { return []; }
       },
 
       destroy: async (config: SpritesConfig, sandboxId: string) => {
@@ -189,16 +161,10 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         try {
           await fetch(`${baseUrl}/sprites/${encodeURIComponent(sandboxId)}`, {
             method: 'DELETE',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
-        } catch (error) {
-          // Sprite might already be destroyed or doesn't exist
-        }
+        } catch { /* already destroyed or doesn't exist */ }
       },
-
-      // Instance operations (map to individual Sandbox methods)
 
       runCommand: async (sandbox: SpritesSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const token = sandbox._token;
@@ -206,11 +172,6 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         const name = sandbox.name;
         const startTime = Date.now();
 
-        // Limitation: The Sprites exec API returns a single response body, so
-        // stdout and stderr are merged via 2>&1. The combined output is assigned
-        // to stdout or stderr based on exit code. This means stderr writes from
-        // successful commands (e.g., warnings) appear in stdout, and stdout from
-        // failed commands is attributed to stderr.
         const delimiter = `__COMPUTESDK_EXIT_${Date.now()}__`;
         let shellCmd = command;
 
@@ -250,15 +211,9 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
           const raw = await res.text();
 
           if (!res.ok) {
-            return {
-              stdout: '',
-              stderr: raw,
-              exitCode: 1,
-              durationMs: Date.now() - startTime,
-            };
+            return { stdout: '', stderr: raw, exitCode: 1, durationMs: Date.now() - startTime };
           }
 
-          // Parse exit code from delimiter
           const delimIdx = raw.lastIndexOf(delimiter);
           let output: string;
           let exitCode: number;
@@ -295,21 +250,16 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         try {
           const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(name)}`, {
             method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
 
-          if (!res.ok) {
-            throw new Error(`Sprites API error (${res.status})`);
-          }
+          if (!res.ok) throw new Error(`Sprites API error (${res.status})`);
 
           const data = await res.json() as Record<string, any>;
 
           return {
             id: data.id || name,
             provider: 'sprites',
-            runtime: 'python',
             status: data.status === 'running' ? 'running' : data.status === 'warm' ? 'running' : 'stopped',
             createdAt: new Date(data.created_at),
             timeout: 300000,
@@ -330,31 +280,22 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
       },
 
       getUrl: async (sandbox: SpritesSandbox, options: { port: number; protocol?: string }): Promise<string> => {
-        // Note: options.port is accepted for interface compatibility but not used.
-        // Sprites exposes a single public URL per sprite and does not support
-        // port-based routing. The API's /proxy endpoint uses WebSocket-based TCP
-        // tunneling, not HTTP port mapping like E2B or Modal.
         if (sandbox.url) {
           const protocol = options.protocol || 'https';
           const baseHost = sandbox.url.replace(/^https?:\/\//, '');
           return `${protocol}://${baseHost}`;
         }
 
-        // Fallback: fetch fresh sprite data to get the url
         const token = sandbox._token;
         const baseUrl = sandbox._baseUrl;
         const name = sandbox.name;
 
         const res = await fetch(`${baseUrl}/sprites/${encodeURIComponent(name)}`, {
           method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${token}`,
-          },
+          headers: { 'Authorization': `Bearer ${token}` },
         });
 
-        if (!res.ok) {
-          throw new Error(`Failed to get Sprites URL: API error (${res.status})`);
-        }
+        if (!res.ok) throw new Error(`Failed to get Sprites URL: API error (${res.status})`);
 
         const data = await res.json() as Record<string, any>;
         const protocol = options.protocol || 'https';
@@ -362,7 +303,6 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
         return `${protocol}://${host}`;
       },
 
-      // Optional filesystem methods
       filesystem: {
         readFile: async (sandbox: SpritesSandbox, filePath: string): Promise<string> => {
           const token = sandbox._token;
@@ -375,16 +315,11 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
 
           const res = await fetch(url.toString(), {
             method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
 
-          if (!res.ok) {
-            throw new Error(`Failed to read file: API error (${res.status})`);
-          }
-
-          return await res.text();
+          if (!res.ok) throw new Error(`Failed to read file: API error (${res.status})`);
+          return res.text();
         },
 
         writeFile: async (sandbox: SpritesSandbox, filePath: string, content: string): Promise<void> => {
@@ -406,9 +341,7 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
             body: content,
           });
 
-          if (!res.ok) {
-            throw new Error(`Failed to write file: API error (${res.status})`);
-          }
+          if (!res.ok) throw new Error(`Failed to write file: API error (${res.status})`);
         },
 
         mkdir: async (sandbox: SpritesSandbox, dirPath: string): Promise<void> => {
@@ -416,8 +349,6 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
           const baseUrl = sandbox._baseUrl;
           const name = sandbox.name;
 
-          // Use writeFile with mkdir=true to create a placeholder, ensuring the directory exists
-          // Alternatively, write an empty .keep file in the directory
           const url = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/write`);
           url.searchParams.set('path', `${dirPath}/.keep`);
           url.searchParams.set('workingDir', '/');
@@ -432,9 +363,7 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
             body: '',
           });
 
-          if (!res.ok) {
-            throw new Error(`Failed to create directory: API error (${res.status})`);
-          }
+          if (!res.ok) throw new Error(`Failed to create directory: API error (${res.status})`);
         },
 
         readdir: async (sandbox: SpritesSandbox, dirPath: string): Promise<FileEntry[]> => {
@@ -448,14 +377,10 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
 
           const res = await fetch(url.toString(), {
             method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
 
-          if (!res.ok) {
-            throw new Error(`Failed to list directory: API error (${res.status})`);
-          }
+          if (!res.ok) throw new Error(`Failed to list directory: API error (${res.status})`);
 
           const data = await res.json() as { entries: any[]; count: number };
           return (data.entries || []).map((entry: any) => ({
@@ -471,7 +396,6 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
           const baseUrl = sandbox._baseUrl;
           const name = sandbox.name;
 
-          // Try reading as a file first
           const fileUrl = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/read`);
           fileUrl.searchParams.set('path', filePath);
           fileUrl.searchParams.set('workingDir', '/');
@@ -483,7 +407,6 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
 
           if (fileRes.ok) return true;
 
-          // If file read fails, try listing as a directory
           const dirUrl = new URL(`${baseUrl}/sprites/${encodeURIComponent(name)}/fs/list`);
           dirUrl.searchParams.set('path', filePath);
           dirUrl.searchParams.set('workingDir', '/');
@@ -507,20 +430,14 @@ export const sprites = defineProvider<SpritesSandbox, SpritesConfig>({
 
           const res = await fetch(url.toString(), {
             method: 'DELETE',
-            headers: {
-              'Authorization': `Bearer ${token}`,
-            },
+            headers: { 'Authorization': `Bearer ${token}` },
           });
 
-          if (!res.ok) {
-            throw new Error(`Failed to delete file: API error (${res.status})`);
-          }
+          if (!res.ok) throw new Error(`Failed to delete file: API error (${res.status})`);
         }
       },
 
-      getInstance: (sandbox: SpritesSandbox): SpritesSandbox => {
-        return sandbox;
-      },
+      getInstance: (sandbox: SpritesSandbox): SpritesSandbox => sandbox,
     }
   }
 });

--- a/packages/test-utils/src/provider-test-suite.ts
+++ b/packages/test-utils/src/provider-test-suite.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 // @ts-ignore - workspace reference
-import type { Provider, ProviderSandbox, CommandResult, FileEntry, RunCommandOptions, Runtime, SandboxInfo } from '@computesdk/provider';
+import type { Provider, ProviderSandbox, CommandResult, FileEntry, RunCommandOptions, SandboxInfo } from '@computesdk/provider';
 
 export interface ProviderTestConfig {
   /** The provider instance to test */
@@ -46,278 +46,182 @@ export function defineProviderTests(config: ProviderTestConfig) {
   } = config;
 
   return () => {
-    // Get supported runtimes dynamically from provider
-    const supportedRuntimes = provider.getSupportedRuntimes();
-    
-    // Helper function to create and cleanup sandboxes for each runtime
-    const createRuntimeSandbox = async () => {
+    let sandbox: ProviderSandbox;
+
+    const createSandbox = async () => {
       if (skipIntegration) {
         return createMockSandbox(config);
-      } else {
-        // Only pass ports if explicitly configured (some providers don't support it)
-        const createOptions: any = {};
-        if (ports && ports.length > 0) {
-          createOptions.ports = ports;
-        }
-        return await provider.sandbox.create(createOptions);
       }
+      const createOptions: any = {};
+      if (ports && ports.length > 0) {
+        createOptions.ports = ports;
+      }
+      return await provider.sandbox.create(createOptions);
     };
 
-    const cleanupSandbox = async (sandbox: ProviderSandbox) => {
-      if (sandbox && !skipIntegration) {
+    const cleanupSandbox = async (sb: ProviderSandbox) => {
+      if (sb && !skipIntegration) {
         try {
           await Promise.race([
-            sandbox.destroy(),
-            new Promise((_, reject) => 
+            sb.destroy(),
+            new Promise((_, reject) =>
               setTimeout(() => reject(new Error('Destroy timeout')), 10000)
             )
           ]);
-        } catch (error) {
+        } catch {
           // Ignore cleanup errors (including timeouts)
         }
       }
     };
 
-    // Test each supported runtime dynamically
-    supportedRuntimes.forEach((runtime: Runtime) => {
-      const runtimeName = runtime.charAt(0).toUpperCase() + runtime.slice(1);
-      
-      describe(`${runtimeName} Runtime`, () => {
-        let sandbox: ProviderSandbox;
+    beforeEach(async () => {
+      sandbox = await createSandbox();
+    }, 90000);
 
-        beforeEach(async () => {
-          sandbox = await createRuntimeSandbox();
-        }, 90000);
+    afterEach(async () => {
+      await cleanupSandbox(sandbox);
+    }, 30000);
 
-        afterEach(async () => {
-          await cleanupSandbox(sandbox);
-        }, 30000);
-
-        it(`should create a ${runtimeName} sandbox with valid ID`, () => {
-          expect(sandbox).toBeDefined();
-          expect(sandbox.sandboxId).toBeDefined();
-          expect(typeof sandbox.sandboxId).toBe('string');
-          expect(sandbox.provider).toBe(name.toLowerCase());
-        });
-
-        // Common tests for all runtimes
-        it('should execute shell commands', async () => {
-          const result = await sandbox.runCommand('echo "Hello from command"');
-
-          expect(result).toBeDefined();
-          expect(result.stdout).toContain('Hello from command');
-          expect(result.exitCode).toBe(0);
-        }, timeout);
-
-        it('should execute background commands', async () => {
-          const result = await sandbox.runCommand('sleep 1', { background: true });
-
-          expect(result).toBeDefined();
-          // Background commands should still return quickly with exit code 0
-          expect(result.exitCode).toBe(0);
-        }, timeout);
-
-        it('should get sandbox info', async () => {
-          const info = await sandbox.getInfo();
-          
-          expect(info).toBeDefined();
-          expect(info.id).toBeDefined();
-          expect(info.provider).toBe(name.toLowerCase());
-          expect(info.status).toBeDefined();
-        });
-
-        if (supportsGetUrl) {
-          const primaryPort = (ports && ports.length > 0) ? ports[0] : 3000;
-
-          it('should get sandbox URL for a port', async () => {
-            const url = await sandbox.getUrl({ port: primaryPort });
-            
-            expect(url).toBeDefined();
-            expect(typeof url).toBe('string');
-            expect(url.length).toBeGreaterThan(0);
-            // URL should contain the port number or be a valid URL format
-            expect(url).toMatch(/^(https?|wss?):\/\/.+/);
-          });
-
-          if (ports && ports.length > 1) {
-            it('should get sandbox URL with custom protocol', async () => {
-              const url = await sandbox.getUrl({ port: ports[1], protocol: 'wss' });
-              
-              expect(url).toBeDefined();
-              expect(typeof url).toBe('string');
-              // Should respect the protocol if the provider supports it
-              // Some providers may ignore protocol and always return https
-              expect(url).toMatch(/^(https?|wss?):\/\/.+/);
-            });
-          }
-        }
-
-        it('should handle invalid commands gracefully', async () => {
-          const result = await sandbox.runCommand('nonexistent-command-12345');
-          expect(result.exitCode).not.toBe(0);
-        });
-
-        // Filesystem tests (only for first runtime to avoid duplication)
-        if (supportsFilesystem && runtime === supportedRuntimes[0]) {
-          describe('Filesystem Operations', () => {
-            const testFilePath = `${filesystemBasePath}/test-file.txt`;
-            const testDirPath = `${filesystemBasePath}/test-dir`;
-            const testContent = 'Hello, ComputeSDK filesystem!';
-
-            it('should write and read files', async () => {
-              await sandbox.filesystem.writeFile(testFilePath, testContent);
-              const content = await sandbox.filesystem.readFile(testFilePath);
-
-              expect(content).toBe(testContent);
-            }, timeout);
-
-            it('should check file existence', async () => {
-              await sandbox.filesystem.writeFile(testFilePath, testContent);
-              const exists = await sandbox.filesystem.exists(testFilePath);
-
-              expect(exists).toBe(true);
-            }, timeout);
-
-            it('should create directories', async () => {
-              await sandbox.filesystem.mkdir(testDirPath);
-              const exists = await sandbox.filesystem.exists(testDirPath);
-
-              expect(exists).toBe(true);
-            }, timeout);
-
-            it('should list directory contents', async () => {
-              await sandbox.filesystem.mkdir(testDirPath);
-              await sandbox.filesystem.writeFile(`${testDirPath}/file1.txt`, 'content1');
-              await sandbox.filesystem.writeFile(`${testDirPath}/file2.txt`, 'content2');
-
-              const entries = await sandbox.filesystem.readdir(testDirPath);
-
-              expect(entries).toBeDefined();
-              expect(Array.isArray(entries)).toBe(true);
-              expect(entries.length).toBeGreaterThanOrEqual(2);
-
-              const fileNames = entries.map((entry: FileEntry) => entry.name);
-              expect(fileNames).toContain('file1.txt');
-              expect(fileNames).toContain('file2.txt');
-            }, timeout);
-
-            it('should remove files and directories', async () => {
-              await sandbox.filesystem.writeFile(testFilePath, testContent);
-              await sandbox.filesystem.remove(testFilePath);
-
-              const exists = await sandbox.filesystem.exists(testFilePath);
-              expect(exists).toBe(false);
-            }, timeout);
-
-            it('should handle file not found errors', async () => {
-              await expect(async () => {
-                await sandbox.filesystem.readFile('/nonexistent/file.txt');
-              }).rejects.toThrow();
-            });
-          });
-        }
-
-        // Shell command argument quoting tests (only for first runtime to avoid duplication)
-        if (runtime === supportedRuntimes[0]) {
-          describe('Shell Command Argument Quoting', () => {
-            it('should properly quote arguments with spaces', async () => {
-              const result = await sandbox.runCommand('sh -c \'echo "hello world"\'');
-
-              expect(result.exitCode).toBe(0);
-              expect(result.stdout.trim()).toBe('hello world');
-            }, timeout);
-
-            it('should properly quote arguments with special characters', async () => {
-              const result = await sandbox.runCommand('sh -c \'echo "$HOME"\'');
-
-              expect(result.exitCode).toBe(0);
-              // Should output something (either literal "$HOME" or actual home path)
-              expect(result.stdout.trim()).toBeTruthy();
-            }, timeout);
-
-            it('should handle complex shell commands with pipes', async () => {
-              const result = await sandbox.runCommand('sh -c \'echo "test content" > /tmp/test-quoting.txt && cat /tmp/test-quoting.txt\'');
-
-              expect(result.exitCode).toBe(0);
-              expect(result.stdout.trim()).toBe('test content');
-            }, timeout);
-          });
-        }
-      });
+    it('should create a sandbox with valid ID', () => {
+      expect(sandbox).toBeDefined();
+      expect(sandbox.sandboxId).toBeDefined();
+      expect(typeof sandbox.sandboxId).toBe('string');
+      expect(sandbox.provider).toBe(name.toLowerCase());
     });
 
-    // Enhanced Sandbox Installation Tests (only if COMPUTESDK_API_KEY or COMPUTESDK_ACCESS_TOKEN is set)
-    // const hasComputeCredentials = typeof process !== 'undefined' &&
-    //   (process.env?.COMPUTESDK_API_KEY || process.env?.COMPUTESDK_ACCESS_TOKEN);
+    it('should execute shell commands', async () => {
+      const result = await sandbox.runCommand('echo "Hello from command"');
 
-    // if (hasComputeCredentials && !skipIntegration) {
-    //   describe('Enhanced Sandbox (ComputeSDK Integration)', () => {
-    //     it('should verify basic sandbox functionality before compute installation', async () => {
-    //       // Create a basic sandbox to verify environment is working
-    //       const sandbox = await provider.sandbox.create();
+      expect(result).toBeDefined();
+      expect(result.stdout).toContain('Hello from command');
+      expect(result.exitCode).toBe(0);
+    }, timeout);
 
-    //       try {
-    //         // Sanity check: verify basic shell commands work (use sh which should be everywhere)
-    //         const shCheck = await sandbox.runCommand('which', ['sh']);
-    //         expect(shCheck.exitCode).toBe(0);
+    it('should execute background commands', async () => {
+      const result = await sandbox.runCommand('sleep 1', { background: true });
 
-    //         // Verify we can run commands
-    //         const echoTest = await sandbox.runCommand('echo', ['test']);
-    //         expect(echoTest.exitCode).toBe(0);
-    //         expect(echoTest.stdout.trim()).toBe('test');
-    //       } finally {
-    //         await sandbox.destroy();
-    //       }
-    //     }, 30000);
+      expect(result).toBeDefined();
+      expect(result.exitCode).toBe(0);
+    }, timeout);
 
-    //     it('should create enhanced sandbox with compute CLI installed', async () => {
-    //       // Dynamically import compute to avoid circular dependencies
-    //       const { createCompute } = await import('computesdk');
+    it('should get sandbox info', async () => {
+      const info = await sandbox.getInfo();
 
-    //       const compute = createCompute({
-    //         defaultProvider: provider,
-    //         apiKey: process.env.COMPUTESDK_API_KEY!
-    //       });
+      expect(info).toBeDefined();
+      expect(info.id).toBeDefined();
+      expect(info.provider).toBe(name.toLowerCase());
+      expect(info.status).toBeDefined();
+    });
 
-    //       const sandbox = await compute.sandbox.create();
+    if (supportsGetUrl) {
+      const primaryPort = (ports && ports.length > 0) ? ports[0] : 3000;
 
-    //       try {
-    //         // Verify compute binary was installed by SDK
-    //         const verifyResult = await sandbox.runCommand('which', ['compute']);
-    //         expect(verifyResult.exitCode).toBe(0);
-    //         expect(verifyResult.stdout.trim()).toContain('compute');
+      it('should get sandbox URL for a port', async () => {
+        const url = await sandbox.getUrl({ port: primaryPort });
 
-    //         // Verify enhanced sandbox features are available (these are from ComputeClient)
-    //         expect(typeof (sandbox as any).createTerminal).toBe('function');
-    //         expect(typeof (sandbox as any).createWatcher).toBe('function');
-    //       } finally {
-    //         await sandbox.destroy();
-    //       }
-    //     }, 60000); // Longer timeout for installation
+        expect(url).toBeDefined();
+        expect(typeof url).toBe('string');
+        expect(url.length).toBeGreaterThan(0);
+        expect(url).toMatch(/^(https?|wss?):\/\/.+/);
+      });
 
-    //     it('should start compute daemon and respond to health checks', async () => {
-    //       // Dynamically import compute to avoid circular dependencies
-    //       const { createCompute } = await import('computesdk');
+      if (ports && ports.length > 1) {
+        it('should get sandbox URL with custom protocol', async () => {
+          const url = await sandbox.getUrl({ port: ports[1], protocol: 'wss' });
 
-    //       const compute = createCompute({
-    //         defaultProvider: provider,
-    //         apiKey: process.env.COMPUTESDK_API_KEY!
-    //       });
+          expect(url).toBeDefined();
+          expect(typeof url).toBe('string');
+          expect(url).toMatch(/^(https?|wss?):\/\/.+/);
+        });
+      }
+    }
 
-    //       const sandbox = await compute.sandbox.create();
+    it('should handle invalid commands gracefully', async () => {
+      const result = await sandbox.runCommand('nonexistent-command-12345');
+      expect(result.exitCode).not.toBe(0);
+    });
 
-    //       try {
-    //         // SDK should have installed and started the daemon
-    //         // Verify daemon is responding via curl (port 18080 for Vercel compatibility)
-    //         const healthResult = await sandbox.runCommand('curl', ['-s', 'http://localhost:18080/health']);
-    //         expect(healthResult.exitCode).toBe(0);
-    //         expect(healthResult.stdout).toContain('ok');
-    //       } finally {
-    //         await sandbox.destroy();
-    //       }
-    //     }, 90000); // Even longer timeout for full installation + startup
-    //   });
-    // }
+    if (supportsFilesystem) {
+      describe('Filesystem Operations', () => {
+        const testFilePath = `${filesystemBasePath}/test-file.txt`;
+        const testDirPath = `${filesystemBasePath}/test-dir`;
+        const testContent = 'Hello, ComputeSDK filesystem!';
+
+        it('should write and read files', async () => {
+          await sandbox.filesystem.writeFile(testFilePath, testContent);
+          const content = await sandbox.filesystem.readFile(testFilePath);
+
+          expect(content).toBe(testContent);
+        }, timeout);
+
+        it('should check file existence', async () => {
+          await sandbox.filesystem.writeFile(testFilePath, testContent);
+          const exists = await sandbox.filesystem.exists(testFilePath);
+
+          expect(exists).toBe(true);
+        }, timeout);
+
+        it('should create directories', async () => {
+          await sandbox.filesystem.mkdir(testDirPath);
+          const exists = await sandbox.filesystem.exists(testDirPath);
+
+          expect(exists).toBe(true);
+        }, timeout);
+
+        it('should list directory contents', async () => {
+          await sandbox.filesystem.mkdir(testDirPath);
+          await sandbox.filesystem.writeFile(`${testDirPath}/file1.txt`, 'content1');
+          await sandbox.filesystem.writeFile(`${testDirPath}/file2.txt`, 'content2');
+
+          const entries = await sandbox.filesystem.readdir(testDirPath);
+
+          expect(entries).toBeDefined();
+          expect(Array.isArray(entries)).toBe(true);
+          expect(entries.length).toBeGreaterThanOrEqual(2);
+
+          const fileNames = entries.map((entry: FileEntry) => entry.name);
+          expect(fileNames).toContain('file1.txt');
+          expect(fileNames).toContain('file2.txt');
+        }, timeout);
+
+        it('should remove files and directories', async () => {
+          await sandbox.filesystem.writeFile(testFilePath, testContent);
+          await sandbox.filesystem.remove(testFilePath);
+
+          const exists = await sandbox.filesystem.exists(testFilePath);
+          expect(exists).toBe(false);
+        }, timeout);
+
+        it('should handle file not found errors', async () => {
+          await expect(async () => {
+            await sandbox.filesystem.readFile('/nonexistent/file.txt');
+          }).rejects.toThrow();
+        });
+      });
+    }
+
+    describe('Shell Command Argument Quoting', () => {
+      it('should properly quote arguments with spaces', async () => {
+        const result = await sandbox.runCommand('sh -c \'echo "hello world"\'');
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('hello world');
+      }, timeout);
+
+      it('should properly quote arguments with special characters', async () => {
+        const result = await sandbox.runCommand('sh -c \'echo "$HOME"\'');
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBeTruthy();
+      }, timeout);
+
+      it('should handle complex shell commands with pipes', async () => {
+        const result = await sandbox.runCommand('sh -c \'echo "test content" > /tmp/test-quoting.txt && cat /tmp/test-quoting.txt\'');
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('test content');
+      }, timeout);
+    });
   };
 }
 
@@ -334,85 +238,42 @@ export function runProviderTestSuite(config: ProviderTestConfig) {
  */
 function createMockSandbox(config: ProviderTestConfig): ProviderSandbox {
   const providerName = config.name.toLowerCase();
-  
+
   // Mock state to simulate realistic behavior
   const mockFiles = new Map<string, string>();
   const mockDirs = new Set<string>();
-  
+
   return {
     sandboxId: 'mock-sandbox-123',
     provider: providerName,
-    getInstance: <T = unknown>(): T => ({} as T), // Mock native instance getter
+    getInstance: <T = unknown>(): T => ({} as T),
 
     runCommand: async (command: string, options?: RunCommandOptions): Promise<CommandResult> => {
       if (command.includes('echo "Hello from command"')) {
-        return {
-          stdout: 'Hello from command\n',
-          stderr: '',
-          exitCode: 0,
-          durationMs: 10
-        };
+        return { stdout: 'Hello from command\n', stderr: '', exitCode: 0, durationMs: 10 };
       }
-
       if (command === 'nonexistent-command-12345') {
-        return {
-          stdout: '',
-          stderr: `bash: ${command}: command not found\n`,
-          exitCode: 127,
-          durationMs: 5
-        };
+        return { stdout: '', stderr: `bash: ${command}: command not found\n`, exitCode: 127, durationMs: 5 };
       }
-
       if (command.includes('sleep 1') && options?.background) {
-        return {
-          stdout: '',
-          stderr: '',
-          exitCode: 0,
-          durationMs: 1
-        };
+        return { stdout: '', stderr: '', exitCode: 0, durationMs: 1 };
       }
-
-      // Shell command quoting tests
       if (command === 'sh -c \'echo "hello world"\'') {
-        return {
-          stdout: 'hello world\n',
-          stderr: '',
-          exitCode: 0,
-          durationMs: 10
-        };
+        return { stdout: 'hello world\n', stderr: '', exitCode: 0, durationMs: 10 };
       }
-
       if (command === 'sh -c \'echo "$HOME"\'') {
-        return {
-          stdout: '/home/user\n',
-          stderr: '',
-          exitCode: 0,
-          durationMs: 10
-        };
+        return { stdout: '/home/user\n', stderr: '', exitCode: 0, durationMs: 10 };
       }
-
       if (command === 'sh -c \'echo "test content" > /tmp/test-quoting.txt && cat /tmp/test-quoting.txt\'') {
         mockFiles.set('/tmp/test-quoting.txt', 'test content');
-        return {
-          stdout: 'test content\n',
-          stderr: '',
-          exitCode: 0,
-          durationMs: 20
-        };
+        return { stdout: 'test content\n', stderr: '', exitCode: 0, durationMs: 20 };
       }
-
-      return {
-        stdout: `Mock command output: ${command}`,
-        stderr: '',
-        exitCode: 0,
-        durationMs: 50
-      };
+      return { stdout: `Mock command output: ${command}`, stderr: '', exitCode: 0, durationMs: 50 };
     },
-    
+
     getInfo: async (): Promise<SandboxInfo> => ({
       id: 'mock-sandbox-123',
       provider: providerName,
-      runtime: 'node',
       status: 'running',
       createdAt: new Date('2024-01-01T00:00:00Z'),
       timeout: 300000,
@@ -423,83 +284,43 @@ function createMockSandbox(config: ProviderTestConfig): ProviderSandbox {
       const { port, protocol = 'https' } = options;
       return `${protocol}://mock-sandbox-123-${port}.example.com`;
     },
-    
-    destroy: async (): Promise<void> => {
-      // Mock implementation
-    },
-    
+
+    destroy: async (): Promise<void> => {},
+
     filesystem: {
       readFile: async (path: string): Promise<string> => {
-        if (mockFiles.has(path)) {
-          return mockFiles.get(path)!;
-        }
+        if (mockFiles.has(path)) return mockFiles.get(path)!;
         throw new Error(`ENOENT: no such file or directory, open '${path}'`);
       },
-      
-      writeFile: async (path: string, content: string): Promise<void> => {
-        mockFiles.set(path, content);
-      },
-      
-      mkdir: async (path: string): Promise<void> => {
-        mockDirs.add(path);
-      },
-      
+      writeFile: async (path: string, content: string): Promise<void> => { mockFiles.set(path, content); },
+      mkdir: async (path: string): Promise<void> => { mockDirs.add(path); },
       readdir: async (path: string): Promise<FileEntry[]> => {
         const entries: FileEntry[] = [];
-        
-        // Add files in this directory
         for (const [filePath, content] of mockFiles.entries()) {
           if (filePath.startsWith(path + '/') && !filePath.substring(path.length + 1).includes('/')) {
-            const fileName = filePath.substring(path.length + 1);
-            entries.push({
-              name: fileName,
-              type: 'file',
-              size: content.length,
-              modified: new Date('2024-01-01T00:00:00Z')
-            });
+            entries.push({ name: filePath.substring(path.length + 1), type: 'file', size: content.length, modified: new Date('2024-01-01T00:00:00Z') });
           }
         }
-        
-        // Add subdirectories
         for (const dirPath of mockDirs) {
           if (dirPath.startsWith(path + '/') && !dirPath.substring(path.length + 1).includes('/')) {
-            const dirName = dirPath.substring(path.length + 1);
-            entries.push({
-              name: dirName,
-              type: 'directory',
-              size: 0,
-              modified: new Date('2024-01-01T00:00:00Z')
-            });
+            entries.push({ name: dirPath.substring(path.length + 1), type: 'directory', size: 0, modified: new Date('2024-01-01T00:00:00Z') });
           }
         }
-        
         return entries;
       },
-      
-      exists: async (path: string): Promise<boolean> => {
-        return mockFiles.has(path) || mockDirs.has(path);
-      },
-      
-      remove: async (path: string): Promise<void> => {
-        mockFiles.delete(path);
-        mockDirs.delete(path);
-      }
+      exists: async (path: string): Promise<boolean> => mockFiles.has(path) || mockDirs.has(path),
+      remove: async (path: string): Promise<void> => { mockFiles.delete(path); mockDirs.delete(path); }
     },
-    
-    getProvider: (): Provider => {
-      // Return a mock provider for testing
-      return {
-        name: providerName,
-        getSupportedRuntimes: () => ['node', 'python'],
-        sandbox: {
-          create: async () => { throw new Error('Not implemented in mock'); },
-          getById: async () => { throw new Error('Not implemented in mock'); },
-          list: async () => { throw new Error('Not implemented in mock'); },
-          destroy: async () => { throw new Error('Not implemented in mock'); }
-        }
-      } as Provider;
-    }
 
+    getProvider: (): Provider => ({
+      name: providerName,
+      sandbox: {
+        create: async () => { throw new Error('Not implemented in mock'); },
+        getById: async () => { throw new Error('Not implemented in mock'); },
+        list: async () => { throw new Error('Not implemented in mock'); },
+        destroy: async () => { throw new Error('Not implemented in mock'); }
+      }
+    } as Provider)
   };
 }
 

--- a/packages/upstash/src/index.ts
+++ b/packages/upstash/src/index.ts
@@ -8,7 +8,7 @@
 import { Box, EphemeralBox } from '@upstash/box';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 export type UpstashSandboxInstance = Box | EphemeralBox;
 
@@ -29,8 +29,8 @@ export function isUpstashBoxInstance(sandbox: UpstashSandboxInstance): sandbox i
 export interface UpstashConfig {
   /** Upstash Box API key - if not provided, will fallback to UPSTASH_BOX_API_KEY environment variable */
   apiKey?: string;
-  /** Default runtime environment */
-  runtime?: Runtime;
+  /** Default runtime environment (e.g. 'node', 'python') */
+  runtime?: string;
   /** Execution timeout in milliseconds (default: 600000) */
   timeout?: number;
 }
@@ -69,20 +69,23 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
         }
 
         const timeout = options?.timeout ?? config.timeout ?? 600000;
+        const optRuntime = (options as any)?.runtime as string | undefined;
+        const ephemeral = (options as any)?.ephemeral as boolean | undefined;
+        const ttl = (options as any)?.ttl as number | undefined;
 
         try {
           let box: UpstashSandboxInstance;
 
           if (options?.snapshotId) {
-            const runtime = (options?.runtime ?? config.runtime ?? 'node') as any;
+            const runtime = (optRuntime ?? config.runtime ?? 'node') as any;
 
-            if (options?.ephemeral === true) {
+            if (ephemeral === true) {
               // Restore lightweight ephemeral box from snapshot
               box = await EphemeralBox.fromSnapshot(options.snapshotId, {
                 apiKey,
                 runtime,
                 timeout,
-                ttl: options?.ttl,
+                ttl,
                 env: options?.envs,
               });
             } else {
@@ -94,10 +97,9 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
                 env: options?.envs,
               });
             }
-          } else if (options?.ephemeral !== true) {
+          } else if (ephemeral !== true) {
             // Destructure known ComputeSDK fields, collect the rest for passthrough
             const {
-              runtime: _runtime,
               timeout: _timeout,
               envs,
               name: _name,
@@ -107,15 +109,13 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
               sandboxId: _sandboxId,
               namespace: _namespace,
               directory: _directory,
-              ephemeral: _ephemeral,
-              ttl: _ttl,
               ...providerOptions
             } = options || {};
 
             // Create new full box
             box = await Box.create({
               apiKey,
-              runtime: (_runtime ?? config.runtime ?? 'node') as any,
+              runtime: (optRuntime ?? config.runtime ?? 'node') as any,
               timeout,
               env: envs,
               ...providerOptions,
@@ -124,9 +124,9 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
             // create lightweight ephemeral box (exec + files only, instant ready)
             const ephemeralBox = await EphemeralBox.create({
               apiKey,
-              runtime: (options?.runtime ?? config.runtime ?? 'node') as any,
+              runtime: (optRuntime ?? config.runtime ?? 'node') as any,
               timeout,
-              ttl: options?.ttl,
+              ttl,
             });
             box = ephemeralBox;
           }
@@ -200,10 +200,8 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
         const startTime = Date.now();
 
         try {
-          // Build command with options
           let fullCommand = command;
 
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
             const envPrefix = Object.entries(options.env)
               .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
@@ -211,17 +209,14 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
 
-          // Handle working directory
           if (options?.cwd) {
             fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
           }
 
-          // Handle background execution
           if (options?.background) {
             fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           }
 
-          // exec.command() returns a Run<string> with .result, .exitCode, .status
           const run = await sandbox.exec.command(fullCommand);
 
           return {
@@ -231,7 +226,6 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
             durationMs: Date.now() - startTime,
           };
         } catch (error) {
-          // Extract result from error if available (non-zero exit codes)
           const result = (error as any)?.result;
           if (result) {
             return {
@@ -252,20 +246,16 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
       },
 
       getInfo: async (sandbox: UpstashSandboxInstance): Promise<SandboxInfo> => {
-        // getStatus() returns { status: string } where status is one of:
-        // "creating" | "idle" | "running" | "paused" | "error" | "deleted"
         const { status } = await sandbox.getStatus();
 
-        // Map Upstash statuses to universal set: 'running' | 'stopped' | 'error'
         const universalStatus: SandboxInfo['status'] =
           (status === 'creating' || status === 'idle' || status === 'running') ? 'running' :
             status === 'error' ? 'error' :
-              'stopped'; // paused, deleted, or any unknown state
+              'stopped';
 
         return {
           id: sandbox.id,
           provider: 'upstash',
-          runtime: 'node',
           status: universalStatus,
           createdAt: new Date(),
           timeout: 600000,
@@ -284,8 +274,6 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
         }
 
         try {
-          // getPreviewUrl() creates a publicly accessible URL for a port
-          // Returns: { url, port, token?, username?, password? }
           const preview = await sandbox.getPreviewUrl(options.port);
           return preview.url;
         } catch (error) {
@@ -296,7 +284,6 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
       },
 
       // Filesystem methods - Upstash Box has full filesystem support
-      // All paths must be under /workspace/home — resolvePath() remaps absolute paths.
       filesystem: {
         readFile: async (sandbox: UpstashSandboxInstance, path: string): Promise<string> => {
           return await sandbox.files.read(resolvePath(sandbox, path));
@@ -346,8 +333,6 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
         const apiKey = config.apiKey || process.env.UPSTASH_BOX_API_KEY!;
 
         try {
-          // Reconnect to the box and create a snapshot
-          // snapshot() creates asynchronously and polls until ready
           const box = await Box.get(sandboxId, { apiKey });
           const snapshot = await box.snapshot({
             name: options?.name || `snapshot-${Date.now()}`,
@@ -369,13 +354,11 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
         }
       },
 
-      list: async (config: UpstashConfig) => {
-        // Upstash lists snapshots per-box via box.listSnapshots(), not globally.
-        // No global snapshot list API exists.
+      list: async (_config: UpstashConfig) => {
         return [];
       },
 
-      delete: async (config: UpstashConfig, snapshotId: string) => {
+      delete: async (_config: UpstashConfig, _snapshotId: string) => {
         throw new Error(
           'Upstash snapshot deletion requires a box context. Use sandbox.getInstance().deleteSnapshot(snapshotId) instead.'
         );
@@ -383,17 +366,17 @@ export const upstash = defineProvider<UpstashSandboxInstance, UpstashConfig>({
     },
 
     template: {
-      create: async (config: UpstashConfig, options: { name: string }) => {
+      create: async (_config: UpstashConfig, _options: { name: string }) => {
         throw new Error(
           'Upstash Box does not support template creation directly. Use snapshot.create() to save a box state, then Box.fromSnapshot() to restore from it.'
         );
       },
 
-      list: async (config: UpstashConfig) => {
+      list: async (_config: UpstashConfig) => {
         return [];
       },
 
-      delete: async (config: UpstashConfig, templateId: string) => {
+      delete: async (_config: UpstashConfig, _templateId: string) => {
         // No-op - Upstash uses snapshots instead of templates
       },
     },

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -1,8 +1,5 @@
 /**
  * Vercel Provider - Factory-based Implementation
- * 
- * Demonstrates the new defineProvider() factory pattern with ~50 lines
- * instead of the original ~350 lines of boilerplate.
  */
 
 import { Sandbox as VercelSandbox, Snapshot as VercelSnapshot } from '@vercel/sandbox';
@@ -11,485 +8,240 @@ import { Writable } from 'node:stream';
 
 export type { VercelSandbox, VercelSnapshot };
 
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-import type { Runtime, CodeResult, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
-
-/**
- * Vercel sandbox provider configuration
- */
 export interface VercelConfig {
-  /** Vercel API token */
   token?: string;
-  /** Vercel team ID */
   teamId?: string;
-  /** Vercel project ID */
   projectId?: string;
-  /** Runtime environment for code execution */
-  runtime?: Runtime;
-  /** Execution timeout in milliseconds */
+  /** Default runtime environment (e.g. 'node', 'python') */
+  runtime?: string;
   timeout?: number;
-  /** Ports to expose */
   ports?: number[];
 }
 
-/**
- * Resolved Vercel credentials with the authentication method to use
- */
 interface ResolvedCredentials {
-  /** Whether to use OIDC authentication (no explicit credentials needed) */
   useOidc: boolean;
-  /** Token for traditional auth (only used if useOidc is false) */
   token: string;
-  /** Team ID for traditional auth (only used if useOidc is false) */
   teamId: string;
-  /** Project ID for traditional auth (only used if useOidc is false) */
   projectId: string;
 }
 
-/**
- * Resolve Vercel credentials with proper precedence:
- * 1. Config values (from setConfig) always win
- * 2. Environment variables are used as fallback
- * 3. OIDC is only used when no config credentials are provided
- */
 function resolveCredentials(config: VercelConfig): ResolvedCredentials {
-  // Get values from config first, then fall back to environment
   const token = config.token || (typeof process !== 'undefined' && process.env?.VERCEL_TOKEN) || '';
   const teamId = config.teamId || (typeof process !== 'undefined' && process.env?.VERCEL_TEAM_ID) || '';
   const projectId = config.projectId || (typeof process !== 'undefined' && process.env?.VERCEL_PROJECT_ID) || '';
-  
-  // Check if config explicitly provided credentials (config takes precedence)
   const hasConfigCredentials = !!(config.token || config.teamId || config.projectId);
-  
-  // Only use OIDC if:
-  // 1. No config credentials were provided, AND
-  // 2. OIDC token is available in environment
   const oidcToken = typeof process !== 'undefined' && process.env?.VERCEL_OIDC_TOKEN;
   const useOidc = !hasConfigCredentials && !!oidcToken;
-  
   return { useOidc, token, teamId, projectId };
 }
 
-/**
- * Validate that we have sufficient credentials to authenticate
- */
 function validateCredentials(creds: ResolvedCredentials): void {
-  if (creds.useOidc) {
-    // OIDC auth - no additional validation needed
-    return;
-  }
-  
-  // Traditional auth - need all three
+  if (creds.useOidc) return;
   if (!creds.token) {
     throw new Error(
       `Missing Vercel authentication. Either:\n` +
       `1. Use OIDC token: Run 'vercel env pull' to get VERCEL_OIDC_TOKEN, or\n` +
-      `2. Use traditional method: Provide 'token' in config or set VERCEL_TOKEN environment variable. Get your token from https://vercel.com/account/tokens`
+      `2. Use traditional method: Provide 'token' in config or set VERCEL_TOKEN environment variable.`
     );
   }
-  if (!creds.teamId) {
-    throw new Error(
-      `Missing Vercel team ID. Provide 'teamId' in config or set VERCEL_TEAM_ID environment variable.`
-    );
-  }
-  if (!creds.projectId) {
-    throw new Error(
-      `Missing Vercel project ID. Provide 'projectId' in config or set VERCEL_PROJECT_ID environment variable.`
-    );
-  }
+  if (!creds.teamId) throw new Error(`Missing Vercel team ID. Provide 'teamId' in config or set VERCEL_TEAM_ID.`);
+  if (!creds.projectId) throw new Error(`Missing Vercel project ID. Provide 'projectId' in config or set VERCEL_PROJECT_ID.`);
 }
 
-/**
- * Get a writable stream that collects UTF-8 string data and buffers it
- * in memory, returning the full concatenated string when done.
- */
 function getUtf8Sink() {
   const chunks: string[] = [];
   const sink = new Writable({
     write(chunk, _enc, cb) {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") :
-        String(chunk));
+      chunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
       cb();
     },
   });
   return { sink, value: () => chunks.join("") };
 }
 
-
-
-/**
- * Create a Vercel provider instance using the factory pattern
- */
 export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSnapshot>({
   name: 'vercel',
   methods: {
     sandbox: {
-      // Collection operations (map to compute.sandbox.*)
       create: async (config: VercelConfig, options?: CreateSandboxOptions) => {
-        // Resolve credentials with proper precedence (config wins over env)
         const creds = resolveCredentials(config);
         validateCredentials(creds);
-
-        // options.timeout takes precedence over config.timeout
         const timeout = options?.timeout ?? config.timeout ?? 300000;
-
         try {
-          let sandbox: VercelSandbox;
-
-          // Destructure known ComputeSDK fields, collect the rest for passthrough
           const {
-            runtime: optRuntime,
-            timeout: _timeout,
-            envs: _envs, // Vercel SDK does not support envs at sandbox creation time
-            name: _name,
-            metadata: _metadata,
-            templateId,
-            snapshotId: optSnapshotId,
-            sandboxId: _sandboxId,
-            namespace: _namespace,
-            directory: _directory,
-            ports: optPorts,
-            source: optSource,
+            timeout: _timeout, envs: _envs, name: _name, metadata: _metadata,
+            templateId, snapshotId: optSnapshotId, sandboxId: _sandboxId,
+            namespace: _namespace, directory: _directory,
             ...providerOptions
           } = options || {};
+          const optRuntime = (options as any)?.runtime;
+          const optPorts = (options as any)?.ports;
+          const optSource = (options as any)?.source;
 
-            // Construct base params, spreading provider-specific options
-            const params: any = {
-              timeout,
-              ...providerOptions, // Spread provider-specific options (e.g., resources, networkPolicy, signal)
-            };
-            
-            // Only add ports if explicitly configured (options.ports takes precedence)
-            const ports = optPorts ?? config.ports;
-            if (ports && ports.length > 0) {
-              params.ports = ports;
-            }
+          const params: any = { timeout, ...providerOptions };
+          const ports = optPorts ?? config.ports;
+          if (ports && ports.length > 0) params.ports = ports;
 
-            // Pass runtime if specified (Vercel supports runtime selection).
-            // Vercel only accepts specific versioned runtimes (node24, node22, python3.13),
-            // so translate ComputeSDK's generic names to Vercel's expected format.
-            if (optRuntime) {
-              const vercelRuntime =
-                optRuntime === 'node' ? 'node24' :
-                optRuntime === 'python' ? 'python3.13' :
-                optRuntime;
-              params.runtime = vercelRuntime;
-            }
+          if (optRuntime) {
+            params.runtime =
+              optRuntime === 'node' ? 'node24' :
+              optRuntime === 'python' ? 'python3.13' :
+              optRuntime;
+          }
 
-            // Support both ComputeSDK format (snapshotId/templateId at top level) and 
-            // Vercel SDK format (source.snapshotId nested)
-            const snapshotId = optSnapshotId || templateId ||
-              (optSource?.type === 'snapshot' && optSource?.snapshotId);
-            
-            if (snapshotId) {
-              params.source = {
-                type: 'snapshot',
-                snapshotId
-              };
-            } else if (optSource) {
-              // Pass through source as-is (e.g., git or tarball sources)
-              params.source = optSource;
-            }
+          const snapshotId = optSnapshotId || templateId ||
+            (optSource?.type === 'snapshot' && optSource?.snapshotId);
+          if (snapshotId) {
+            params.source = { type: 'snapshot', snapshotId };
+          } else if (optSource) {
+            params.source = optSource;
+          }
 
-            // Add auth params if not using OIDC
-            if (!creds.useOidc) {
-              params.token = creds.token;
-              params.teamId = creds.teamId;
-              params.projectId = creds.projectId;
-            }
+          if (!creds.useOidc) {
+            params.token = creds.token;
+            params.teamId = creds.teamId;
+            params.projectId = creds.projectId;
+          }
 
-          sandbox = await VercelSandbox.create(params);
-
-          return {
-            sandbox,
-            sandboxId: sandbox.sandboxId
-          };
+          const sandbox = await VercelSandbox.create(params);
+          return { sandbox, sandboxId: sandbox.sandboxId };
         } catch (error) {
           if (error instanceof Error) {
             if (error.message.includes('unauthorized') || error.message.includes('token')) {
-              throw new Error(
-                `Vercel authentication failed. Please check your VERCEL_TOKEN environment variable. Get your token from https://vercel.com/account/tokens`
-              );
+              throw new Error(`Vercel authentication failed. Please check your VERCEL_TOKEN environment variable.`);
             }
             if (error.message.includes('team') || error.message.includes('project')) {
-              throw new Error(
-                `Vercel team/project configuration failed. Please check your VERCEL_TEAM_ID and VERCEL_PROJECT_ID environment variables.`
-              );
+              throw new Error(`Vercel team/project configuration failed. Check VERCEL_TEAM_ID and VERCEL_PROJECT_ID.`);
             }
           }
-          throw new Error(
-            `Failed to create Vercel sandbox: ${error instanceof Error ? error.message : String(error)}`
-          );
+          throw new Error(`Failed to create Vercel sandbox: ${error instanceof Error ? error.message : String(error)}`);
         }
       },
 
       getById: async (config: VercelConfig, sandboxId: string) => {
-        // Resolve credentials with proper precedence (config wins over env)
         const creds = resolveCredentials(config);
-
         try {
-          let sandbox: VercelSandbox;
-
-          if (creds.useOidc) {
-            // Use OIDC token method
-            sandbox = await VercelSandbox.get({ sandboxId });
-          } else {
-            // Use traditional method
-            sandbox = await VercelSandbox.get({
-              sandboxId,
-              token: creds.token,
-              teamId: creds.teamId,
-              projectId: creds.projectId,
-            });
-          }
-
-          return {
-            sandbox,
-            sandboxId
-          };
-        } catch (error) {
-          // Sandbox doesn't exist or can't be accessed
-          return null;
-        }
+          const sandbox = creds.useOidc
+            ? await VercelSandbox.get({ sandboxId })
+            : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+          return { sandbox, sandboxId };
+        } catch { return null; }
       },
 
       list: async (_config: VercelConfig) => {
-        throw new Error(
-          `Vercel provider does not support listing sandboxes. Vercel sandboxes are ephemeral and designed for single-use execution.`
-        );
+        throw new Error(`Vercel provider does not support listing sandboxes.`);
       },
 
       destroy: async (config: VercelConfig, sandboxId: string) => {
-        // Resolve credentials with proper precedence (config wins over env)
         const creds = resolveCredentials(config);
-
         try {
-          let sandbox: VercelSandbox;
-
-          if (creds.useOidc) {
-            // Use OIDC token method
-            sandbox = await VercelSandbox.get({ sandboxId });
-          } else {
-            // Use traditional method
-            sandbox = await VercelSandbox.get({
-              sandboxId,
-              token: creds.token,
-              teamId: creds.teamId,
-              projectId: creds.projectId,
-            });
-          }
-
+          const sandbox = creds.useOidc
+            ? await VercelSandbox.get({ sandboxId })
+            : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
           await sandbox.stop();
-        } catch (error) {
-          // Sandbox might already be destroyed or doesn't exist
-          // This is acceptable for destroy operations
-        }
+        } catch { /* already destroyed or doesn't exist */ }
       },
-
-      // Instance operations (map to individual Sandbox methods)
 
       runCommand: async (sandbox: VercelSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
-
         try {
-          // Build command with options
           let fullCommand = command;
-          
-          // Handle environment variables
           if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env)
-              .map(([k, v]) => `${k}="${escapeShellArg(v)}"`)
-              .join(' ');
+            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(v)}"`).join(' ');
             fullCommand = `${envPrefix} ${fullCommand}`;
           }
-
-          // If running in the background, don't capture stdout/stderr
           const stdout = options?.background ? undefined : getUtf8Sink();
           const stderr = options?.background ? undefined : getUtf8Sink();
-
           const result = await sandbox.runCommand({
-            cmd: 'sh',
-            args: ['-c', fullCommand],
-            cwd: options?.cwd,
-            detached: options?.background,
-            stdout: stdout?.sink,
-            stderr: stderr?.sink,
+            cmd: 'sh', args: ['-c', fullCommand],
+            cwd: options?.cwd, detached: options?.background,
+            stdout: stdout?.sink, stderr: stderr?.sink,
           });
-
-          return {
-            stdout: stdout?.value() ?? '',
-            stderr: stderr?.value() ?? '',
-            exitCode: result.exitCode ?? 0,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: stdout?.value() ?? '', stderr: stderr?.value() ?? '', exitCode: result.exitCode ?? 0, durationMs: Date.now() - startTime };
         } catch (error) {
-          return {
-            stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
-            exitCode: 127,
-            durationMs: Date.now() - startTime,
-          };
+          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
         }
       },
 
-      getInfo: async (sandbox: VercelSandbox): Promise<SandboxInfo> => {
-        return {
-          id: 'vercel-unknown',
-          provider: 'vercel',
-          runtime: 'node', // Vercel default
-          status: 'running',
-          createdAt: new Date(),
-          timeout: 300000,
-          metadata: {
-            vercelSandboxId: 'vercel-unknown'
-          }
-        };
-      },
+      getInfo: async (_sandbox: VercelSandbox): Promise<SandboxInfo> => ({
+        id: 'vercel-unknown',
+        provider: 'vercel',
+        status: 'running',
+        createdAt: new Date(),
+        timeout: 300000,
+        metadata: { vercelSandboxId: 'vercel-unknown' }
+      }),
 
       getUrl: async (sandbox: VercelSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         try {
-          // Use Vercel's built-in domain method to get the real domain
           let url = sandbox.domain(options.port);
-          
-          // If a specific protocol is requested, replace the URL's protocol
           if (options.protocol) {
             const urlObj = new URL(url);
             urlObj.protocol = options.protocol + ':';
             url = urlObj.toString();
           }
-          
           return url;
         } catch (error) {
-          throw new Error(
-            `Failed to get Vercel domain for port ${options.port}: ${error instanceof Error ? error.message : String(error)}. Ensure the port has an associated route.`
-          );
+          throw new Error(`Failed to get Vercel domain for port ${options.port}: ${error instanceof Error ? error.message : String(error)}.`);
         }
       },
 
       filesystem: {
         readFile: async (sandbox: VercelSandbox, path: string): Promise<string> => {
           const stream = await sandbox.readFile({ path });
-          if (!stream) {
-            throw new Error(`File not found: ${path}`);
-          }
+          if (!stream) throw new Error(`File not found: ${path}`);
           const chunks: Buffer[] = [];
-          for await (const chunk of stream) {
-            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-          }
+          for await (const chunk of stream) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
           return Buffer.concat(chunks).toString('utf-8');
         },
-
         writeFile: async (sandbox: VercelSandbox, path: string, content: string): Promise<void> => {
           await sandbox.writeFiles([{ path, content: Buffer.from(content) }]);
         },
-
-        mkdir: async (sandbox: VercelSandbox, path: string): Promise<void> => {
-          await sandbox.mkDir(path);
-        },
-
+        mkdir: async (sandbox: VercelSandbox, path: string): Promise<void> => { await sandbox.mkDir(path); },
         readdir: async (_sandbox: VercelSandbox, _path: string): Promise<FileEntry[]> => {
-          throw new Error('Vercel sandbox does not support readdir. Use runCommand to list directory contents.');
+          throw new Error('Vercel sandbox does not support readdir.');
         },
-
         exists: async (_sandbox: VercelSandbox, _path: string): Promise<boolean> => {
-          throw new Error('Vercel sandbox does not support exists. Use runCommand to check file existence.');
+          throw new Error('Vercel sandbox does not support exists.');
         },
-
         remove: async (_sandbox: VercelSandbox, _path: string): Promise<void> => {
-          throw new Error('Vercel sandbox does not support remove. Use runCommand to delete files.');
+          throw new Error('Vercel sandbox does not support remove.');
         }
       },
 
-      // Provider-specific typed getInstance method
-      getInstance: (sandbox: VercelSandbox): VercelSandbox => {
-        return sandbox;
-      },
-
+      getInstance: (sandbox: VercelSandbox): VercelSandbox => sandbox,
     },
 
     snapshot: {
       create: async (config: VercelConfig, sandboxId: string) => {
-        // Resolve credentials with proper precedence (config wins over env)
         const creds = resolveCredentials(config);
-
-        let sandbox: VercelSandbox;
-
-        if (creds.useOidc) {
-          // Use OIDC token method
-          sandbox = await VercelSandbox.get({ sandboxId });
-        } else {
-          // Use traditional method
-          sandbox = await VercelSandbox.get({
-            sandboxId,
-            token: creds.token,
-            teamId: creds.teamId,
-            projectId: creds.projectId,
-          });
-        }
-
+        const sandbox = creds.useOidc
+          ? await VercelSandbox.get({ sandboxId })
+          : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
         return await sandbox.snapshot();
       },
-
-      list: async (_config: VercelConfig) => {
-        throw new Error(
-          `Vercel provider does not support listing snapshots.`
-        );
-      },
-
+      list: async (_config: VercelConfig) => { throw new Error(`Vercel provider does not support listing snapshots.`); },
       delete: async (config: VercelConfig, snapshotId: string) => {
-        // Resolve credentials with proper precedence (config wins over env)
         const creds = resolveCredentials(config);
-
-        let snapshot: VercelSnapshot;
-
-        if (creds.useOidc) {
-          // Use OIDC token method
-          snapshot = await VercelSnapshot.get({ snapshotId });
-        } else {
-          // Use traditional method
-          snapshot = await VercelSnapshot.get({
-            snapshotId,
-            token: creds.token,
-            teamId: creds.teamId,
-            projectId: creds.projectId,
-          });
-        }
-
+        const snapshot = creds.useOidc
+          ? await VercelSnapshot.get({ snapshotId })
+          : await VercelSnapshot.get({ snapshotId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
         await snapshot.delete();
       }
     },
 
-    // Vercel doesn't have a separate "template" concept - snapshots serve as templates
     template: {
       create: async (_config: VercelConfig, _options: { name: string }) => {
-        throw new Error(
-          `Vercel does not support creating templates directly. Use snapshot.create() to create a snapshot from a running sandbox.`
-        );
+        throw new Error(`Vercel does not support creating templates directly. Use snapshot.create() instead.`);
       },
-
-      list: async (_config: VercelConfig) => {
-        throw new Error(
-          `Vercel provider does not support listing templates.`
-        );
-      },
-
+      list: async (_config: VercelConfig) => { throw new Error(`Vercel provider does not support listing templates.`); },
       delete: async (config: VercelConfig, templateId: string) => {
-        // Reuse snapshot.delete since Vercel doesn't have separate templates
         const creds = resolveCredentials(config);
-
-        let snapshot: VercelSnapshot;
-
-        if (creds.useOidc) {
-          snapshot = await VercelSnapshot.get({ snapshotId: templateId });
-        } else {
-          snapshot = await VercelSnapshot.get({
-            snapshotId: templateId,
-            token: creds.token,
-            teamId: creds.teamId,
-            projectId: creds.projectId,
-          });
-        }
-
+        const snapshot = creds.useOidc
+          ? await VercelSnapshot.get({ snapshotId: templateId })
+          : await VercelSnapshot.get({ snapshotId: templateId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
         await snapshot.delete();
       }
     }

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -14,8 +14,6 @@ export interface VercelConfig {
   token?: string;
   teamId?: string;
   projectId?: string;
-  /** Default runtime environment (e.g. 'node', 'python') */
-  runtime?: string;
   timeout?: number;
   ports?: number[];
 }


### PR DESCRIPTION
## Summary

Removes the `Runtime` concept (`'node' | 'python' | 'deno' | 'bun'`) from the SDK. This was originally designed to support a `runCode()` API that was already removed. With no runtime-dispatch logic remaining, these are dead API surface.

## What changed

| File | Change |
|---|---|
| `packages/computesdk/src/types/universal-sandbox.ts` | Remove `Runtime` type; remove `runtime` field from `SandboxInfo` |
| `packages/computesdk/src/index.ts` | Remove `Runtime` from public exports |
| `packages/provider/src/types/provider.ts` | Remove `Runtime` import; remove `getSupportedRuntimes()` from `Provider` interface |
| `packages/provider/src/types/index.ts` | Remove `Runtime` from re-exports |
| `packages/provider/src/factory.ts` | Remove `Runtime` import; remove `getSupportedRuntimes()` from `GeneratedProvider` |
| `packages/test-utils/src/provider-test-suite.ts` | Remove runtime-iteration test loop; tests now run once per sandbox instead of once per runtime |
| `packages/computesdk/src/__tests__/test-utils.ts` | Remove `Runtime`, `MOCK_SUPPORTED_RUNTIMES`, `getSupportedRuntimes()` from mock provider |
| `packages/provider/src/__tests__/createCompute.test.ts` | Remove `Runtime` import and usages from mock |
| `packages/lambda/src/__tests__/index.test.ts` | Remove `getSupportedRuntimes` assertion |
| `packages/aws-lambda/src/__tests__/index.test.ts` | Remove `getSupportedRuntimes` assertion |
| `.changeset/remove-runtime-concept.md` | Changeset for major version bump |

## Breaking changes

- `Runtime` type removed from `computesdk` exports
- `runtime` field removed from `SandboxInfo`
- `getSupportedRuntimes(): Runtime[]` removed from the `Provider` interface — provider implementations no longer need to implement this

## Migration

Remove any calls to `provider.getSupportedRuntimes()` and any references to `SandboxInfo.runtime` in your code.