### PR TITLE
fix: timeout bug in tensorlake + update tensorlake docs

### DIFF
--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -26,9 +26,9 @@ const compute = tensorlake({
 // Create sandbox
 const sandbox = await compute.sandbox.create();
 
-// Execute code
-const result = await sandbox.runCode('print("Hello from Tensorlake!")');
-console.log(result.output); // "Hello from Tensorlake!"
+// Run a command
+const result = await sandbox.runCommand('echo "Hello from Tensorlake!"');
+console.log(result.stdout); // "Hello from Tensorlake!"
 
 // Clean up
 await sandbox.destroy();
@@ -46,7 +46,7 @@ interface TensorlakeConfig {
   proxyUrl?: string;
   /** Default container image for new sandboxes (default: ubuntu-minimal) */
   image?: string;
-  /** Default timeout in seconds for sandboxes */
+  /** Execution timeout in milliseconds */
   timeout?: number;
 }
 ```
@@ -70,15 +70,3 @@ const snapshot = await compute.snapshot.create(sandboxId);
 // Restore from a snapshot
 const sandbox = await compute.sandbox.create({ snapshotId: snapshot.id });
 ```
-
-## Runtime Detection
-
-The provider automatically detects the runtime based on code patterns:
-
-**Python indicators:**
-- `print` statements
-- `import` statements
-- `def` function definitions
-- Python-specific syntax (`f"`, `raise`, `sys.`, etc.)
-
-**Default:** Node.js for all other cases

--- a/packages/tensorlake/src/index.ts
+++ b/packages/tensorlake/src/index.ts
@@ -73,9 +73,8 @@ export const tensorlake = defineProvider<
       ) => {
         const { apiKey, apiUrl } = resolveAuth(config);
         const image = options?.image || config.image || DEFAULT_IMAGE;
-        const timeoutSecs = options?.timeout
-          ? Math.ceil(options.timeout / 1000)
-          : config.timeout;
+        const timeoutMs = options?.timeout ?? config.timeout;
+        const timeoutSecs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
 
         try {
           const startTime = Date.now();


### PR DESCRIPTION
This pull request updates the Tensorlake provider documentation and implementation to clarify and standardize timeout configuration, improve sandbox command execution examples, and remove outdated runtime detection information. The changes make the API usage and documentation more consistent and easier to understand.

**Documentation and API usage improvements:**

* Updated the example in `docs/providers/tensorlake.md` to use `sandbox.runCommand` with `echo` instead of `sandbox.runCode` with Python, and clarified the usage of the `stdout` property in the result.
* Changed the description of the `timeout` configuration option in `docs/providers/tensorlake.md` to specify that it is in milliseconds, not seconds.
* Removed the "Runtime Detection" section from the documentation, as automatic runtime detection based on code patterns is no longer relevant or supported.

**Implementation consistency:**

* Updated the provider implementation in `packages/tensorlake/src/index.ts` to treat the `timeout` option as milliseconds, converting it to seconds for internal use to match the new documentation and improve consistency.