### PR TITLE
changeset for modal update

### DIFF
--- a/.changeset/modal-sdk-v0-7-migration.md
+++ b/.changeset/modal-sdk-v0-7-migration.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/modal": patch
+---
+
+Migrate to Modal JS SDK v0.7. Replaces the static API (App.lookup, Sandbox.fromId, app.createSandbox) with the new ModalClient subsystem API (client.apps.fromName, client.sandboxes.create, client.sandboxes.fromId), caches the App as a Promise<App> to keep the modal() factory synchronous, clarifies the auth error message to mention both config and env var credentials, and aligns the README with the v3 SDK.


### PR DESCRIPTION
This pull request migrates the codebase to use Modal JS SDK v0.7, updating API usage, improving error messages, and aligning documentation with the latest SDK version. The most important changes are:

**SDK Migration:**

* Replaces usage of the static API methods (`App.lookup`, `Sandbox.fromId`, `app.createSandbox`) with the new `ModalClient` subsystem API (`client.apps.fromName`, `client.sandboxes.create`, `client.sandboxes.fromId`).
* Caches the `App` instance as a `Promise<App>` to allow the `modal()` factory to remain synchronous.

**Error Handling:**

* Clarifies the authentication error message to mention both configuration file and environment variable credentials.

**Documentation:**

* Updates the README to align with the v3 SDK.