### PR TITLE
feat: support raw and env kubeconfig for k8s provider

### DIFF
--- a/.changeset/little-dryers-bake.md
+++ b/.changeset/little-dryers-bake.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/k8s': patch
+---
+
+Add support for loading Kubernetes config from inline raw content and `KUBECONFIG_B64`, with explicit source precedence and updated documentation.

--- a/docs/providers/k8s.md
+++ b/docs/providers/k8s.md
@@ -31,6 +31,7 @@ await sandbox.destroy();
 ```typescript
 interface K8sConfig {
   kubeConfigPath?: string;
+  kubeConfigRaw?: string;
   context?: string;
   namespace?: string;
   image?: string;
@@ -41,5 +42,11 @@ interface K8sConfig {
   urlTemplate?: string;
 }
 ```
+
+Kubeconfig loading precedence:
+1. `kubeConfigRaw`
+2. `KUBECONFIG_B64` (base64-encoded kubeconfig)
+3. `kubeConfigPath`
+4. default kubeconfig resolution
 
 Note: In this MVP, `getUrl` uses `urlTemplate` for URL construction and does not provision Kubernetes Services automatically.

--- a/packages/k8s/README.md
+++ b/packages/k8s/README.md
@@ -33,6 +33,7 @@ await sandbox.destroy();
 ```ts
 interface K8sConfig {
   kubeConfigPath?: string;
+  kubeConfigRaw?: string;
   context?: string;
   namespace?: string;
   image?: string;
@@ -43,6 +44,12 @@ interface K8sConfig {
   urlTemplate?: string;
 }
 ```
+
+Kubeconfig loading precedence:
+1. `kubeConfigRaw`
+2. `KUBECONFIG_B64` (base64-encoded kubeconfig)
+3. `kubeConfigPath`
+4. default kubeconfig resolution
 
 ## Notes
 

--- a/packages/k8s/src/__tests__/kubeconfig.test.ts
+++ b/packages/k8s/src/__tests__/kubeconfig.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveKubeConfigSource } from '../index';
+
+describe('resolveKubeConfigSource', () => {
+  it('prefers kubeConfigRaw over env and path', () => {
+    const source = resolveKubeConfigSource(
+      { kubeConfigRaw: 'raw-config', kubeConfigPath: '/tmp/config' },
+      { KUBECONFIG_B64: Buffer.from('env-config', 'utf8').toString('base64') },
+    );
+    expect(source).toEqual({ type: 'raw', value: 'raw-config' });
+  });
+
+  it('uses KUBECONFIG_B64 when raw is not provided', () => {
+    const source = resolveKubeConfigSource(
+      { kubeConfigPath: '/tmp/config' },
+      { KUBECONFIG_B64: Buffer.from('env-config', 'utf8').toString('base64') },
+    );
+    expect(source).toEqual({ type: 'env', value: 'env-config' });
+  });
+
+  it('falls back to kubeConfigPath when env is absent', () => {
+    const source = resolveKubeConfigSource({ kubeConfigPath: '/tmp/config' }, {});
+    expect(source).toEqual({ type: 'path', value: '/tmp/config' });
+  });
+
+  it('uses default source when no input is provided', () => {
+    const source = resolveKubeConfigSource({}, {});
+    expect(source).toEqual({ type: 'default' });
+  });
+});

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -21,6 +21,7 @@ type Runtime = 'node' | 'python';
 
 export interface K8sConfig {
   kubeConfigPath?: string;
+  kubeConfigRaw?: string;
   context?: string;
   namespace?: string;
   image?: string;
@@ -38,6 +39,7 @@ interface K8sSandboxHandle {
   createdAt: Date;
   timeout: number;
   kubeConfigPath?: string;
+  kubeConfigRaw?: string;
   context?: string;
   urlTemplate?: string;
   serviceType?: 'ClusterIP' | 'NodePort';
@@ -45,8 +47,18 @@ interface K8sSandboxHandle {
 
 function loadKubeConfig(config: K8sConfig): KubeConfig {
   const kc = new KubeConfig();
-  if (config.kubeConfigPath) kc.loadFromFile(config.kubeConfigPath);
-  else kc.loadFromDefault();
+
+  if (config.kubeConfigRaw) {
+    kc.loadFromString(config.kubeConfigRaw);
+  } else if (process.env.KUBECONFIG_B64) {
+    const decoded = Buffer.from(process.env.KUBECONFIG_B64, 'base64').toString('utf8');
+    kc.loadFromString(decoded);
+  } else if (config.kubeConfigPath) {
+    kc.loadFromFile(config.kubeConfigPath);
+  } else {
+    kc.loadFromDefault();
+  }
+
   if (config.context) kc.setCurrentContext(config.context);
   return kc;
 }
@@ -144,6 +156,7 @@ async function execInPod(
 function loadKubeConfigFromHandle(sandbox: K8sSandboxHandle): KubeConfig {
   return loadKubeConfig({
     kubeConfigPath: sandbox.kubeConfigPath,
+    kubeConfigRaw: sandbox.kubeConfigRaw,
     context: sandbox.context,
   });
 }
@@ -260,6 +273,7 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
             createdAt: new Date(),
             timeout,
             kubeConfigPath: config.kubeConfigPath,
+            kubeConfigRaw: config.kubeConfigRaw,
             context: config.context,
             urlTemplate: config.urlTemplate,
             serviceType: config.serviceType || 'ClusterIP',
@@ -286,6 +300,7 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
               createdAt: pod.metadata?.creationTimestamp || new Date(),
               timeout: config.timeout ?? 120000,
               kubeConfigPath: config.kubeConfigPath,
+              kubeConfigRaw: config.kubeConfigRaw,
               context: config.context,
               urlTemplate: config.urlTemplate,
               serviceType: config.serviceType || 'ClusterIP',
@@ -315,6 +330,7 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
               createdAt: pod.metadata?.creationTimestamp || new Date(),
               timeout: config.timeout ?? 120000,
               kubeConfigPath: config.kubeConfigPath,
+              kubeConfigRaw: config.kubeConfigRaw,
               context: config.context,
               urlTemplate: config.urlTemplate,
               serviceType: config.serviceType || 'ClusterIP',

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -39,22 +39,43 @@ interface K8sSandboxHandle {
   createdAt: Date;
   timeout: number;
   kubeConfigPath?: string;
-  kubeConfigRaw?: string;
   context?: string;
   urlTemplate?: string;
   serviceType?: 'ClusterIP' | 'NodePort';
 }
 
+const rawKubeConfigBySandboxId = new Map<string, string>();
+
+type KubeConfigSource =
+  | { type: 'raw'; value: string }
+  | { type: 'env'; value: string }
+  | { type: 'path'; value: string }
+  | { type: 'default' };
+
+export function resolveKubeConfigSource(config: K8sConfig, env: NodeJS.ProcessEnv = process.env): KubeConfigSource {
+  if (config.kubeConfigRaw) {
+    return { type: 'raw', value: config.kubeConfigRaw };
+  }
+
+  if (env.KUBECONFIG_B64) {
+    return { type: 'env', value: Buffer.from(env.KUBECONFIG_B64, 'base64').toString('utf8') };
+  }
+
+  if (config.kubeConfigPath) {
+    return { type: 'path', value: config.kubeConfigPath };
+  }
+
+  return { type: 'default' };
+}
+
 function loadKubeConfig(config: K8sConfig): KubeConfig {
   const kc = new KubeConfig();
 
-  if (config.kubeConfigRaw) {
-    kc.loadFromString(config.kubeConfigRaw);
-  } else if (process.env.KUBECONFIG_B64) {
-    const decoded = Buffer.from(process.env.KUBECONFIG_B64, 'base64').toString('utf8');
-    kc.loadFromString(decoded);
-  } else if (config.kubeConfigPath) {
-    kc.loadFromFile(config.kubeConfigPath);
+  const source = resolveKubeConfigSource(config);
+  if (source.type === 'raw' || source.type === 'env') {
+    kc.loadFromString(source.value);
+  } else if (source.type === 'path') {
+    kc.loadFromFile(source.value);
   } else {
     kc.loadFromDefault();
   }
@@ -154,9 +175,10 @@ async function execInPod(
 }
 
 function loadKubeConfigFromHandle(sandbox: K8sSandboxHandle): KubeConfig {
+  const sandboxId = sandbox.podName;
   return loadKubeConfig({
     kubeConfigPath: sandbox.kubeConfigPath,
-    kubeConfigRaw: sandbox.kubeConfigRaw,
+    kubeConfigRaw: rawKubeConfigBySandboxId.get(sandboxId),
     context: sandbox.context,
   });
 }
@@ -264,6 +286,9 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
 
         await core.createNamespacedPod({ namespace, body: pod });
         await waitForPodRunning(core, namespace, podName, timeout);
+        if (config.kubeConfigRaw) {
+          rawKubeConfigBySandboxId.set(`${namespace}/${podName}`, config.kubeConfigRaw);
+        }
 
         return {
           sandbox: {
@@ -273,7 +298,6 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
             createdAt: new Date(),
             timeout,
             kubeConfigPath: config.kubeConfigPath,
-            kubeConfigRaw: config.kubeConfigRaw,
             context: config.context,
             urlTemplate: config.urlTemplate,
             serviceType: config.serviceType || 'ClusterIP',
@@ -292,6 +316,9 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
         try {
           const pod = await core.readNamespacedPod({ name, namespace });
           const runtime = parseRuntime(pod.metadata?.labels?.[LABEL_RUNTIME] || config.runtime || 'node');
+          if (config.kubeConfigRaw) {
+            rawKubeConfigBySandboxId.set(`${namespace}/${name}`, config.kubeConfigRaw);
+          }
           return {
             sandbox: {
               podName: `${namespace}/${name}`,
@@ -300,7 +327,6 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
               createdAt: pod.metadata?.creationTimestamp || new Date(),
               timeout: config.timeout ?? 120000,
               kubeConfigPath: config.kubeConfigPath,
-              kubeConfigRaw: config.kubeConfigRaw,
               context: config.context,
               urlTemplate: config.urlTemplate,
               serviceType: config.serviceType || 'ClusterIP',
@@ -322,6 +348,9 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
         return (pods.items || []).map(pod => {
           const podName = pod.metadata?.name || '';
           const runtime = parseRuntime(pod.metadata?.labels?.[LABEL_RUNTIME] || config.runtime || 'node');
+          if (config.kubeConfigRaw) {
+            rawKubeConfigBySandboxId.set(`${namespace}/${podName}`, config.kubeConfigRaw);
+          }
           return {
             sandbox: {
               podName: `${namespace}/${podName}`,
@@ -330,7 +359,6 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
               createdAt: pod.metadata?.creationTimestamp || new Date(),
               timeout: config.timeout ?? 120000,
               kubeConfigPath: config.kubeConfigPath,
-              kubeConfigRaw: config.kubeConfigRaw,
               context: config.context,
               urlTemplate: config.urlTemplate,
               serviceType: config.serviceType || 'ClusterIP',
@@ -354,6 +382,8 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
         await core.deleteNamespacedService({ namespace, name: serviceNameForPod(name) }).catch(error => {
           if (!isNotFound(error)) throw error;
         });
+
+        rawKubeConfigBySandboxId.delete(sandboxId);
       },
 
       runCommand: async (sandbox: K8sSandboxHandle, command: string, options?: RunCommandOptions): Promise<CommandResult> => {


### PR DESCRIPTION
## Summary
- add `kubeConfigRaw` support to `@computesdk/k8s` so kubeconfig content can be passed directly without writing temp files
- add `KUBECONFIG_B64` environment variable support with explicit load precedence: `kubeConfigRaw` -> `KUBECONFIG_B64` -> `kubeConfigPath` -> default resolution
- document the new kubeconfig input options in both provider docs and package README

## Validation
- `pnpm --filter @computesdk/k8s build`
- `pnpm --filter @computesdk/k8s test`