### PR TITLE
docs for k8s pkg

### DIFF
--- a/docs/providers/k8s.md
+++ b/docs/providers/k8s.md
@@ -20,6 +20,8 @@ The identity used by your kubeconfig needs the following RBAC in the target name
 | `pods/exec` | `create` |
 | `services` | `delete` |
 
+`services: delete` is required because `destroy` opportunistically cleans up a Service named `<pod-name>-svc` (in case one was created out-of-band to back `getUrl`). The provider never creates Services itself.
+
 Local clusters (kind, k3d, minikube, Docker Desktop) grant cluster-admin by default and need no extra setup.
 
 ## Usage
@@ -43,6 +45,20 @@ console.log(result.stdout); // "Hello from k8s!"
 await sandbox.destroy();
 ```
 
+Sandbox IDs returned from `create()` are the bare Pod name (e.g. `computesdk-sbx-abc12345`); `getById()` and `list()` return the namespace-prefixed form `<namespace>/<podName>`. Both forms are accepted by `compute.sandbox.getById(...)` and `compute.sandbox.destroy(...)` — bare IDs are resolved against the provider's configured `namespace`.
+
+### Pod Layout
+
+Each sandbox is a single Pod with one container:
+
+- **Pod name**: `<podNamePrefix>-<up to 8 random base36 chars>` (default prefix `computesdk-sbx`).
+- **Container name**: `sandbox` — use this with `kubectl exec` (e.g. `kubectl exec -it -c sandbox <pod> -- /bin/sh`).
+- **Labels**: `computesdk.io/managed=true`, `computesdk.io/runtime=<node|python>`, `computesdk.io/sandbox-id=<pod-name>`.
+- **Annotations**: any `metadata` you pass to `create()` is stored as `computesdk.io/meta-<key>`. Non-string values are JSON-stringified.
+- **Restart policy**: `Never`. Pods are one-shot; recreate the sandbox if the container dies.
+
+`compute.sandbox.list()` returns Pods in the configured `namespace` that match `computesdk.io/managed=true`. Sandboxes in other namespaces are not returned.
+
 ### Run Commands
 
 ```typescript
@@ -57,6 +73,8 @@ await sandbox.runCommand('node app.js', {
 
 await sandbox.runCommand('python server.py', { background: true });
 ```
+
+Background commands are launched with `nohup` and their combined stdout/stderr is redirected to `/tmp/computesdk-bg.log` inside the Pod. Tail it with another `runCommand('cat /tmp/computesdk-bg.log')` if you need the output.
 
 ### Environment Variables
 
@@ -114,7 +132,7 @@ interface K8sConfig {
   runtime?: 'node' | 'python';
   /** Time to wait for Pod to reach Running state, in ms - defaults to 120000 */
   timeout?: number;
-  /** Service type used when constructing URLs - defaults to "ClusterIP" */
+  /** Reserved — currently has no effect. The provider does not create Services; use `urlTemplate` for routing. */
   serviceType?: 'ClusterIP' | 'NodePort';
   /** Prefix for generated Pod names - defaults to "computesdk-sbx" */
   podNamePrefix?: string;
@@ -132,5 +150,7 @@ Kubeconfig loading precedence:
 ## Limitations
 
 - Filesystem methods are not implemented in this MVP — use `runCommand` with `cat`, `tee`, etc. to read and write files.
-- `getUrl` does not provision Kubernetes Services automatically. Set `urlTemplate` to match your existing routing setup.
-- Pod resource requests and limits are fixed (250m / 256Mi requests, 1 CPU / 1Gi limits).
+- The provider never creates Kubernetes Services. `getUrl` is purely template-based — set `urlTemplate` to match your existing routing setup (ingress, gateway, or DNS). `serviceType` is accepted for forward compatibility but currently has no effect.
+- Pod resource requests and limits are fixed (250m / 256Mi requests, 1 CPU / 1Gi limits). Set `image` if you need a different runtime; CPU/memory are not yet configurable.
+- Pods use `restartPolicy: Never`. If the container exits, the sandbox is gone — create a new one.
+- `compute.sandbox.list()` only scans the namespace configured on the provider; it does not enumerate across namespaces.

--- a/docs/providers/k8s.md
+++ b/docs/providers/k8s.md
@@ -45,7 +45,7 @@ console.log(result.stdout); // "Hello from k8s!"
 await sandbox.destroy();
 ```
 
-Sandbox IDs returned from `create()` are the bare Pod name (e.g. `computesdk-sbx-abc12345`); `getById()` and `list()` return the namespace-prefixed form `<namespace>/<podName>`. Both forms are accepted by `compute.sandbox.getById(...)` and `compute.sandbox.destroy(...)` — bare IDs are resolved against the provider's configured `namespace`.
+Sandbox IDs are namespace-prefixed: `<namespace>/<podName>` (e.g. `default/computesdk-sbx-abc12345`). `create()`, `getById()`, and `list()` all return this form, so values round-trip without normalization. `getById()` and `destroy()` also accept a bare Pod name for convenience — bare IDs are resolved against the provider's configured `namespace`.
 
 ### Pod Layout
 
@@ -132,8 +132,6 @@ interface K8sConfig {
   runtime?: 'node' | 'python';
   /** Time to wait for Pod to reach Running state, in ms - defaults to 120000 */
   timeout?: number;
-  /** Reserved — currently has no effect. The provider does not create Services; use `urlTemplate` for routing. */
-  serviceType?: 'ClusterIP' | 'NodePort';
   /** Prefix for generated Pod names - defaults to "computesdk-sbx" */
   podNamePrefix?: string;
   /** URL template for getUrl - see Port Forwarding section */
@@ -150,7 +148,7 @@ Kubeconfig loading precedence:
 ## Limitations
 
 - Filesystem methods are not implemented in this MVP — use `runCommand` with `cat`, `tee`, etc. to read and write files.
-- The provider never creates Kubernetes Services. `getUrl` is purely template-based — set `urlTemplate` to match your existing routing setup (ingress, gateway, or DNS). `serviceType` is accepted for forward compatibility but currently has no effect.
+- The provider never creates Kubernetes Services. `getUrl` is purely template-based — set `urlTemplate` to match your existing routing setup (ingress, gateway, or DNS).
 - Pod resource requests and limits are fixed (250m / 256Mi requests, 1 CPU / 1Gi limits). Set `image` if you need a different runtime; CPU/memory are not yet configurable.
 - Pods use `restartPolicy: Never`. If the container exits, the sandbox is gone — create a new one.
 - `compute.sandbox.list()` only scans the namespace configured on the provider; it does not enumerate across namespaces.

--- a/packages/k8s/README.md
+++ b/packages/k8s/README.md
@@ -39,7 +39,6 @@ interface K8sConfig {
   image?: string;
   runtime?: 'node' | 'python';
   timeout?: number;
-  serviceType?: 'ClusterIP' | 'NodePort';
   podNamePrefix?: string;
   urlTemplate?: string;
 }

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -27,7 +27,6 @@ export interface K8sConfig {
   image?: string;
   runtime?: Runtime;
   timeout?: number;
-  serviceType?: 'ClusterIP' | 'NodePort';
   podNamePrefix?: string;
   urlTemplate?: string;
 }
@@ -41,7 +40,6 @@ interface K8sSandboxHandle {
   kubeConfigPath?: string;
   context?: string;
   urlTemplate?: string;
-  serviceType?: 'ClusterIP' | 'NodePort';
 }
 
 const rawKubeConfigBySandboxId = new Map<string, string>();
@@ -242,14 +240,13 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
         const kc = loadKubeConfig(config);
         const core = kc.makeApiClient(CoreV1Api);
 
-        const sandboxId = `${podNamePrefix}-${Math.random().toString(36).slice(2, 10)}`;
-        const podName = sandboxId;
+        const podName = `${podNamePrefix}-${Math.random().toString(36).slice(2, 10)}`;
         const image = imageForRuntime(runtime, config.image);
 
         const labels: Record<string, string> = {
           [LABEL_MANAGED]: 'true',
           [LABEL_RUNTIME]: runtime,
-          [LABEL_SID]: sandboxId,
+          [LABEL_SID]: podName,
         };
 
         const annotations = Object.fromEntries(
@@ -300,9 +297,8 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
             kubeConfigPath: config.kubeConfigPath,
             context: config.context,
             urlTemplate: config.urlTemplate,
-            serviceType: config.serviceType || 'ClusterIP',
           },
-          sandboxId,
+          sandboxId: `${namespace}/${podName}`,
         };
       },
 
@@ -329,7 +325,6 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
               kubeConfigPath: config.kubeConfigPath,
               context: config.context,
               urlTemplate: config.urlTemplate,
-              serviceType: config.serviceType || 'ClusterIP',
             },
             sandboxId: `${namespace}/${name}`,
           };
@@ -361,7 +356,6 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
               kubeConfigPath: config.kubeConfigPath,
               context: config.context,
               urlTemplate: config.urlTemplate,
-              serviceType: config.serviceType || 'ClusterIP',
             },
             sandboxId: `${namespace}/${podName}`,
           };
@@ -383,7 +377,7 @@ const createK8sProvider = defineProvider<K8sSandboxHandle, K8sConfig>({
           if (!isNotFound(error)) throw error;
         });
 
-        rawKubeConfigBySandboxId.delete(sandboxId);
+        rawKubeConfigBySandboxId.delete(`${namespace}/${name}`);
       },
 
       runCommand: async (sandbox: K8sSandboxHandle, command: string, options?: RunCommandOptions): Promise<CommandResult> => {


### PR DESCRIPTION
This pull request updates the Kubernetes provider to clarify its behavior around Service creation, simplify configuration, and improve documentation for users. The key changes are the removal of the unused `serviceType` configuration, clearer documentation about how sandboxes and IDs work, and improved explanations of pod layout and limitations.

**Documentation improvements:**

* Added detailed explanations of sandbox IDs, pod naming conventions, container labels/annotations, and the pod lifecycle to `docs/providers/k8s.md`. This helps users understand how sandboxes are managed and how to interact with them.
* Clarified that the provider never creates Kubernetes Services and that `getUrl` is template-based, with recommendations for configuring routing. Also documented that `compute.sandbox.list()` only scans the configured namespace. [[1]](diffhunk://#diff-6874d4752c529586f4f8b4ad16da51bb98782162a8ef962d3260acc0e1c483f0R23-R24) [[2]](diffhunk://#diff-6874d4752c529586f4f8b4ad16da51bb98782162a8ef962d3260acc0e1c483f0L135-R154)

**Configuration and code simplification:**

* Removed the unused `serviceType` property from the `K8sConfig` interface and all related code in both documentation and implementation files (`docs/providers/k8s.md`, `packages/k8s/README.md`, `packages/k8s/src/index.ts`). [[1]](diffhunk://#diff-6874d4752c529586f4f8b4ad16da51bb98782162a8ef962d3260acc0e1c483f0L117-L118) [[2]](diffhunk://#diff-2d4c79d705d72c4698d6f73e2a1ce1367db374025ecda5b4accd0b8218f9bf8dL42) [[3]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L30) [[4]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L44) [[5]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L303-R301) [[6]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L332) [[7]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L364)
* Updated sandbox ID handling to always use the `<namespace>/<podName>` form for consistency, and updated the code to reflect this in all relevant places. [[1]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L245-R249) [[2]](diffhunk://#diff-066c74bc8a1e0f4926e22f36c3859150633071aa602e40a911fa893350aeb666L386-R380)

**Additional documentation enhancements:**

* Explained how background commands are handled in pods and how to access their output.

These changes make the provider's behavior more predictable and its documentation more helpful for users.