### PR TITLE
chore: add missing changeset for k8s provider

### DIFF
--- a/.changeset/tiny-berries-boil.md
+++ b/.changeset/tiny-berries-boil.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/k8s': minor
+---
+
+Add the initial Kubernetes provider package with pod-backed sandbox lifecycle support, command execution, provider docs, and CI integration coverage.


### PR DESCRIPTION
## Summary
- add a missing Changeset entry for `@computesdk/k8s` after the Kubernetes provider PR merged
- classify the release as a minor bump for the initial provider package rollout

## Notes
- this is a follow-up metadata-only PR to ensure release automation includes the k8s provider change