### PR TITLE
feat: make snapshotId a typed reserved field on CreateSandboxOptions

### DIFF
--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -103,7 +103,10 @@ export interface SandboxFileSystem {
  */
 export interface CreateSandboxOptions {
   timeout?: number;
+  /** Boot from a pre-existing template (provider-specific template/image ID) */
   templateId?: string;
+  /** Boot from a snapshot created via compute.snapshot.create() */
+  snapshotId?: string;
   metadata?: Record<string, any>;
   envs?: Record<string, string>;
   name?: string;

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -123,7 +123,7 @@ export const runloop = defineProvider<
             name,
             metadata,
             templateId,
-            snapshotId: _snapshotId,
+            snapshotId,
             sandboxId: optSandboxId,
             namespace: _namespace,
             directory: _directory,
@@ -145,11 +145,17 @@ export const runloop = defineProvider<
             ...providerOptions,
           };
 
-          if (templateId) {
+          // snapshotId is the canonical cross-provider key for booting from a snapshot
+          if (snapshotId) {
+            devboxParams.snapshot_id = snapshotId;
+          } else if (templateId) {
+            // templateId fallback: support blueprint (bpt_) and snapshot (snp_) prefixes
             if (templateId.startsWith("bpt_")) {
               devboxParams.blueprint_id = templateId;
             } else if (templateId.startsWith("snp_")) {
               devboxParams.snapshot_id = templateId;
+            } else {
+              devboxParams.blueprint_id = templateId;
             }
           }
 


### PR DESCRIPTION
## Summary

`snapshotId` was previously only accessible via the catch-all `[key: string]: any` index signature on `CreateSandboxOptions`, making it undiscoverable and untyped. This PR promotes it to a first-class typed field, consistent with `templateId`.

Additionally, the Runloop provider was silently discarding `snapshotId` (aliased to `_snapshotId`) — this fixes it to map directly to Runloop's `snapshot_id` param.

## Changes

### `packages/computesdk/src/types/universal-sandbox.ts`
- Added `snapshotId?: string` as an explicit field on `CreateSandboxOptions` with a JSDoc comment distinguishing it from `templateId`

### `packages/runloop/src/index.ts`
- `snapshotId` now correctly maps to `devboxParams.snapshot_id`
- `templateId` fallback retained for backwards compat, with `bpt_`/`snp_` prefix detection
- Unknown `templateId` values (no matching prefix) now fall back to `blueprint_id` rather than being silently ignored

## Usage

```ts
// Now typed and autocompleted across all providers
const sandbox = await compute.sandbox.create({
  snapshotId: 'my-snapshot-id',
});

// Runloop — previously required passing snapshotId via templateId with snp_ prefix
const sandbox = await runloopSdk.sandbox.create({
  snapshotId: 'snp_abc123', // now works directly
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox creation behavior for the Runloop provider by honoring `snapshotId` and altering `templateId` fallback mapping, which could affect what image/snapshot newly created sandboxes boot from.
> 
> **Overview**
> Promotes `snapshotId` to an explicit, documented field on `CreateSandboxOptions` so boot-from-snapshot is typed/discoverable across providers.
> 
> Updates the Runloop provider’s `sandbox.create` to pass `snapshotId` through to Runloop’s `snapshot_id`, and keeps `templateId` as a backwards-compatible fallback (mapping `bpt_` to `blueprint_id`, `snp_` to `snapshot_id`, and defaulting unknown values to `blueprint_id` instead of dropping them).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5119837471312bcef593007f831d5ac45b036c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->