### PR TITLE
update k8s doc page + add k8s to workbench

### DIFF
--- a/docs/providers/k8s.md
+++ b/docs/providers/k8s.md
@@ -1,14 +1,26 @@
 # Kubernetes
 
-Kubernetes provider for ComputeSDK.
+Kubernetes provider for ComputeSDK — run each sandbox as a Pod in your cluster and execute commands via `pods/exec`.
 
-## Installation & Setup
+## Installation
 
 ```bash
 npm install @computesdk/k8s
 ```
 
-The provider uses your current kubeconfig context by default (`~/.kube/config`).
+## Setup
+
+The provider uses your current kubeconfig context by default. It calls `loadFromDefault()` from `@kubernetes/client-node`, which reads `$KUBECONFIG` if set, otherwise `~/.kube/config`. Override with `kubeConfigPath` or `context` in the provider config if you need to target a specific cluster.
+
+The identity used by your kubeconfig needs the following RBAC in the target namespace:
+
+| Resource | Verbs |
+|---|---|
+| `pods` | `create`, `get`, `list`, `delete` |
+| `pods/exec` | `create` |
+| `services` | `delete` |
+
+Local clusters (kind, k3d, minikube, Docker Desktop) grant cluster-admin by default and need no extra setup.
 
 ## Usage
 
@@ -20,25 +32,93 @@ const compute = k8s({
   runtime: 'node',
 });
 
+// Create sandbox
 const sandbox = await compute.sandbox.create();
-const result = await sandbox.runCommand('node -e "console.log(\"Hello from k8s\")"');
-console.log(result.stdout);
+
+// Run a command
+const result = await sandbox.runCommand('echo "Hello from k8s!"');
+console.log(result.stdout); // "Hello from k8s!"
+
+// Clean up
 await sandbox.destroy();
 ```
+
+### Run Commands
+
+```typescript
+const result = await sandbox.runCommand('ls -la /');
+console.log(result.stdout);
+
+// Pipes, redirects, cwd, env, background
+await sandbox.runCommand('node app.js', {
+  cwd: '/app',
+  env: { NODE_ENV: 'production' },
+});
+
+await sandbox.runCommand('python server.py', { background: true });
+```
+
+### Environment Variables
+
+Pass environment variables to the Pod at creation time:
+
+```typescript
+const sandbox = await compute.sandbox.create({
+  envs: {
+    API_KEY: 'your-api-key',
+    DATABASE_URL: 'postgresql://localhost:5432/mydb',
+  },
+});
+```
+
+These are set on the Pod's container spec and available to every command in the sandbox.
+
+### Port Forwarding
+
+`getUrl` is template-based in this MVP — set `urlTemplate` to construct routable URLs through your own ingress, gateway, or DNS pattern. The provider substitutes these placeholders:
+
+| Placeholder | Value |
+|---|---|
+| `{protocol}` | From the `protocol` option (default `http`) |
+| `{service}` | `<pod-name>-svc` |
+| `{namespace}` | Pod namespace |
+| `{port}` | From the `port` option |
+
+```typescript
+const compute = k8s({
+  urlTemplate: '{protocol}://{service}.{namespace}.svc.cluster.local:{port}',
+});
+
+const sandbox = await compute.sandbox.create();
+const url = await sandbox.getUrl({ port: 3000 });
+// http://computesdk-sbx-abc123-svc.default.svc.cluster.local:3000
+```
+
+If `urlTemplate` is not set, `getUrl` returns a placeholder URL ending in `.invalid` so misconfiguration is obvious.
 
 ### Configuration Options
 
 ```typescript
 interface K8sConfig {
+  /** Path to kubeconfig file - if not set, uses $KUBECONFIG or ~/.kube/config */
   kubeConfigPath?: string;
+  /** Raw kubeconfig YAML/JSON string - takes precedence over path-based loading */
   kubeConfigRaw?: string;
+  /** Kubeconfig context to use - defaults to the current-context */
   context?: string;
+  /** Target namespace for created Pods - defaults to "default" */
   namespace?: string;
+  /** Container image - defaults to node:20-alpine or python:3.11-slim based on runtime */
   image?: string;
+  /** Runtime - defaults to "node" */
   runtime?: 'node' | 'python';
+  /** Time to wait for Pod to reach Running state, in ms - defaults to 120000 */
   timeout?: number;
+  /** Service type used when constructing URLs - defaults to "ClusterIP" */
   serviceType?: 'ClusterIP' | 'NodePort';
+  /** Prefix for generated Pod names - defaults to "computesdk-sbx" */
   podNamePrefix?: string;
+  /** URL template for getUrl - see Port Forwarding section */
   urlTemplate?: string;
 }
 ```
@@ -49,4 +129,8 @@ Kubeconfig loading precedence:
 3. `kubeConfigPath`
 4. default kubeconfig resolution
 
-Note: In this MVP, `getUrl` uses `urlTemplate` for URL construction and does not provision Kubernetes Services automatically.
+## Limitations
+
+- Filesystem methods are not implemented in this MVP — use `runCommand` with `cat`, `tee`, etc. to read and write files.
+- `getUrl` does not provision Kubernetes Services automatically. Set `urlTemplate` to match your existing routing setup.
+- Pod resource requests and limits are fixed (250m / 256Mi requests, 1 CPU / 1Gi limits).

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -73,7 +73,8 @@
     "@computesdk/agentuity": "workspace:*",
     "@computesdk/freestyle": "workspace:*",
     "@computesdk/secure-exec": "workspace:*",
-    "@computesdk/upstash": "workspace:*"
+    "@computesdk/upstash": "workspace:*",
+    "@computesdk/k8s": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@computesdk/e2b": {
@@ -128,6 +129,9 @@
       "optional": true
     },
     "@computesdk/upstash": {
+      "optional": true
+    },
+    "@computesdk/k8s": {
       "optional": true
     }
   },

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -24,6 +24,7 @@ const SHARED_PROVIDER_NAMES = [
   'freestyle',
   'secure-exec',
   'upstash',
+  'k8s',
 ] as const;
 
 type SharedProviderName = typeof SHARED_PROVIDER_NAMES[number];
@@ -53,6 +54,7 @@ const SHARED_PROVIDER_AUTH: Record<SharedProviderName, readonly (readonly string
   freestyle: [['FREESTYLE_API_KEY']],
   'secure-exec': [[]],
   upstash: [['UPSTASH_BOX_API_KEY']],
+  k8s: [[]],
 };
 
 const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
@@ -81,6 +83,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
   freestyle: { apiKey: 'FREESTYLE_API_KEY' },
   'secure-exec': {},
   upstash: { apiKey: 'UPSTASH_BOX_API_KEY' },
+  k8s: {},
 };
 
 function getProviderConfigFromEnv(provider: SharedProviderName): Record<string, string> {
@@ -339,6 +342,9 @@ export async function loadProvider(providerName: ProviderName): Promise<any> {
         return await import('@computesdk/secure-exec');
       case 'upstash':
         return await import('@computesdk/upstash');
+      case 'k8s':
+        // @ts-ignore - package type declarations may be unavailable in local workbench typecheck
+        return await import('@computesdk/k8s');
       default:
         throw new Error(`Unknown provider: ${providerName}`);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1579,6 +1579,9 @@ importers:
       '@computesdk/just-bash':
         specifier: workspace:*
         version: link:../just-bash
+      '@computesdk/k8s':
+        specifier: workspace:*
+        version: link:../k8s
       '@computesdk/modal':
         specifier: workspace:*
         version: link:../modal


### PR DESCRIPTION
This pull request adds support for the Kubernetes provider (`@computesdk/k8s`) to the ComputeSDK Workbench and updates the documentation to provide comprehensive setup, usage, and configuration instructions. The main changes include adding the new provider as a dependency, integrating it into the CLI provider system, and significantly expanding the documentation to cover RBAC requirements, environment variables, port forwarding, and current limitations.

**Kubernetes Provider Integration:**

* Added `@computesdk/k8s` as a dependency and marked it as optional in `packages/workbench/package.json` and `pnpm-lock.yaml`, allowing Workbench to use Kubernetes as a provider. [[1]](diffhunk://#diff-c7c396f0ad9f4fd4a9e63b786410b227259377234d03f85b457bbbfd984e8e0aL76-R77) [[2]](diffhunk://#diff-c7c396f0ad9f4fd4a9e63b786410b227259377234d03f85b457bbbfd984e8e0aR133-R135) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1588-R1590)
* Registered `k8s` as a supported provider in the CLI (`providers.ts`), including its environment and authentication configuration, and enabled dynamic import for the provider. [[1]](diffhunk://#diff-8ad00dbf620b5e4c8add4dd322b346f9451d74400851825d731e8e37ff728a92R27) [[2]](diffhunk://#diff-8ad00dbf620b5e4c8add4dd322b346f9451d74400851825d731e8e37ff728a92R57) [[3]](diffhunk://#diff-8ad00dbf620b5e4c8add4dd322b346f9451d74400851825d731e8e37ff728a92R86) [[4]](diffhunk://#diff-8ad00dbf620b5e4c8add4dd322b346f9451d74400851825d731e8e37ff728a92R345-R347)

**Documentation Improvements:**

* Expanded `docs/providers/k8s.md` to clarify setup (including kubeconfig handling and RBAC), usage patterns (sandbox creation, command execution, environment variables), and port forwarding via customizable URL templates. [[1]](diffhunk://#diff-6874d4752c529586f4f8b4ad16da51bb98782162a8ef962d3260acc0e1c483f0L3-R23) [[2]](diffhunk://#diff-6874d4752c529586f4f8b4ad16da51bb98782162a8ef962d3260acc0e1c483f0R35-R128)
* Documented configuration options and current MVP limitations, such as lack of automatic service provisioning and fixed resource requests/limits.

These changes make it possible to run ComputeSDK sandboxes as Kubernetes Pods, execute commands within them, and integrate with custom ingress or DNS setups, while providing clear guidance and configuration options for users.