### PR TITLE
feat(computesdk): add defineSetup primitive (phase 1)

### DIFF
--- a/packages/computesdk/SETUP.md
+++ b/packages/computesdk/SETUP.md
@@ -1,0 +1,324 @@
+# `defineSetup` — Implementation Notes
+
+## Background
+
+This document describes the `defineSetup` primitive added to ComputeSDK in
+response to the Linear issue:"Add `defineSetup` primitive to
+ComputeSDK". It captures what was built in phase 1, the reasoning behind the
+key design decisions, and the work still needed for phase 2.
+
+The Linear issue proposed a declarative, portable value object that defines
+the execution environment for a sandbox — the runtime equivalent of a
+Dockerfile, but resolved at runtime against installed dependencies (Nix,
+where available). The motivation: today, a user who wants a sandbox with
+Python + ffmpeg + their repo cloned + dependencies installed has to write a
+sequence of imperative `runCommand()` calls. That's verbose, error-prone, and
+not portable across providers. `defineSetup` lets them describe the *what*
+once and have the SDK handle the *how* on whichever provider runs the
+workload.
+
+## Phase 1 — what shipped
+
+### New primitive
+
+```ts
+import { compute, defineSetup, deps } from 'computesdk';
+
+const setup = defineSetup({
+  source: { type: 'github', repo: 'acme/my-app', ref: 'main' },
+  deps: [deps.python, deps.ffmpeg, deps.nix('imagemagick')],
+  install: ['pip install -r requirements.txt', 'pytest'],
+  env: { API_KEY: process.env.API_KEY! },
+  resources: { cpu: 2, memory: '4gb' },
+});
+
+const sandbox = await compute.sandbox.create({ setup });
+await sandbox.runCommand('python main.py');
+```
+
+### Files added
+
+- [`src/setup.ts`](src/setup.ts) — the public surface. `defineSetup` returns
+  a deeply-frozen `SetupConfig`. The `deps` registry exposes curated
+  Nix-backed entries (`python`, `node`, `go`, `rust`, `ruby`, `ffmpeg`,
+  `imagemagick`, `git`, `curl`, `wget`, `jq`) plus `deps.nix(pkg)` as the
+  escape hatch for arbitrary `nixpkgs` atoms. Each `Dep` is a plain
+  `{ name, nixPkg }` object — no methods, fully serializable.
+- [`src/apply-setup.ts`](src/apply-setup.ts) — internal orchestrator.
+  Materializes source via the universal `runCommand` / `filesystem`
+  interface; runs `nix profile install nixpkgs#<pkg>` per dep; runs the
+  `install` script(s) sequentially. All shell arguments single-quote-escaped
+  to prevent injection.
+- [`src/__tests__/setup.test.ts`](src/__tests__/setup.test.ts) — 19 tests
+  covering value freezing, every source type, dep install command shape,
+  step ordering, env merging, shell escaping, and failure cleanup.
+
+### Files modified
+
+- [`src/types/universal-sandbox.ts`](src/types/universal-sandbox.ts) — added
+  `setup?: SetupConfig` to `CreateSandboxOptions`.
+- [`src/compute.ts`](src/compute.ts) — `createWithFallback` now merges
+  `setup.env` into `options.envs` before calling the provider, then runs
+  `applySetup` against the returned sandbox. Setup failures destroy the
+  partial sandbox before the error propagates so we don't leak resources.
+- [`src/index.ts`](src/index.ts) — exports `defineSetup`, `deps`, and the
+  associated types (`Dep`, `SetupConfig`, `SetupSource`, `SetupResources`).
+
+### Design decisions
+
+**Setup is a pure value, not a class.** Per the issue's "key design
+decisions", there is no `setup.run()` method. The sandbox owns lifecycle and
+execution; the setup is just data. Because of this, setups can be exported
+from libraries (the proto-registry idea — `@computesdk/setups/python` —
+falls out for free), JSON-serialized, sent over the wire, or compared by
+value. `defineSetup` deeply freezes the result so a shared setup can't be
+mutated by one consumer and break another.
+
+**Orchestration lives in core, not per-provider.** The Linear issue is
+silent on where setup materialization happens. We chose to put it in core
+(`apply-setup.ts`), driven entirely by the universal `Sandbox` interface
+that every provider already implements. The benefit: `defineSetup` works on
+all 40+ provider packages on day one with zero changes to any of them.
+The cost: we run extra `runCommand` calls after create. Phase 2 introduces
+a hook so providers that can do better natively (e.g. baking a setup into a
+template image) can opt in.
+
+**Nix is the dep mechanism, with no fallback.** The issue says "deps uses
+Nix under the hood for hermetic, reproducible environments." We implement
+that literally — `nix profile install nixpkgs#<pkg>`. If the sandbox image
+doesn't have Nix installed, the command fails fast with a readable error.
+We deliberately did not add an apt/yum fallback in phase 1: a fallback would
+silently degrade reproducibility, which is the whole point of the Nix
+choice. Better to be honest about which providers are setup-ready and use
+phase 2 to broaden support.
+
+**`setup.env` flows two places.** It's merged into `options.envs` before
+the provider creates the sandbox (so the runtime environment has the vars
+set persistently), *and* passed via `RunCommandOptions.env` to every command
+that `applySetup` runs (so install steps see them even if a provider doesn't
+honor `envs` for ad-hoc `runCommand` calls). User-supplied `envs` win on
+collision — explicit beats declarative.
+
+**`resources` is best-effort.** Most providers don't accept CPU/memory
+hints at create time. Phase 1 passes `setup.resources` through on the
+options object so providers can read it if they care, but core never
+errors when sizing isn't honored.
+
+### Phase 1 limitations (deliberate)
+
+- Sandbox base image must have Nix installed for `deps` to work.
+- `local` source uploads text files only — the universal
+  `SandboxFileSystem.writeFile(path, content: string)` signature can't carry
+  binaries.
+- `resources` is plumbed but unused by core; provider authors must opt in.
+- No caching — every `create({ setup })` re-clones, re-installs from
+  scratch on a fresh sandbox.
+
+---
+
+## Phase 2 — what's still needed
+
+Phase 1 ships a working primitive that is honest about its limitations.
+Phase 2 is about closing the gap between "works on Nix-ready images" and
+"works everywhere", plus the polish that makes setups useful in production.
+
+### 1. Broaden dep resolution beyond pure Nix
+
+**Problem.** Most provider base images don't ship with Nix. Today, anyone
+using `deps` on E2B, Modal, Daytona, etc. gets a hard failure on the very
+first `nix profile install`.
+
+**Proposal.** Extend the `Dep` shape to carry per-package-manager hints, and
+make `applySetup` choose at runtime based on what the sandbox has.
+
+```ts
+interface Dep {
+  name: string;
+  nixPkg: string;
+  apt?: string;       // debian/ubuntu fallback
+  brew?: string;      // macOS fallback (for local sandbox providers)
+  pip?: string;       // python-package fallback for python deps
+}
+```
+
+The orchestrator probes once per sandbox (`command -v nix`,
+`command -v apt-get`) and dispatches accordingly. Curated `deps.python`
+fills in all three fields; `deps.nix(...)` only fills `nixPkg` (escape hatch
+keeps current semantics — Nix or fail).
+
+**Acceptance.** A setup with `deps: [deps.python, deps.ffmpeg]` works on a
+stock E2B sandbox without the user installing Nix first.
+
+### 2. Provider-native setup hook
+
+**Problem.** Running setup as post-create `runCommand`s is correct but slow.
+A user who creates 100 sandboxes from the same setup runs the same git
+clone + nix install + pip install 100 times. Some providers (E2B, Modal)
+support snapshots/templates that could materialize a setup *once* and then
+reuse it.
+
+**Proposal.** Add an optional method to `DirectProvider`:
+
+```ts
+interface DirectProvider {
+  // ... existing fields
+  applySetup?: (sandbox: Sandbox, setup: SetupConfig) => Promise<void>;
+}
+```
+
+If a provider implements `applySetup`, core delegates to it instead of
+running the default orchestrator. Providers can do whatever's optimal —
+look up a cached snapshot, materialize natively, etc. — and fall back to
+calling the exported `applySetup` from `apply-setup.ts` when they don't
+have anything better.
+
+**Acceptance.** E2B provider can materialize a setup into a snapshot once
+and reuse it on subsequent `compute.sandbox.create({ setup })` calls with
+the same setup hash.
+
+### 3. Setup hashing for caching and identity
+
+**Problem.** No way to tell "is this the same setup I materialized last
+time?". Required for any caching / snapshot reuse, and useful for telemetry
+and debugging.
+
+**Proposal.** Add `hashSetup(setup: SetupConfig): string` that returns a
+stable SHA-256 of the canonicalized JSON representation of the setup.
+`defineSetup` can attach the hash as a non-enumerable property
+(`__setupHash`) so users don't have to recompute.
+
+Edge cases to handle: `env` vars that come from `process.env` should *not*
+participate in the hash (different machines, same setup logically), but
+explicit literals should. One option: split `env` into `secrets` (excluded
+from hash) and `env` (included).
+
+**Acceptance.** Two `defineSetup({...})` calls with equivalent specs produce
+the same hash; changing any field changes the hash; secrets don't.
+
+### 4. Binary file uploads for `source: 'local'`
+
+**Problem.** `SandboxFileSystem.writeFile(path, content: string)` can't
+upload images, compiled binaries, etc. Anyone using `local` source for a
+real project hits this immediately.
+
+**Proposal.** Extend the universal filesystem signature to accept
+`string | Uint8Array`, update all 40+ provider implementations to handle
+the binary case (most use SDKs that already support it), and switch the
+local-uploader to read with `fs.readFile(path)` (no encoding) and pass the
+buffer through.
+
+This is a wider change than just `setup` — it improves
+`sandbox.filesystem.writeFile` for all callers — but the local-source path
+is the forcing function.
+
+**Acceptance.** A `setup` with `source: { type: 'local', path: './app' }`
+correctly uploads a directory containing PNG assets and pre-built
+executables.
+
+### 5. Proto-registry packages
+
+**Problem.** The Linear issue calls out `@computesdk/setups/python` as a
+goal: shareable, reusable specs anyone can `import` and pass to
+`sandbox.create`. The mechanism works in phase 1 (because `defineSetup`
+returns a plain value), but no curated registry exists.
+
+**Proposal.** Stand up `packages/setups/` containing one subpackage per
+common environment:
+
+- `@computesdk/setups/python` — Python 3.12 + pip + venv + common scientific
+  stack (numpy, pandas, requests).
+- `@computesdk/setups/node` — Node 20 + npm + pnpm.
+- `@computesdk/setups/data-science` — Python + Jupyter + pandas + matplotlib
+  + ffmpeg.
+- `@computesdk/setups/playwright` — Node + Playwright + Chromium deps.
+
+Each export is a `defineSetup({...})` value. They compose naturally: a
+user can spread one and override fields:
+
+```ts
+import { pythonSetup } from '@computesdk/setups/python';
+const mySetup = defineSetup({ ...pythonSetup, install: '...' });
+```
+
+(Spread works because `defineSetup` re-freezes anyway.)
+
+**Acceptance.** At least three setups published to npm and used in an
+example in the docs.
+
+### 6. Honor `resources` where the provider supports it
+
+**Problem.** `setup.resources` is currently inert. Providers that *can*
+honor CPU/memory hints (Modal, Kernel, Fly) should do so when a setup
+specifies them.
+
+**Proposal.** Document a contract in `@computesdk/provider`: "if your
+provider's create call accepts CPU/memory, read them from
+`options.setup?.resources`". Update Modal, Kernel, and Fly first as
+reference implementations. Providers that can't honor sizing remain
+ignorant of the field.
+
+**Acceptance.** A setup with `resources: { cpu: 2, memory: '4gb' }` creates
+a Modal sandbox sized accordingly; the same setup on E2B silently uses E2B
+defaults; neither errors.
+
+### 7. Setup validation and clearer errors
+
+**Problem.** `defineSetup` accepts any object that matches the type. A
+typo like `source: { type: 'githhub', ... }` won't be caught until runtime,
+when `applySetup` falls through the source switch.
+
+**Proposal.** Validate at `defineSetup` time:
+
+- `source.type` is one of the known values.
+- `source.repo` matches `<org>/<repo>` for github source.
+- `deps` entries have `name` and `nixPkg` fields.
+- `resources.memory` matches `\d+(?:gb|mb|kb)?` (case-insensitive).
+- `env` keys are valid env-var identifiers.
+
+Throw `Error` with a path-prefixed message (`SetupConfig.source.type:
+expected "github" | "local" | "tar", got "githhub"`) so the user sees the
+problem at definition site, not deep inside an orchestrator.
+
+**Acceptance.** Every invalid `defineSetup({...})` call throws synchronously
+with a message that names the offending field and what was expected.
+
+### 8. Streaming progress for slow setups
+
+**Problem.** A setup with 5 deps and a `pip install` can take minutes.
+Today the user just waits silently for `compute.sandbox.create({ setup })`
+to resolve.
+
+**Proposal.** Optional `onProgress` callback on `CreateSandboxOptions`:
+
+```ts
+await compute.sandbox.create({
+  setup,
+  onProgress: (event) => console.log(event),
+});
+
+// event: { phase: 'source' | 'deps' | 'install', step: string, status: 'start' | 'done' | 'error', durationMs?: number }
+```
+
+`applySetup` emits one event per step. The CLI / UI layer can render this;
+programmatic users can ignore it.
+
+**Acceptance.** `examples/setup-progress` shows live progress output as a
+multi-step setup runs.
+
+---
+
+## Suggested phase 2 sequencing
+
+1. **Hashing (3)** + **validation (7)** — small, self-contained, unblock
+   everything else. ~1 day.
+2. **Multi-package-manager dep resolution (1)** — the highest-leverage
+   change for actual users. ~2 days.
+3. **Provider-native setup hook (2)** + reference impl on E2B — ~3 days.
+4. **Binary uploads (4)** — touches every provider package, so plan for
+   review fan-out. ~3 days.
+5. **Proto-registries (5)** — once 1–4 land. ~1 day.
+6. **`resources` honoring (6)** + **streaming progress (8)** — polish, can
+   slip if needed.
+
+Total: roughly 2 weeks of focused work, with (4) being the biggest unknown
+because of the cross-provider blast radius.

--- a/packages/computesdk/SETUP.md
+++ b/packages/computesdk/SETUP.md
@@ -3,7 +3,7 @@
 ## Background
 
 This document describes the `defineSetup` primitive added to ComputeSDK in
-response to the Linear issue:"Add `defineSetup` primitive to
+response to the Linear issue: "Add `defineSetup` primitive to
 ComputeSDK". It captures what was built in phase 1, the reasoning behind the
 key design decisions, and the work still needed for phase 2.
 
@@ -107,9 +107,19 @@ errors when sizing isn't honored.
 ### Phase 1 limitations (deliberate)
 
 - Sandbox base image must have Nix installed for `deps` to work.
-- `local` source uploads text files only — the universal
-  `SandboxFileSystem.writeFile(path, content: string)` signature can't carry
-  binaries.
+- Sandbox base image must have the per-source-type toolchain installed for
+  `source` to work: `git` for `source: 'github'`, and `curl` plus `tar` (with
+  gzip support) for `source: 'tar'`. `source: 'local'` has no sandbox-side
+  toolchain requirement — it uploads through the universal filesystem
+  interface. Missing tools surface as a generic `Setup step failed` with the
+  shell's `command not found` error; clearer preflight diagnostics are a
+  Phase 2 item (see "Setup validation and clearer errors" below).
+- `local` source uploads UTF-8 text files in plain directory trees only —
+  the universal `SandboxFileSystem.writeFile(path, content: string)` signature
+  can't carry binaries, and there's no symlink primitive on the universal
+  filesystem. Non-UTF-8 / binary files and symbolic links in the source tree
+  throw a clear error rather than silently corrupting or being dropped from
+  the upload.
 - `resources` is plumbed but unused by core; provider authors must opt in.
 - No caching — every `create({ setup })` re-clones, re-installs from
   scratch on a fresh sandbox.

--- a/packages/computesdk/src/__tests__/setup.test.ts
+++ b/packages/computesdk/src/__tests__/setup.test.ts
@@ -138,12 +138,82 @@ describe('applySetup', () => {
     }
   });
 
-  it('installs each dep via nix profile install', async () => {
+  it('uploads valid multi-byte UTF-8 text without rejection', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'setup-test-'));
+    try {
+      // 'héllo 🌍' exercises 2-byte and 4-byte UTF-8 sequences — must not be
+      // mistaken for non-UTF-8 by the binary check.
+      await fs.writeFile(path.join(tmp, 'a.txt'), 'héllo 🌍');
+      const sandbox = makeSandbox();
+      await applySetup(sandbox, { source: { type: 'local', path: tmp } });
+      expect(sandbox.filesystem.writeFile).toHaveBeenCalledWith('a.txt', 'héllo 🌍');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error for files containing NUL bytes (binary)', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'setup-test-'));
+    try {
+      await fs.writeFile(path.join(tmp, 'logo.png'), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+      const sandbox = makeSandbox();
+      await expect(
+        applySetup(sandbox, { source: { type: 'local', path: tmp } }),
+      ).rejects.toThrow(/Cannot upload binary file.*logo\.png/);
+      expect(sandbox.filesystem.writeFile).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error for symlinks (would otherwise silently drop)', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'setup-test-'));
+    try {
+      // Dangling symlink — readdir still surfaces it and isSymbolicLink() is
+      // true regardless of whether the target exists.
+      await fs.symlink('nonexistent-target', path.join(tmp, 'link.txt'));
+      const sandbox = makeSandbox();
+      await expect(
+        applySetup(sandbox, { source: { type: 'local', path: tmp } }),
+      ).rejects.toThrow(/Cannot upload symlink.*link\.txt/);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error for files with invalid UTF-8 byte sequences', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'setup-test-'));
+    try {
+      // PNG magic header: 0x89 is an invalid UTF-8 leading byte. No NUL, so this
+      // exercises the TextDecoder path rather than the NUL-byte fast path.
+      await fs.writeFile(path.join(tmp, 'logo.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      const sandbox = makeSandbox();
+      await expect(
+        applySetup(sandbox, { source: { type: 'local', path: tmp } }),
+      ).rejects.toThrow(/Cannot upload non-UTF-8 file.*logo\.png/);
+      expect(sandbox.filesystem.writeFile).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('installs all deps in a single batched nix profile install', async () => {
     const sandbox = makeSandbox();
     await applySetup(sandbox, { deps: [deps.python, deps.ffmpeg] });
     const calls = sandbox.runCommand.mock.calls.map((c: any[]) => c[0]);
-    expect(calls).toContain("nix profile install 'nixpkgs#python3'");
-    expect(calls).toContain("nix profile install 'nixpkgs#ffmpeg'");
+    // One invocation, both installables — pays Nix eval cost once and lets
+    // builds/fetches parallelize across the list.
+    const nixCalls = calls.filter((c: string) => c.startsWith('nix profile install'));
+    expect(nixCalls).toEqual([
+      "nix profile install 'nixpkgs#python3' 'nixpkgs#ffmpeg'",
+    ]);
+  });
+
+  it('skips nix profile install entirely when deps is empty', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, { deps: [] });
+    const calls = sandbox.runCommand.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.startsWith('nix profile install'))).toBe(false);
   });
 
   it('runs install command with env and string form', async () => {

--- a/packages/computesdk/src/__tests__/setup.test.ts
+++ b/packages/computesdk/src/__tests__/setup.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi } from 'vitest';
+import { defineSetup, deps } from '../setup';
+import { applySetup } from '../apply-setup';
+import { compute, type DirectProvider } from '../compute';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+function makeSandbox(overrides: { runCommand?: any; filesystem?: any } = {}) {
+  return {
+    sandboxId: 'sb-1',
+    provider: 'mock',
+    filesystem: {
+      readFile: vi.fn(),
+      writeFile: vi.fn(async () => {}),
+      mkdir: vi.fn(async () => {}),
+      readdir: vi.fn(),
+      exists: vi.fn(),
+      remove: vi.fn(),
+      ...overrides.filesystem,
+    },
+    runCommand: overrides.runCommand ?? vi.fn(async () => ({
+      stdout: '', stderr: '', exitCode: 0, durationMs: 1,
+    })),
+    getInfo: vi.fn(),
+    getUrl: vi.fn(),
+    destroy: vi.fn(async () => {}),
+  } as any;
+}
+
+describe('defineSetup', () => {
+  it('returns a frozen value object', () => {
+    const setup = defineSetup({
+      deps: [deps.python],
+      install: 'pip install foo',
+      env: { API_KEY: 'k' },
+    });
+    expect(Object.isFrozen(setup)).toBe(true);
+    expect(Object.isFrozen(setup.deps)).toBe(true);
+    expect(Object.isFrozen(setup.env)).toBe(true);
+    expect(() => {
+      (setup as any).install = 'mutated';
+    }).toThrow();
+  });
+
+  it('freezes nested source and resources', () => {
+    const setup = defineSetup({
+      source: { type: 'github', repo: 'a/b', ref: 'main' },
+      resources: { cpu: 2, memory: '4gb' },
+    });
+    expect(Object.isFrozen(setup.source)).toBe(true);
+    expect(Object.isFrozen(setup.resources)).toBe(true);
+  });
+
+  it('preserves install as string vs array', () => {
+    expect(defineSetup({ install: 'a' }).install).toBe('a');
+    const arr = defineSetup({ install: ['a', 'b'] }).install;
+    expect(arr).toEqual(['a', 'b']);
+    expect(Object.isFrozen(arr)).toBe(true);
+  });
+});
+
+describe('deps registry', () => {
+  it('exposes curated deps as frozen values', () => {
+    expect(deps.python).toEqual({ name: 'python', nixPkg: 'python3' });
+    expect(deps.ffmpeg).toEqual({ name: 'ffmpeg', nixPkg: 'ffmpeg' });
+    expect(Object.isFrozen(deps.python)).toBe(true);
+  });
+
+  it('exposes deps.nix as escape hatch for arbitrary nix packages', () => {
+    const dep = deps.nix('imagemagickBig');
+    expect(dep).toEqual({ name: 'imagemagickBig', nixPkg: 'imagemagickBig' });
+    expect(Object.isFrozen(dep)).toBe(true);
+  });
+});
+
+describe('applySetup', () => {
+  it('clones a github source with depth=1 and the given ref', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, {
+      source: { type: 'github', repo: 'acme/my-app', ref: 'main' },
+    });
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      "git clone --depth 1 --branch 'main' 'https://github.com/acme/my-app.git' .",
+      undefined,
+    );
+  });
+
+  it('omits --branch when ref is missing', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, { source: { type: 'github', repo: 'acme/my-app' } });
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      "git clone --depth 1 'https://github.com/acme/my-app.git' .",
+      undefined,
+    );
+  });
+
+  it('extracts a tarball via curl | tar', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, { source: { type: 'tar', url: 'https://x.test/a.tgz' } });
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      "curl -fsSL 'https://x.test/a.tgz' | tar -xz -C .",
+      undefined,
+    );
+  });
+
+  it('uploads a local directory recursively (text files only)', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'setup-test-'));
+    try {
+      await fs.writeFile(path.join(tmp, 'a.txt'), 'hello');
+      await fs.mkdir(path.join(tmp, 'sub'));
+      await fs.writeFile(path.join(tmp, 'sub', 'b.txt'), 'world');
+      const sandbox = makeSandbox();
+      await applySetup(sandbox, { source: { type: 'local', path: tmp } });
+      expect(sandbox.filesystem.writeFile).toHaveBeenCalledWith('a.txt', 'hello');
+      expect(sandbox.filesystem.mkdir).toHaveBeenCalledWith('sub');
+      expect(sandbox.filesystem.writeFile).toHaveBeenCalledWith('sub/b.txt', 'world');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('installs each dep via nix profile install', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, { deps: [deps.python, deps.ffmpeg] });
+    const calls = sandbox.runCommand.mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toContain("nix profile install 'nixpkgs#python3'");
+    expect(calls).toContain("nix profile install 'nixpkgs#ffmpeg'");
+  });
+
+  it('runs install command with env and string form', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, {
+      install: 'pip install -r requirements.txt',
+      env: { API_KEY: 'abc' },
+    });
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      'pip install -r requirements.txt',
+      { env: { API_KEY: 'abc' } },
+    );
+  });
+
+  it('runs install commands sequentially when given an array', async () => {
+    const order: string[] = [];
+    const sandbox = makeSandbox({
+      runCommand: vi.fn(async (cmd: string) => {
+        order.push(cmd);
+        return { stdout: '', stderr: '', exitCode: 0, durationMs: 1 };
+      }),
+    });
+    await applySetup(sandbox, { install: ['echo 1', 'echo 2', 'echo 3'] });
+    expect(order).toEqual(['echo 1', 'echo 2', 'echo 3']);
+  });
+
+  it('throws when a setup step exits non-zero', async () => {
+    const sandbox = makeSandbox({
+      runCommand: vi.fn(async () => ({
+        stdout: '', stderr: 'boom', exitCode: 42, durationMs: 1,
+      })),
+    });
+    await expect(
+      applySetup(sandbox, { install: 'false' }),
+    ).rejects.toThrow(/exit 42/);
+  });
+
+  it('runs source -> deps -> install in that order', async () => {
+    const order: string[] = [];
+    const sandbox = makeSandbox({
+      runCommand: vi.fn(async (cmd: string) => {
+        order.push(cmd);
+        return { stdout: '', stderr: '', exitCode: 0, durationMs: 1 };
+      }),
+    });
+    await applySetup(sandbox, {
+      source: { type: 'github', repo: 'a/b' },
+      deps: [deps.python],
+      install: 'pip install -r r.txt',
+    });
+    expect(order[0]).toMatch(/^git clone/);
+    expect(order[1]).toMatch(/^nix profile install/);
+    expect(order[2]).toBe('pip install -r r.txt');
+  });
+
+  it('quotes shell metacharacters in source urls so the shell does not interpret them', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, {
+      source: { type: 'tar', url: "https://x.test/a.tgz; rm -rf /" },
+    });
+    // The full url should appear inside a single-quoted argument, so the shell
+    // sees one literal string rather than two commands.
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      "curl -fsSL 'https://x.test/a.tgz; rm -rf /' | tar -xz -C .",
+      undefined,
+    );
+  });
+
+  it('escapes embedded single quotes in user-provided strings', async () => {
+    const sandbox = makeSandbox();
+    await applySetup(sandbox, {
+      source: { type: 'github', repo: "a/b", ref: "weird'branch" },
+    });
+    const cmd = (sandbox.runCommand as any).mock.calls[0][0] as string;
+    // The escaped form is '\'' — the ref must round-trip cleanly through the shell.
+    expect(cmd).toContain("--branch 'weird'\\''branch'");
+  });
+});
+
+describe('compute.sandbox.create with setup', () => {
+  it('runs applySetup after the provider creates the sandbox', async () => {
+    const runCommand = vi.fn(async () => ({
+      stdout: '', stderr: '', exitCode: 0, durationMs: 1,
+    }));
+    const sandbox = makeSandbox({ runCommand });
+    const provider: DirectProvider = {
+      name: 'mock',
+      sandbox: {
+        create: vi.fn(async () => sandbox),
+        getById: async () => null,
+        destroy: async () => {},
+      },
+    };
+    compute.setConfig({ providers: [provider] });
+
+    const setup = defineSetup({ install: 'echo hi' });
+    const result = await compute.sandbox.create({ setup });
+
+    expect(result).toBe(sandbox);
+    expect(runCommand).toHaveBeenCalledWith('echo hi', undefined);
+  });
+
+  it('merges setup.env into options.envs (user envs win)', async () => {
+    const create = vi.fn(async () => makeSandbox());
+    const provider: DirectProvider = {
+      name: 'mock',
+      sandbox: { create, getById: async () => null, destroy: async () => {} },
+    };
+    compute.setConfig({ providers: [provider] });
+
+    await compute.sandbox.create({
+      setup: defineSetup({ env: { A: 'from-setup', B: 'from-setup' } }),
+      envs: { A: 'from-user' },
+    });
+
+    const passedOptions = (create as any).mock.calls[0][0];
+    expect(passedOptions.envs).toEqual({ A: 'from-user', B: 'from-setup' });
+  });
+
+  it('destroys the sandbox if applySetup fails', async () => {
+    const destroy = vi.fn(async () => {});
+    const sandbox = makeSandbox({
+      runCommand: vi.fn(async () => ({
+        stdout: '', stderr: 'install failed', exitCode: 1, durationMs: 1,
+      })),
+    });
+    sandbox.destroy = destroy;
+    const provider: DirectProvider = {
+      name: 'mock',
+      sandbox: {
+        create: async () => sandbox,
+        getById: async () => null,
+        destroy: async () => {},
+      },
+    };
+    compute.setConfig({ providers: [provider], fallbackOnError: false });
+
+    await expect(
+      compute.sandbox.create({ setup: defineSetup({ install: 'false' }) }),
+    ).rejects.toThrow(/Setup step failed/);
+    expect(destroy).toHaveBeenCalled();
+  });
+});

--- a/packages/computesdk/src/__tests__/setup.test.ts
+++ b/packages/computesdk/src/__tests__/setup.test.ts
@@ -75,13 +75,31 @@ describe('deps registry', () => {
 });
 
 describe('applySetup', () => {
-  it('clones a github source with depth=1 and the given ref', async () => {
+  it('fetches a github source at depth=1 for the given branch ref', async () => {
     const sandbox = makeSandbox();
     await applySetup(sandbox, {
       source: { type: 'github', repo: 'acme/my-app', ref: 'main' },
     });
     expect(sandbox.runCommand).toHaveBeenCalledWith(
-      "git clone --depth 1 --branch 'main' 'https://github.com/acme/my-app.git' .",
+      "git init -q && " +
+        "git remote add origin 'https://github.com/acme/my-app.git' && " +
+        "git fetch --depth 1 origin 'main' && " +
+        "git checkout -q FETCH_HEAD",
+      undefined,
+    );
+  });
+
+  it('fetches a github source at a 40-char commit SHA (pinning works)', async () => {
+    const sandbox = makeSandbox();
+    const sha = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';
+    await applySetup(sandbox, {
+      source: { type: 'github', repo: 'acme/my-app', ref: sha },
+    });
+    expect(sandbox.runCommand).toHaveBeenCalledWith(
+      "git init -q && " +
+        "git remote add origin 'https://github.com/acme/my-app.git' && " +
+        `git fetch --depth 1 origin '${sha}' && ` +
+        "git checkout -q FETCH_HEAD",
       undefined,
     );
   });
@@ -201,7 +219,7 @@ describe('applySetup', () => {
     });
     const cmd = (sandbox.runCommand as any).mock.calls[0][0] as string;
     // The escaped form is '\'' — the ref must round-trip cleanly through the shell.
-    expect(cmd).toContain("--branch 'weird'\\''branch'");
+    expect(cmd).toContain("git fetch --depth 1 origin 'weird'\\''branch'");
   });
 });
 
@@ -228,6 +246,27 @@ describe('compute.sandbox.create with setup', () => {
     expect(runCommand).toHaveBeenCalledWith('echo hi', undefined);
   });
 
+  it('does not forward setup to the provider create call', async () => {
+    const create = vi.fn(async () => makeSandbox());
+    const provider: DirectProvider = {
+      name: 'mock',
+      sandbox: { create, getById: async () => null, destroy: async () => {} },
+    };
+    compute.setConfig({ providers: [provider] });
+
+    await compute.sandbox.create({
+      setup: defineSetup({
+        source: { type: 'github', repo: 'a/b' },
+        install: 'echo hi',
+      }),
+      envs: { USER_VAR: 'v' },
+    });
+
+    const passedOptions = (create as any).mock.calls[0][0];
+    expect(passedOptions).not.toHaveProperty('setup');
+    expect(passedOptions.envs).toEqual({ USER_VAR: 'v' });
+  });
+
   it('merges setup.env into options.envs (user envs win)', async () => {
     const create = vi.fn(async () => makeSandbox());
     const provider: DirectProvider = {
@@ -243,6 +282,34 @@ describe('compute.sandbox.create with setup', () => {
 
     const passedOptions = (create as any).mock.calls[0][0];
     expect(passedOptions.envs).toEqual({ A: 'from-user', B: 'from-setup' });
+  });
+
+  it('runs setup commands with the merged env (user envs win on conflict)', async () => {
+    const runCommand = vi.fn(async () => ({
+      stdout: '', stderr: '', exitCode: 0, durationMs: 1,
+    }));
+    const sandbox = makeSandbox({ runCommand });
+    const provider: DirectProvider = {
+      name: 'mock',
+      sandbox: {
+        create: vi.fn(async () => sandbox),
+        getById: async () => null,
+        destroy: async () => {},
+      },
+    };
+    compute.setConfig({ providers: [provider] });
+
+    await compute.sandbox.create({
+      envs: { A: 'user', USER_ONLY: 'u' },
+      setup: defineSetup({
+        env: { A: 'setup', SETUP_ONLY: 's' },
+        install: 'echo hi',
+      }),
+    });
+
+    expect(runCommand).toHaveBeenCalledWith('echo hi', {
+      env: { A: 'user', SETUP_ONLY: 's', USER_ONLY: 'u' },
+    });
   });
 
   it('destroys the sandbox if applySetup fails', async () => {

--- a/packages/computesdk/src/apply-setup.ts
+++ b/packages/computesdk/src/apply-setup.ts
@@ -1,0 +1,123 @@
+/**
+ * applySetup - Orchestrator that materializes a SetupConfig inside a sandbox.
+ *
+ * This runs *after* the provider has created a raw sandbox. It uses only the
+ * universal Sandbox interface (runCommand, filesystem) so it works on every
+ * provider without provider-specific code. Providers that want to handle setup
+ * natively (e.g. by baking it into a template image) can intercept earlier.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { Sandbox, RunCommandOptions } from './types/universal-sandbox';
+import type { Dep, SetupConfig, SetupSource } from './setup';
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function runOrThrow(
+  sandbox: Sandbox,
+  command: string,
+  options: RunCommandOptions | undefined,
+  context: string,
+): Promise<void> {
+  const result = await sandbox.runCommand(command, options);
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr?.trim() || result.stdout?.trim() || '(no output)';
+    throw new Error(
+      `Setup step failed (${context}, exit ${result.exitCode}):\n  $ ${command}\n${stderr}`,
+    );
+  }
+}
+
+async function materializeSource(
+  sandbox: Sandbox,
+  source: SetupSource,
+  env: Record<string, string> | undefined,
+): Promise<void> {
+  switch (source.type) {
+    case 'github': {
+      const url = `https://github.com/${source.repo}.git`;
+      const refFlag = source.ref ? `--branch ${shellEscape(source.ref)} ` : '';
+      const command = `git clone --depth 1 ${refFlag}${shellEscape(url)} .`;
+      await runOrThrow(sandbox, command, env ? { env } : undefined, `clone ${source.repo}`);
+      return;
+    }
+    case 'tar': {
+      const command = `curl -fsSL ${shellEscape(source.url)} | tar -xz -C .`;
+      await runOrThrow(sandbox, command, env ? { env } : undefined, `extract tar ${source.url}`);
+      return;
+    }
+    case 'local': {
+      await uploadDirectory(sandbox, source.path, '.');
+      return;
+    }
+  }
+}
+
+async function uploadDirectory(
+  sandbox: Sandbox,
+  hostPath: string,
+  sandboxPath: string,
+): Promise<void> {
+  const stat = await fs.stat(hostPath);
+  if (!stat.isDirectory()) {
+    throw new Error(`Local source path is not a directory: ${hostPath}`);
+  }
+  const entries = await fs.readdir(hostPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const childHost = path.join(hostPath, entry.name);
+    const childSandbox = sandboxPath === '.' ? entry.name : `${sandboxPath}/${entry.name}`;
+    if (entry.isDirectory()) {
+      await sandbox.filesystem.mkdir(childSandbox);
+      await uploadDirectory(sandbox, childHost, childSandbox);
+    } else if (entry.isFile()) {
+      // Phase 1: text files only. The universal SandboxFileSystem.writeFile
+      // signature is (path, content: string) — binary uploads need a future
+      // extension to the interface.
+      const content = await fs.readFile(childHost, 'utf-8');
+      await sandbox.filesystem.writeFile(childSandbox, content);
+    }
+  }
+}
+
+async function installDeps(
+  sandbox: Sandbox,
+  deps: readonly Dep[],
+  env: Record<string, string> | undefined,
+): Promise<void> {
+  for (const dep of deps) {
+    const command = `nix profile install ${shellEscape(`nixpkgs#${dep.nixPkg}`)}`;
+    await runOrThrow(sandbox, command, env ? { env } : undefined, `install dep ${dep.name}`);
+  }
+}
+
+async function runInstall(
+  sandbox: Sandbox,
+  install: string | readonly string[],
+  env: Record<string, string> | undefined,
+): Promise<void> {
+  const commands = typeof install === 'string' ? [install] : install;
+  for (const command of commands) {
+    await runOrThrow(sandbox, command, env ? { env } : undefined, 'install script');
+  }
+}
+
+/**
+ * Materialize a SetupConfig inside an already-created sandbox: pull source,
+ * install deps via Nix, run install scripts. Throws on the first failure;
+ * caller is responsible for destroying the sandbox if it wants to clean up.
+ */
+export async function applySetup(sandbox: Sandbox, setup: SetupConfig): Promise<void> {
+  const env = setup.env as Record<string, string> | undefined;
+  if (setup.source) {
+    await materializeSource(sandbox, setup.source, env);
+  }
+  if (setup.deps && setup.deps.length > 0) {
+    await installDeps(sandbox, setup.deps, env);
+  }
+  if (setup.install) {
+    await runInstall(sandbox, setup.install, env);
+  }
+}

--- a/packages/computesdk/src/apply-setup.ts
+++ b/packages/computesdk/src/apply-setup.ts
@@ -39,9 +39,26 @@ async function materializeSource(
   switch (source.type) {
     case 'github': {
       const url = `https://github.com/${source.repo}.git`;
-      const refFlag = source.ref ? `--branch ${shellEscape(source.ref)} ` : '';
-      const command = `git clone --depth 1 ${refFlag}${shellEscape(url)} .`;
-      await runOrThrow(sandbox, command, env ? { env } : undefined, `clone ${source.repo}`);
+      if (source.ref) {
+        // `git clone --branch` only resolves branches and tags, so it rejects
+        // commit SHAs — the standard way to pin a reproducible checkout.
+        // `git fetch <ref>` accepts branches, tags, and SHAs uniformly on GitHub
+        // (uploadpack.allowReachableSHA1InWant is enabled there by default).
+        const command =
+          `git init -q && ` +
+          `git remote add origin ${shellEscape(url)} && ` +
+          `git fetch --depth 1 origin ${shellEscape(source.ref)} && ` +
+          `git checkout -q FETCH_HEAD`;
+        await runOrThrow(
+          sandbox,
+          command,
+          env ? { env } : undefined,
+          `clone ${source.repo}@${source.ref}`,
+        );
+      } else {
+        const command = `git clone --depth 1 ${shellEscape(url)} .`;
+        await runOrThrow(sandbox, command, env ? { env } : undefined, `clone ${source.repo}`);
+      }
       return;
     }
     case 'tar': {
@@ -108,9 +125,18 @@ async function runInstall(
  * Materialize a SetupConfig inside an already-created sandbox: pull source,
  * install deps via Nix, run install scripts. Throws on the first failure;
  * caller is responsible for destroying the sandbox if it wants to clean up.
+ *
+ * `options.env` overrides `setup.env` for the duration of setup commands. The
+ * caller (compute core) is responsible for resolving precedence between
+ * user-supplied envs and `setup.env` and passing the merged result here.
  */
-export async function applySetup(sandbox: Sandbox, setup: SetupConfig): Promise<void> {
-  const env = setup.env as Record<string, string> | undefined;
+export async function applySetup(
+  sandbox: Sandbox,
+  setup: SetupConfig,
+  options?: { env?: Record<string, string> },
+): Promise<void> {
+  const env =
+    options?.env ?? (setup.env as Record<string, string> | undefined);
   if (setup.source) {
     await materializeSource(sandbox, setup.source, env);
   }

--- a/packages/computesdk/src/apply-setup.ts
+++ b/packages/computesdk/src/apply-setup.ts
@@ -86,14 +86,41 @@ async function uploadDirectory(
   for (const entry of entries) {
     const childHost = path.join(hostPath, entry.name);
     const childSandbox = sandboxPath === '.' ? entry.name : `${sandboxPath}/${entry.name}`;
-    if (entry.isDirectory()) {
+    if (entry.isSymbolicLink()) {
+      // Phase 1 has no symlink primitive on the universal filesystem, and
+      // dereferencing on the host risks cycles and path-escape. Fail loud
+      // instead of silently dropping the entry from the upload.
+      throw new Error(
+        `Cannot upload symlink from local source: ${childHost}. ` +
+          `defineSetup({ source: { type: 'local' } }) currently does not support symbolic links. ` +
+          `Use a github or tar source for projects that rely on symlinks.`,
+      );
+    } else if (entry.isDirectory()) {
       await sandbox.filesystem.mkdir(childSandbox);
       await uploadDirectory(sandbox, childHost, childSandbox);
     } else if (entry.isFile()) {
       // Phase 1: text files only. The universal SandboxFileSystem.writeFile
       // signature is (path, content: string) — binary uploads need a future
-      // extension to the interface.
-      const content = await fs.readFile(childHost, 'utf-8');
+      // extension to the interface. Read raw bytes and reject anything that
+      // isn't UTF-8 text so a binary asset can't silently corrupt on upload.
+      const buffer = await fs.readFile(childHost);
+      if (buffer.includes(0)) {
+        throw new Error(
+          `Cannot upload binary file from local source: ${childHost}. ` +
+            `defineSetup({ source: { type: 'local' } }) currently supports UTF-8 text files only. ` +
+            `Use a github or tar source for projects with binary assets.`,
+        );
+      }
+      let content: string;
+      try {
+        content = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+      } catch {
+        throw new Error(
+          `Cannot upload non-UTF-8 file from local source: ${childHost}. ` +
+            `defineSetup({ source: { type: 'local' } }) currently supports UTF-8 text files only. ` +
+            `Use a github or tar source for projects with binary assets.`,
+        );
+      }
       await sandbox.filesystem.writeFile(childSandbox, content);
     }
   }
@@ -104,10 +131,14 @@ async function installDeps(
   deps: readonly Dep[],
   env: Record<string, string> | undefined,
 ): Promise<void> {
-  for (const dep of deps) {
-    const command = `nix profile install ${shellEscape(`nixpkgs#${dep.nixPkg}`)}`;
-    await runOrThrow(sandbox, command, env ? { env } : undefined, `install dep ${dep.name}`);
-  }
+  if (deps.length === 0) return;
+  // Batch into a single `nix profile install` so we pay the eval cost once and
+  // let Nix parallelize fetches/builds across the whole list, instead of
+  // serializing N separate invocations.
+  const args = deps.map((dep) => shellEscape(`nixpkgs#${dep.nixPkg}`)).join(' ');
+  const command = `nix profile install ${args}`;
+  const context = `install deps [${deps.map((dep) => dep.name).join(', ')}]`;
+  await runOrThrow(sandbox, command, env ? { env } : undefined, context);
 }
 
 async function runInstall(

--- a/packages/computesdk/src/compute.ts
+++ b/packages/computesdk/src/compute.ts
@@ -8,6 +8,7 @@ import type {
   Sandbox as SandboxInterface,
   CreateSandboxOptions as UniversalCreateSandboxOptions,
 } from './types/universal-sandbox';
+import { applySetup } from './apply-setup';
 
 export interface CreateSandboxOptions extends UniversalCreateSandboxOptions {
   /** Optional provider name override (must match provider.name) */
@@ -214,7 +215,9 @@ class ComputeManager {
 
   private async createWithFallback(options?: CreateSandboxOptions): Promise<SandboxInterface> {
     const preferredProviderName = options?.provider;
-    const { provider: _providerName, ...providerOptions } = options || {};
+    const { provider: _providerName, ...rest } = options || {};
+    const providerOptions = this.applySetupEnvToOptions(rest);
+    const setup = providerOptions.setup;
     const candidates = this.getCreateCandidates(preferredProviderName);
     const canFallback = this.fallbackOnError && !preferredProviderName;
     const errors: string[] = [];
@@ -223,6 +226,14 @@ class ComputeManager {
       try {
         const sandbox = await provider.sandbox.create(providerOptions);
         this.registerSandboxProvider(sandbox, provider);
+        if (setup) {
+          try {
+            await applySetup(sandbox, setup);
+          } catch (setupError) {
+            await this.cleanupAfterSetupFailure(sandbox);
+            throw setupError;
+          }
+        }
         return sandbox;
       } catch (error) {
         errors.push(`${getProviderLabel(provider, index)}: ${getProviderErrorDetail(error)}`);
@@ -236,6 +247,31 @@ class ComputeManager {
       `Failed to create sandbox across ${candidates.length} provider(s).\n` +
       errors.map((error) => `- ${error}`).join('\n')
     );
+  }
+
+  /**
+   * Merge `setup.env` into `options.envs` so the provider sees them at create
+   * time. User-supplied envs win over setup-supplied envs.
+   */
+  private applySetupEnvToOptions(options: UniversalCreateSandboxOptions): UniversalCreateSandboxOptions {
+    const setup = options.setup;
+    if (!setup?.env) return options;
+    return {
+      ...options,
+      envs: { ...setup.env, ...(options.envs || {}) },
+    };
+  }
+
+  private async cleanupAfterSetupFailure(sandbox: SandboxInterface): Promise<void> {
+    const sandboxId = getSandboxId(sandbox);
+    try {
+      await sandbox.destroy();
+    } catch {
+      // best-effort cleanup; surface the original setup error
+    }
+    if (sandboxId) {
+      this.sandboxProviders.delete(sandboxId);
+    }
   }
 
   setConfig(config: ExplicitComputeConfig): void {

--- a/packages/computesdk/src/compute.ts
+++ b/packages/computesdk/src/compute.ts
@@ -215,9 +215,10 @@ class ComputeManager {
 
   private async createWithFallback(options?: CreateSandboxOptions): Promise<SandboxInterface> {
     const preferredProviderName = options?.provider;
-    const { provider: _providerName, ...rest } = options || {};
-    const providerOptions = this.applySetupEnvToOptions(rest);
-    const setup = providerOptions.setup;
+    const { provider: _providerName, setup, ...rest } = options || {};
+    const effectiveEnv = this.resolveEffectiveEnv(rest.envs, setup?.env);
+    const providerOptions: Omit<UniversalCreateSandboxOptions, 'setup'> =
+      effectiveEnv ? { ...rest, envs: effectiveEnv } : rest;
     const candidates = this.getCreateCandidates(preferredProviderName);
     const canFallback = this.fallbackOnError && !preferredProviderName;
     const errors: string[] = [];
@@ -228,7 +229,11 @@ class ComputeManager {
         this.registerSandboxProvider(sandbox, provider);
         if (setup) {
           try {
-            await applySetup(sandbox, setup);
+            await applySetup(
+              sandbox,
+              setup,
+              effectiveEnv ? { env: effectiveEnv } : undefined,
+            );
           } catch (setupError) {
             await this.cleanupAfterSetupFailure(sandbox);
             throw setupError;
@@ -250,16 +255,21 @@ class ComputeManager {
   }
 
   /**
-   * Merge `setup.env` into `options.envs` so the provider sees them at create
-   * time. User-supplied envs win over setup-supplied envs.
+   * Merge `setup.env` with user-supplied `options.envs`, with user envs winning
+   * on conflict. Returns undefined when both sides are empty so callers can
+   * skip threading an env at all.
+   *
+   * The same merged env is used in two places: as `options.envs` for
+   * provider.sandbox.create (sandbox-level env) and as `applySetup`'s `env`
+   * override (per-command env during setup steps). Computing it once keeps
+   * those two paths from drifting.
    */
-  private applySetupEnvToOptions(options: UniversalCreateSandboxOptions): UniversalCreateSandboxOptions {
-    const setup = options.setup;
-    if (!setup?.env) return options;
-    return {
-      ...options,
-      envs: { ...setup.env, ...(options.envs || {}) },
-    };
+  private resolveEffectiveEnv(
+    userEnvs: Record<string, string> | undefined,
+    setupEnv: Record<string, string> | undefined,
+  ): Record<string, string> | undefined {
+    if (!setupEnv && !userEnvs) return undefined;
+    return { ...(setupEnv || {}), ...(userEnvs || {}) };
   }
 
   private async cleanupAfterSetupFailure(sandbox: SandboxInterface): Promise<void> {

--- a/packages/computesdk/src/index.ts
+++ b/packages/computesdk/src/index.ts
@@ -38,3 +38,7 @@ export type {
 // `compute.setConfig({...}); compute.sandbox.create()`.
 export { compute } from './compute';
 export type { CallableCompute, ExplicitComputeConfig } from './compute';
+
+// Setup primitive — declarative environment specs for sandboxes.
+export { defineSetup, deps } from './setup';
+export type { Dep, SetupConfig, SetupSource, SetupResources } from './setup';

--- a/packages/computesdk/src/setup.ts
+++ b/packages/computesdk/src/setup.ts
@@ -1,0 +1,109 @@
+/**
+ * defineSetup - Declarative environment specification for sandboxes.
+ *
+ * A SetupConfig is a pure value: it describes what an execution environment
+ * should look like (source code, system dependencies, install steps, env vars,
+ * resource hints), but has no methods. The sandbox owns lifecycle and execution.
+ *
+ *   import { defineSetup, deps } from 'computesdk';
+ *
+ *   const setup = defineSetup({
+ *     source: { type: 'github', repo: 'acme/my-app', ref: 'main' },
+ *     deps: [deps.python, deps.ffmpeg],
+ *     install: 'pip install -r requirements.txt',
+ *     env: { API_KEY: process.env.API_KEY! },
+ *   });
+ *
+ *   const sandbox = await compute.sandbox.create({ setup });
+ */
+
+/**
+ * A single system dependency. Currently always backed by Nix.
+ */
+export interface Dep {
+  /** Display name, used in error messages (e.g. "python") */
+  readonly name: string;
+  /** Nix package atom, resolved against nixpkgs (e.g. "python3") */
+  readonly nixPkg: string;
+}
+
+/**
+ * Where source code is materialized from before install steps run.
+ */
+export type SetupSource =
+  | { readonly type: 'github'; readonly repo: string; readonly ref?: string }
+  | { readonly type: 'local'; readonly path: string }
+  | { readonly type: 'tar'; readonly url: string };
+
+/**
+ * Resource hints for the sandbox runtime. Best-effort: providers that don't
+ * support sizing at create time silently ignore these.
+ */
+export interface SetupResources {
+  readonly cpu?: number;
+  readonly memory?: string;
+}
+
+/**
+ * Full shape of a setup spec. All fields are optional so callers can mix and
+ * match (e.g. just `deps`, just `source`, etc.).
+ */
+export interface SetupConfig {
+  readonly source?: SetupSource;
+  readonly deps?: readonly Dep[];
+  readonly install?: string | readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly resources?: SetupResources;
+}
+
+function freezeDep(dep: Dep): Dep {
+  return Object.freeze({ name: dep.name, nixPkg: dep.nixPkg });
+}
+
+/**
+ * Wrap a SetupConfig as a frozen value object. Mutating the returned value
+ * (or its nested fields) throws in strict mode, so setups can be safely shared
+ * across calls and modules.
+ */
+export function defineSetup(config: SetupConfig): SetupConfig {
+  const frozen: SetupConfig = {
+    source: config.source ? Object.freeze({ ...config.source }) as SetupSource : undefined,
+    deps: config.deps ? Object.freeze(config.deps.map(freezeDep)) : undefined,
+    install: Array.isArray(config.install)
+      ? Object.freeze([...config.install])
+      : config.install,
+    env: config.env ? Object.freeze({ ...config.env }) : undefined,
+    resources: config.resources ? Object.freeze({ ...config.resources }) : undefined,
+  };
+  return Object.freeze(frozen);
+}
+
+function nixDep(name: string, nixPkg: string): Dep {
+  return Object.freeze({ name, nixPkg });
+}
+
+/**
+ * Curated registry of common system dependencies. Each entry resolves to a
+ * Nix package. Use `deps.nix(...)` for arbitrary packages not in the registry.
+ *
+ *   deps.python              // python3
+ *   deps.ffmpeg              // ffmpeg
+ *   deps.nix('imagemagick')  // any nixpkgs atom
+ */
+export const deps = Object.freeze({
+  python: nixDep('python', 'python3'),
+  python3: nixDep('python3', 'python3'),
+  node: nixDep('node', 'nodejs'),
+  nodejs: nixDep('nodejs', 'nodejs'),
+  go: nixDep('go', 'go'),
+  rust: nixDep('rust', 'rustc'),
+  ruby: nixDep('ruby', 'ruby'),
+  ffmpeg: nixDep('ffmpeg', 'ffmpeg'),
+  imagemagick: nixDep('imagemagick', 'imagemagick'),
+  git: nixDep('git', 'git'),
+  curl: nixDep('curl', 'curl'),
+  wget: nixDep('wget', 'wget'),
+  jq: nixDep('jq', 'jq'),
+  /** Escape hatch for arbitrary Nix packages (resolved against `nixpkgs#<pkg>`). */
+  nix: (pkg: string): Dep => nixDep(pkg, pkg),
+});

--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -5,6 +5,8 @@
  * @computesdk/provider implement this shape (re-exported as SandboxInterface).
  */
 
+import type { SetupConfig } from '../setup';
+
 /**
  * Code execution result
  */
@@ -98,7 +100,7 @@ export interface SandboxFileSystem {
 
 /**
  * Options for creating a sandbox
- * 
+ *
  * Providers can extend this with additional properties specific to their implementation
  */
 export interface CreateSandboxOptions {
@@ -109,6 +111,12 @@ export interface CreateSandboxOptions {
   name?: string;
   namespace?: string;
   directory?: string;
+  /**
+   * Declarative environment spec applied after the sandbox is created.
+   * Materializes source code, installs system deps via Nix, and runs install
+   * scripts. Build with `defineSetup({...})`.
+   */
+  setup?: SetupConfig;
   // Allow provider-specific properties (e.g., domain for E2B)
   [key: string]: any;
 }


### PR DESCRIPTION
This pull request introduces the new `defineSetup` primitive to ComputeSDK, enabling users to declaratively specify sandbox environments in a portable, reproducible way. The implementation includes the new API, core orchestration logic, and comprehensive tests for all major behaviors. The documentation details phase 1 features, design decisions, and a clear roadmap for phase 2 improvements.

**Key changes:**

### New `defineSetup` Primitive & Public API

- Added `defineSetup` and `deps` to allow users to declaratively specify sources, dependencies, install scripts, environment variables, and resources for sandboxes. The setup object is deeply frozen and fully serializable, supporting portability and value-based comparison. (`packages/computesdk/SETUP.md`, `src/setup.ts`)

### Core Orchestration Logic

- Implemented `applySetup` to materialize the declared setup in a sandbox via the universal `runCommand` and `filesystem` interfaces, handling source materialization, dependency installation (via Nix), install scripts, and environment merging. All shell arguments are safely escaped. (`packages/computesdk/SETUP.md`, `src/apply-setup.ts`)

### Integration with Existing SDK

- Modified core types and sandbox creation logic to support the new setup flow, including merging environment variables and ensuring proper cleanup on setup failure. (`src/types/universal-sandbox.ts`, `src/compute.ts`, `src/index.ts`)

### Comprehensive Tests

- Added a thorough test suite (`src/__tests__/setup.test.ts`) covering value freezing, source types, dependency installation, step ordering, environment merging, shell escaping, and failure handling, ensuring robust and predictable behavior.

### Documentation & Roadmap

- Added detailed documentation (`SETUP.md`) describing the new primitive, design decisions (e.g., value vs. class, Nix-only dep resolution), known limitations, and a prioritized roadmap for phase 2 (multi-package-manager support, provider-native hooks, setup hashing, binary uploads, curated registries, resource honoring, validation, and progress reporting).Declarative environment specs for sandboxes: source (github/local/tar), Nix-backed deps, install scripts, env, and resource hints. Orchestrated in core via the universal Sandbox interface, so all providers work unchanged. See SETUP.md for design notes and phase 2 plan.