### PR TITLE
Add @computesdk/browseruse package

### DIFF
--- a/packages/browseruse/example-browseruse.ts
+++ b/packages/browseruse/example-browseruse.ts
@@ -1,0 +1,33 @@
+import { chromium } from 'playwright-core';
+import { browseruse } from './src/index';
+import 'dotenv/config';
+
+async function main() {
+  const bu = browseruse({ apiKey: process.env.BROWSER_USE_API_KEY });
+
+  // Create a new session (stealth + residential proxy are on by default)
+  const session = await bu.session.create();
+
+  // Connect to the session via CDP
+  const browser = await chromium.connectOverCDP(session.connectUrl);
+
+  const defaultContext = browser.contexts()[0]!;
+  const page = defaultContext.pages()[0]!;
+
+  await page.goto('https://news.ycombinator.com/');
+  const topStory = await page.evaluate(() => {
+    const titleElement = document.querySelector('.titleline > a');
+    return titleElement ? titleElement.textContent : null;
+  });
+  console.log('Top story:', topStory);
+
+  await page.close();
+  await browser.close();
+
+  // Clean up the session
+  await session.destroy();
+
+  console.log(`Session complete: ${session.sessionId}`);
+}
+
+main().catch(console.error);

--- a/packages/browseruse/package.json
+++ b/packages/browseruse/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@computesdk/browseruse",
+  "version": "0.1.0",
+  "description": "Browser Use Cloud browser provider for ComputeSDK - cloud browser sessions with stealth mode, residential proxies, profiles, and session recording",
+  "author": "Garrison",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "browser-use-sdk": "^3.4.3",
+    "computesdk": "workspace:*",
+    "dotenv": "^16.0.0",
+    "playwright-core": "^1.40.0"
+  },
+  "keywords": [
+    "computesdk",
+    "browser-use",
+    "browseruse",
+    "browser",
+    "headless",
+    "playwright",
+    "puppeteer",
+    "stealth",
+    "proxy",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/browseruse"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/browseruse/src/__tests__/index.test.ts
+++ b/packages/browseruse/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { runBrowserProviderTestSuite } from '@computesdk/test-utils';
+import { browseruse } from '../index';
+
+runBrowserProviderTestSuite({
+  name: 'browseruse',
+  provider: browseruse({}),
+  skipIntegration: !process.env.BROWSER_USE_API_KEY,
+});

--- a/packages/browseruse/src/index.ts
+++ b/packages/browseruse/src/index.ts
@@ -1,0 +1,300 @@
+/**
+ * Browser Use Cloud Browser Provider - Factory-based Implementation
+ *
+ * Cloud browser sessions with stealth mode, residential proxies, persistent
+ * profiles, and session recordings via the Browser Use Cloud platform.
+ */
+
+import { BrowserUse, type BrowserSessionItemView, type BrowserSessionView, type CreateBrowserSessionRequest, type ProfileView, type ProxyCountryCode } from 'browser-use-sdk/v3';
+import { defineBrowserProvider } from '@computesdk/provider';
+
+import type {
+  BrowserSession,
+  CreateBrowserSessionOptions,
+  BrowserProfile,
+  BrowserRecording,
+  ProxyConfig,
+} from '@computesdk/provider';
+
+/**
+ * Browser Use Cloud-specific configuration options
+ */
+export interface BrowserUseConfig {
+  /** Browser Use API key — falls back to BROWSER_USE_API_KEY env var */
+  apiKey?: string;
+  /** Optional API base URL override */
+  baseUrl?: string;
+  /** Optional request timeout (ms) */
+  timeout?: number;
+  /** Optional max retries */
+  maxRetries?: number;
+}
+
+/**
+ * The native Browser Use cloud session object returned by their SDK.
+ * The list endpoint returns the same shape (BrowserSessionItemView ⊆ BrowserSessionView).
+ */
+type BrowserUseSession = BrowserSessionView | BrowserSessionItemView;
+
+/**
+ * Resolve config values from explicit config or environment variables
+ */
+function resolveConfig(config: BrowserUseConfig) {
+  const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.BROWSER_USE_API_KEY) || '';
+
+  if (!apiKey) {
+    throw new Error(
+      `Missing Browser Use API key. Provide 'apiKey' in config or set BROWSER_USE_API_KEY environment variable. ` +
+      `Get your API key from https://cloud.browser-use.com/settings?tab=api-keys`
+    );
+  }
+
+  return { apiKey, baseUrl: config.baseUrl, timeout: config.timeout, maxRetries: config.maxRetries };
+}
+
+/**
+ * Create a Browser Use SDK client from config
+ */
+function createClient(config: BrowserUseConfig): BrowserUse {
+  const { apiKey, baseUrl, timeout, maxRetries } = resolveConfig(config);
+  return new BrowserUse({ apiKey, baseUrl, timeout, maxRetries });
+}
+
+/**
+ * Apply a single ProxyConfig entry to the create-browser request.
+ * Browser Use supports residential proxies via country code, or custom HTTP/SOCKS5
+ * proxies via host/port. When given a custom proxy, we honor that; otherwise we
+ * fall back to the residential proxy + country code.
+ */
+function applyProxy(params: Partial<CreateBrowserSessionRequest>, proxy: ProxyConfig) {
+  if (proxy.type === 'custom' && proxy.server) {
+    const { host, port } = parseProxyServer(proxy.server);
+    if (host && port) {
+      params.customProxy = {
+        host,
+        port,
+        username: proxy.username ?? null,
+        password: proxy.password ?? null,
+      };
+      return;
+    }
+  }
+  if (proxy.geolocation?.country) {
+    params.proxyCountryCode = proxy.geolocation.country.toLowerCase() as ProxyCountryCode;
+  }
+}
+
+/**
+ * Parse a proxy URL or `host:port` string into its host and port parts.
+ */
+function parseProxyServer(server: string): { host?: string; port?: number } {
+  try {
+    const url = new URL(server.includes('://') ? server : `http://${server}`);
+    const port = url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80);
+    return { host: url.hostname, port };
+  } catch {
+    const [host, portStr] = server.split(':');
+    const port = portStr ? Number(portStr) : undefined;
+    return { host, port };
+  }
+}
+
+/**
+ * Map ComputeSDK session options to Browser Use create-browser params
+ */
+function mapSessionOptions(options?: CreateBrowserSessionOptions): Partial<CreateBrowserSessionRequest> {
+  if (!options) return {};
+
+  const params: Partial<CreateBrowserSessionRequest> = {};
+
+  if (options.viewport) {
+    params.browserScreenWidth = options.viewport.width;
+    params.browserScreenHeight = options.viewport.height;
+  }
+  if (options.recording !== undefined) params.enableRecording = options.recording;
+  if (options.profileId) params.profileId = options.profileId;
+  // Browser Use accepts session timeout in minutes (default 60, max 240)
+  if (options.timeout !== undefined) params.timeout = Math.max(1, Math.ceil(options.timeout / 60));
+
+  // Stealth is enabled by default on Browser Use and not configurable per request.
+  // We accept the option for parity with other providers but it is a no-op.
+
+  if (options.proxies === false) {
+    // Explicit opt-out: disable proxy.
+    params.proxyCountryCode = null;
+  } else if (Array.isArray(options.proxies) && options.proxies.length > 0) {
+    applyProxy(params, options.proxies[0]!);
+  }
+
+  return params;
+}
+
+/**
+ * Map Browser Use session status to our standard set
+ */
+function mapStatus(status: BrowserUseSession['status']): BrowserSession['status'] {
+  switch (status) {
+    case 'active': return 'running';
+    case 'stopped': return 'completed';
+    default: return 'created';
+  }
+}
+
+/**
+ * Create a Browser Use Cloud browser provider instance
+ *
+ * @example
+ * ```ts
+ * import { browseruse } from '@computesdk/browseruse';
+ * import { chromium } from 'playwright-core';
+ *
+ * const bu = browseruse({ apiKey: process.env.BROWSER_USE_API_KEY });
+ *
+ * // Create a stealth browser session (stealth is enabled by default)
+ * const session = await bu.session.create({
+ *   proxies: [{ type: 'residential', geolocation: { country: 'us' } }],
+ * });
+ *
+ * // Connect with Playwright via CDP
+ * const browser = await chromium.connectOverCDP(session.connectUrl);
+ * const page = browser.contexts()[0].pages()[0];
+ * await page.goto('https://example.com');
+ *
+ * await session.destroy();
+ * ```
+ */
+export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseConfig>({
+  name: 'browseruse',
+  methods: {
+    // ─── Session Lifecycle ─────────────────────────────────────────────
+    session: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const session = await client.browsers.create(mapSessionOptions(options));
+        if (!session.cdpUrl) {
+          throw new Error(
+            `Browser Use returned session ${session.id} without a cdpUrl. ` +
+            `The session may not be ready yet — try fetching it again with session.getById().`
+          );
+        }
+        return {
+          session,
+          sessionId: session.id,
+          connectUrl: session.cdpUrl,
+          status: mapStatus(session.status),
+        };
+      },
+
+      getById: async (config, sessionId) => {
+        const client = createClient(config);
+        try {
+          const session = await client.browsers.get(sessionId);
+          if (!session.cdpUrl) return null;
+          return {
+            session,
+            sessionId: session.id,
+            connectUrl: session.cdpUrl,
+            status: mapStatus(session.status),
+          };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const client = createClient(config);
+        const response = await client.browsers.list();
+        return response.items.map((s) => ({
+          session: s,
+          sessionId: s.id,
+          connectUrl: s.cdpUrl ?? undefined,
+          status: mapStatus(s.status),
+        }));
+      },
+
+      destroy: async (config, sessionId) => {
+        const client = createClient(config);
+        await client.browsers.stop(sessionId);
+      },
+
+      getConnectUrl: async (config, sessionId) => {
+        const client = createClient(config);
+        const session = await client.browsers.get(sessionId);
+        if (!session.cdpUrl) {
+          throw new Error(
+            `Browser Use session ${sessionId} has no cdpUrl ` +
+            `(status: ${session.status}). The session may already be stopped.`
+          );
+        }
+        return session.cdpUrl;
+      },
+    },
+
+    // ─── Profiles (Persistent Browser Contexts) ────────────────────────
+    profile: {
+      create: async (config, options) => {
+        const client = createClient(config);
+        const result = await client.profiles.create({
+          name: options?.name,
+          // userId can be passed via metadata.userId
+          userId: typeof options?.metadata?.userId === 'string' ? options.metadata.userId : undefined,
+        });
+        return mapProfile(result);
+      },
+
+      get: async (config, profileId) => {
+        const client = createClient(config);
+        try {
+          const result = await client.profiles.get(profileId);
+          return mapProfile(result);
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config) => {
+        const client = createClient(config);
+        const response = await client.profiles.list();
+        return response.items.map(mapProfile);
+      },
+
+      delete: async (config, profileId) => {
+        const client = createClient(config);
+        await client.profiles.delete(profileId);
+      },
+    },
+
+    // ─── Recordings ────────────────────────────────────────────────────
+    // Browser Use exposes the recording URL on the session itself once the
+    // session ends. We fetch the session and surface its presigned URL.
+    recording: {
+      get: async (config, sessionId) => {
+        const client = createClient(config);
+        try {
+          const session = await client.browsers.get(sessionId);
+          if (!session.recordingUrl) return null;
+          return {
+            recordingId: sessionId,
+            sessionId,
+            format: 'mp4',
+            url: session.recordingUrl,
+          } satisfies BrowserRecording;
+        } catch {
+          return null;
+        }
+      },
+    },
+  },
+});
+
+/**
+ * Map a Browser Use profile to our standard shape
+ */
+function mapProfile(p: ProfileView): BrowserProfile {
+  return {
+    profileId: p.id,
+    name: p.name ?? undefined,
+    createdAt: p.createdAt ? new Date(p.createdAt) : undefined,
+    metadata: p.userId ? { userId: p.userId } : undefined,
+  };
+}

--- a/packages/browseruse/src/index.ts
+++ b/packages/browseruse/src/index.ts
@@ -174,7 +174,7 @@ export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseCon
         if (!session.cdpUrl) {
           throw new Error(
             `Browser Use returned session ${session.id} without a cdpUrl. ` +
-            `The session may not be ready yet — try fetching it again with session.getById().`
+            `The session may not be ready yet — try fetching it again with provider.session.getById('${session.id}').`
           );
         }
         return {
@@ -239,7 +239,11 @@ export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseCon
           // userId can be passed via metadata.userId
           userId: typeof options?.metadata?.userId === 'string' ? options.metadata.userId : undefined,
         });
-        return mapProfile(result);
+        const mapped = mapProfile(result);
+        if (options?.metadata) {
+          mapped.metadata = { ...options.metadata, ...mapped.metadata };
+        }
+        return mapped;
       },
 
       get: async (config, profileId) => {

--- a/packages/browseruse/tsconfig.json
+++ b/packages/browseruse/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/browseruse/tsup.config.ts
+++ b/packages/browseruse/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,49 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/browseruse:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      browser-use-sdk:
+        specifier: ^3.4.3
+        version: 3.4.3
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
+      playwright-core:
+        specifier: ^1.40.0
+        version: 1.58.2
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/cli:
     dependencies:
       '@clack/prompts':
@@ -4793,6 +4836,9 @@ packages:
 
   browser-resolve@2.0.0:
     resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
+
+  browser-use-sdk@3.4.3:
+    resolution: {integrity: sha512-4z4sVHCfboa4zq3a+wcdbhG9yhQH5drRaOuWeHwpZnBGwDdpGmyNnHDvbufFPtTJves8fvgbV10oGjRRdeU1yg==}
 
   browserify-aes@1.2.0:
     resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
@@ -12657,6 +12703,11 @@ snapshots:
     dependencies:
       resolve: 1.22.10
 
+  browser-use-sdk@3.4.3:
+    dependencies:
+      dotenv: 17.3.1
+      zod: 4.3.6
+
   browserify-aes@1.2.0:
     dependencies:
       buffer-xor: 1.0.3
@@ -14045,7 +14096,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -14234,7 +14285,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Summary
- Adds a new `@computesdk/browseruse` provider package that wraps the Browser Use Cloud v3 SDK (`browser-use-sdk`) behind ComputeSDK's `defineBrowserProvider` factory.
- Exposes Browser Use's raw browser endpoint (`/browsers`) so users get a CDP URL for direct Playwright/Puppeteer control — stealth and residential proxies are on by default.
- Maps `session` lifecycle, `profile` management, and `recording` retrieval onto the standard provider interface; omits `extension`/`pool`/`logs` since the v3 raw browser API does not expose them.

## Test plan
- [x] `pnpm --filter @computesdk/browseruse typecheck`
- [x] `pnpm --filter @computesdk/browseruse build`
- [x] `pnpm --filter @computesdk/browseruse test` — 7/7 pass against the live Browser Use Cloud API with `BROWSER_USE_API_KEY` set
