### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a TypeScript monorepo (pnpm workspaces) for **ComputeSDK**, a unified SDK for running code in remote sandboxed environments. It is a library, not a deployable application.
+
+### Key commands
+
+All commands are defined in the root `package.json`:
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install` |
+| Build all | `pnpm build` |
+| Lint | `pnpm lint` |
+| Test (unit) | `pnpm test` |
+| Typecheck | `pnpm typecheck` |
+| Dev (watch) | `pnpm dev` |
+
+### Build order matters
+
+`pnpm build` is ordered: `@computesdk/cmd` → `computesdk` → `@computesdk/provider` → `@computesdk/test-utils` → all remaining packages. Always run a full `pnpm build` after `pnpm install` before running tests or the workbench.
+
+### Tests run in mock mode
+
+Unit tests (`pnpm test`) run without any external API keys. They cover `@computesdk/cmd`, `@computesdk/provider`, `computesdk`, `@computesdk/events`, and `@computesdk/docker`. Integration tests for cloud providers (E2B, Modal, Vercel, etc.) require provider-specific API keys.
+
+### Hello-world without API keys
+
+Use the `@computesdk/just-bash` provider for local testing — no API keys needed. Import from its built dist: `import { justBash } from "./dist/index.mjs"` when running from `packages/just-bash/`, or use it within the workbench.
+
+### ESM considerations
+
+The `just-bash` npm dependency only exports ESM (no CJS `require` entry). When running scripts outside the monorepo test framework, use `node --input-type=module` or write `.mjs` files. Inside vitest tests this is handled automatically.
+
+### pnpm install warning
+
+After `pnpm install`, you may see: `WARN Failed to create bin at .../computesdk-cloudflare. ENOENT`. This is benign — the cloudflare setup binary depends on `dist/setup.mjs` which is created by `pnpm build`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Key commands table (install, build, lint, test, typecheck, dev)
- Build order documentation (dependency chain matters)
- Note that unit tests run in mock mode without API keys
- Instructions for hello-world testing with `@computesdk/just-bash`
- ESM considerations for the `just-bash` dependency
- Benign `pnpm install` warning explanation

### Update script

The VM startup update script runs:
```
pnpm install
pnpm build
```

### Verification

All checks pass:
- `pnpm lint` — all 41 packages pass
- `pnpm test` — 161 tests pass (8 + 92 + 12 + 19 + 30)
- `pnpm typecheck` — 6 core packages pass
- `pnpm build` — all packages build successfully
- Hello-world demo with `@computesdk/just-bash` (sandbox creation, command execution, filesystem ops, sandbox management)

[hello_world_output.log](https://cursor.com/agents/bc-3b7476a8-4833-4f77-9d85-87ada867754a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b7476a8-4833-4f77-9d85-87ada867754a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7476a8-4833-4f77-9d85-87ada867754a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

