### PR TITLE
ci: switch npm publish to GitHub-hosted runner with OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,15 @@ permissions:
   pull-requests: write
   issues: write
   repository-projects: write
+  id-token: write # Required for npm OIDC trusted publishing
 
 jobs:
   release:
     name: Release
-    runs-on: namespace-profile-default
+    # Must use a GitHub-hosted runner — npm OIDC trusted publishing does not
+    # support self-hosted runners (including Namespace) at this time.
+    # https://docs.npmjs.com/trusted-publishers/
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,6 +36,10 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Update npm
+        # npm 11.5.1+ is required for OIDC trusted publishing support
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 
@@ -42,9 +50,15 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          # --provenance generates signed attestations linking each package
+          # to this workflow run. Automatically enabled when using trusted
+          # publishers, but explicit here for clarity.
+          publish: pnpm changeset publish --provenance
           title: "Version Packages"
           commit: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
+          # TODO: once every package has a trusted publisher configured on
+          # npmjs.com, remove NPM_TOKEN entirely. For now it acts as a
+          # fallback for packages not yet configured.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Switches the `release` workflow job from `namespace-profile-default` to `ubuntu-latest` so npm OIDC trusted publishing can be used.

## Why

npm's OIDC trusted publishing currently only supports **GitHub-hosted (cloud) runners** — self-hosted runners (including Namespace) are not yet supported. See [npm trusted publishers docs](https://docs.npmjs.com/trusted-publishers/).

The release workflow was failing because `NPM_TOKEN` in CI didn't have publish access to the unscoped `daemond` package (owned by `@heygarrison`, not the `@computesdk` org). OIDC trusted publishing sidesteps the token ownership problem entirely by binding publishes to this specific workflow file.

## Changes

- `runs-on`: `namespace-profile-default` → `ubuntu-latest`
- `permissions`: added `id-token: write` (required for GitHub to mint OIDC tokens)
- Added `npm install -g npm@latest` step (npm 11.5.1+ required for OIDC)
- Added `--provenance` flag to `pnpm changeset publish`

## Before merging — manual steps required on npmjs.com

Each package needs a **Trusted Publisher** configured before `NPM_TOKEN` can be removed. For every package in the monorepo:

1. Go to `https://www.npmjs.com/package/<package-name>/access`
2. Under **Trusted Publisher**, click **Add**
3. Set:
   - **Owner**: `computesdk`
   - **Repository**: `computesdk`
   - **Workflow**: `release.yml`
   - **Environment**: _(leave blank)_

Since all packages share the same workflow file, this is the only configuration difference between them.

> **Note on `daemond`**: This package is unscoped (`daemond`, not `@computesdk/daemond`) and owned by `@heygarrison` on npm. Its trusted publisher will need to be configured from Garrison's personal npm account.

Once all packages are configured, remove `NPM_TOKEN` from the `changesets` step env to go fully tokenless.
