### PR TITLE
fix(modal): use encryptedPorts instead of unencryptedPorts

### DIFF
--- a/.changeset/modal-encrypted-ports.md
+++ b/.changeset/modal-encrypted-ports.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/modal": patch
+---
+
+Use `encryptedPorts` instead of `unencryptedPorts` when creating Modal sandboxes. This ensures the SDK <> sandbox connection is TLS-wrapped (https://) rather than plaintext (http://), improving both security and latency per Modal's recommendation.

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -91,7 +91,7 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
 
           const optDaemonSsePort = (options as any)?.daemonSsePort as number | false | undefined;
           const ports = mergeExposedPorts(optPorts, config.ports, optDaemonSsePort ?? config.daemonSsePort);
-          if (ports && ports.length > 0) sandboxOptions.unencryptedPorts = ports;
+          if (ports && ports.length > 0) sandboxOptions.encryptedPorts = ports;
 
           const timeout = optTimeout ?? config.timeout;
           if (timeout) sandboxOptions.timeoutMs = timeout;


### PR DESCRIPTION
## Summary

Fixes the SDK <> sandbox connection in the Modal provider to use TLS-wrapped HTTPS instead of plaintext HTTP.

## Problem

Modal flagged that we were passing ports via `unencryptedPorts`, which means all traffic between ComputeSDK and the Modal sandbox goes over plain `http://`. This is both less secure and higher-latency than the alternative.

## Fix

Switch from `unencryptedPorts` to `encryptedPorts` in `SandboxCreateParams`. Modal TLS-wraps ports declared this way, so tunnel URLs use `https://` automatically.

**Change:**
```diff
- if (ports && ports.length > 0) sandboxOptions.unencryptedPorts = ports;
+ if (ports && ports.length > 0) sandboxOptions.encryptedPorts = ports;
```

## Changeset

Includes a `patch` changeset for `@computesdk/modal`.