### PR TITLE
feat(declaw): adopt Sandbox.kill(id) static from @declaw/sdk 1.1.7

### DIFF
--- a/.changeset/declaw-sandbox-kill-static.md
+++ b/.changeset/declaw-sandbox-kill-static.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/declaw": patch
+---
+
+Adopt `Sandbox.kill(id)` static from `@declaw/sdk` 1.1.7 in `destroy`.

--- a/packages/declaw/package.json
+++ b/packages/declaw/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@declaw/sdk": "^1.1.1",
+    "@declaw/sdk": "^1.1.7",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/declaw/src/index.ts
+++ b/packages/declaw/src/index.ts
@@ -4,7 +4,7 @@
  * Wraps `@declaw/sdk` to expose the ComputeSDK provider interface.
  */
 
-import { Sandbox as DeclawSandbox } from '@declaw/sdk';
+import { Sandbox as DeclawSandbox, ConnectionConfig } from '@declaw/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type {
@@ -116,9 +116,12 @@ export const declaw = defineProvider<DeclawSandbox, DeclawConfig>({
         const apiKey = config.apiKey || process.env.DECLAW_API_KEY!;
         const domain = config.domain || process.env.DECLAW_DOMAIN;
         try {
-          const sandbox = await DeclawSandbox.connect(sandboxId, { apiKey, domain });
-          await sandbox.kill();
-        } catch { /* idempotent */ }
+          await DeclawSandbox.kill(sandboxId, {
+            config: new ConnectionConfig({ apiKey, domain }),
+          });
+        } catch {
+          // Idempotent: sandbox may already be gone.
+        }
       },
 
       runCommand: async (sandbox: DeclawSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2184,7 +2184,7 @@ packages:
 
   '@declaw/sdk@1.1.7':
     resolution: {integrity: sha512-UwheCemk8557byAk86SSyI3FeoM6OauU7E70mDjHQEXIH2U/q70dR5sILMLFR3DkYvfVo9ygSgDb2s3fGX+OlA==}
-    engines: {node: '>=20.18.1'}
+    engines: {node: '>=18.0.0'}
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,8 +629,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@declaw/sdk':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.1.7
+        version: 1.1.7
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -2182,9 +2182,9 @@ packages:
   '@daytonaio/toolbox-api-client@0.143.0':
     resolution: {integrity: sha512-E6+yHPnFygNqRIctoDheISHCpzQkHydAU7fiBfsA5pnElfB/yLTOXQlnZfP8gfvOmUkRNU8QCXKzaualRTlI7w==}
 
-  '@declaw/sdk@1.1.1':
-    resolution: {integrity: sha512-+wJNqZHZQlgoq9vJrOQuzzOKSsrnLvKWupMoC5j4gT1da6YWb8pUGemdVu0aXMTk0DbGdRdS9oURinqLKh18yw==}
-    engines: {node: '>=18.0.0'}
+  '@declaw/sdk@1.1.7':
+    resolution: {integrity: sha512-UwheCemk8557byAk86SSyI3FeoM6OauU7E70mDjHQEXIH2U/q70dR5sILMLFR3DkYvfVo9ygSgDb2s3fGX+OlA==}
+    engines: {node: '>=20.18.1'}
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
@@ -9149,9 +9149,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@declaw/sdk@1.1.1':
+  '@declaw/sdk@1.1.7':
     dependencies:
       eventsource-parser: 3.0.6
+    optionalDependencies:
+      undici: 7.19.0
 
   '@emnapi/runtime@1.4.5':
     dependencies:


### PR DESCRIPTION
@declaw/sdk 1.1.7 added Sandbox.kill(sandboxId, opts) as a static method, mirroring Sandbox.killMany(ids). Adopt it in destroy() so the provider talks to the SDK's documented one-call API surface instead of constructing a Sandbox handle to call kill on.

- Bump @declaw/sdk dep ^1.1.1 → ^1.1.7.