### PR TITLE
fix: make snapshotId a typed field and wire it through Runloop

### DIFF
--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -103,7 +103,19 @@ export interface SandboxFileSystem {
  */
 export interface CreateSandboxOptions {
   timeout?: number;
+  /** Provider-agnostic template/image ID to boot from */
   templateId?: string;
+  /**
+   * Snapshot ID to restore from when creating a sandbox.
+   *
+   * Each provider maps this to its native concept:
+   * - E2B: passed directly as the template/image ID
+   * - Daytona: sets `createParams.snapshot`
+   * - Modal: loads the image via `client.images.fromId(snapshotId)`
+   * - CodeSandbox: calls `sdk.sandboxes.resume(snapshotId)`
+   * - Runloop: maps to `snapshot_id` in devbox creation params
+   */
+  snapshotId?: string;
   metadata?: Record<string, any>;
   envs?: Record<string, string>;
   name?: string;

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -123,7 +123,7 @@ export const runloop = defineProvider<
             name,
             metadata,
             templateId,
-            snapshotId: _snapshotId,
+            snapshotId,
             sandboxId: optSandboxId,
             namespace: _namespace,
             directory: _directory,
@@ -145,7 +145,11 @@ export const runloop = defineProvider<
             ...providerOptions,
           };
 
-          if (templateId) {
+          // snapshotId is the canonical cross-provider field — map it directly to snapshot_id.
+          // templateId is kept for backwards compatibility: bpt_ prefix → blueprint_id, snp_ prefix → snapshot_id.
+          if (snapshotId) {
+            devboxParams.snapshot_id = snapshotId;
+          } else if (templateId) {
             if (templateId.startsWith("bpt_")) {
               devboxParams.blueprint_id = templateId;
             } else if (templateId.startsWith("snp_")) {


### PR DESCRIPTION
## Summary

Two related fixes to make `snapshotId` a proper first-class citizen in the SDK:

### 1. `CreateSandboxOptions` — add `snapshotId` as a typed field

Previously `snapshotId` was only accessible via the `[key: string]: any` catch-all index signature. TypeScript wouldn't autocomplete it or catch typos. This PR adds it as an explicit optional field alongside `templateId`, with a doc comment explaining how each provider maps it.

### 2. Runloop provider — stop discarding `snapshotId`

The Runloop `sandbox.create` path destructured `snapshotId` as `_snapshotId` (ignoring it entirely) and only used `templateId` with prefix matching to set `snapshot_id`. This meant `sandbox.create({ snapshotId: 'snp_abc' })` silently did nothing on Runloop.

**Before:**
```ts
snapshotId: _snapshotId,  // thrown away
// ...
if (templateId?.startsWith("snp_")) devboxParams.snapshot_id = templateId;
```

**After:**
```ts
snapshotId,  // properly destructured
// ...
if (snapshotId) {
  devboxParams.snapshot_id = snapshotId;
} else if (templateId) {
  if (templateId.startsWith("bpt_")) devboxParams.blueprint_id = templateId;
  else if (templateId.startsWith("snp_")) devboxParams.snapshot_id = templateId;
}
```

`templateId` prefix matching is preserved for backwards compatibility — users who were passing raw Runloop IDs via `templateId` continue to work.

## Usage (after this PR)

```ts
// Works correctly across all providers — fully typed
const sandbox = await compute.sandbox.create({
  snapshotId: 'snp_abc123',  // ✅ typed, autocompleted, no typo risk
});

// Runloop-specific: templateId still works via prefix matching
const sandbox = await runloopSdk.sandbox.create({
  templateId: 'bpt_xyz',   // blueprint
  // or
  templateId: 'snp_xyz',   // snapshot (legacy path)
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive typing change plus a straightforward parameter mapping fix in the Runloop sandbox creation path; main risk is behavior change for callers previously (incorrectly) ignored by Runloop.
> 
> **Overview**
> Makes `snapshotId` a first-class, typed field on `CreateSandboxOptions` (with provider mapping docs) instead of relying on the catch-all index signature.
> 
> Fixes the Runloop provider to actually honor `snapshotId` by wiring it into devbox creation (`snapshot_id`), while keeping legacy `templateId` prefix-based mapping (`bpt_` → `blueprint_id`, `snp_` → `snapshot_id`) for backwards compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0e6242c091452f1cc4557b6ad55d684b79e21b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->