### PR TITLE
Add Modal provider option for scalable sandboxes

### DIFF
--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @computesdk/modal
 
+## 1.8.46
+
+### Patch Changes
+
+- Add `scalableSandboxes` to opt into Modal's scalable sandboxes create path.
+
 ## 1.8.45
 
 ### Patch Changes

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/modal",
-  "version": "1.8.45",
+  "version": "1.8.46",
   "description": "Modal provider for ComputeSDK - serverless Python execution with GPU support and zero cold starts",
   "author": "Garrison",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "modal": "^0.7.4",
+    "modal": "0.7.6",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -35,6 +35,11 @@ export interface ModalConfig {
   scalableSandboxes?: boolean;
 }
 
+export interface ModalCreateSandboxOptions extends CreateSandboxOptions {
+  daemonSsePort?: number | false;
+  scalableSandboxes?: boolean;
+}
+
 /**
  * extends ModalConfig with resources initialised once at
  * factory time so they don't need to be recreated on every sandbox operation.
@@ -60,6 +65,7 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
 
           const app = await config._appPromise;
 
+          const modalOptions = (options ?? {}) as ModalCreateSandboxOptions;
           const {
             timeout: optTimeout,
             envs,
@@ -71,9 +77,10 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
             namespace: _namespace,
             directory: _directory,
             ports: optPorts,
+            daemonSsePort: optDaemonSsePort,
             scalableSandboxes: optScalableSandboxes,
             ...providerOptions
-          } = (options || {}) as CreateSandboxOptions & { scalableSandboxes?: boolean };
+          } = modalOptions;
 
           let image: Image;
           const sourceId = snapshotId || templateId;
@@ -91,7 +98,6 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
             ...(providerOptions as Partial<SandboxCreateParams>),
           };
 
-          const optDaemonSsePort = (options as any)?.daemonSsePort as number | false | undefined;
           const ports = mergeExposedPorts(optPorts, config.ports, optDaemonSsePort ?? config.daemonSsePort);
           if (ports && ports.length > 0) sandboxOptions.encryptedPorts = ports;
 

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -32,6 +32,7 @@ export interface ModalConfig {
   ports?: number[];
   daemonSsePort?: number | false;
   appName?: string;
+  scalableSandboxes?: boolean;
 }
 
 /**
@@ -70,8 +71,9 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
             namespace: _namespace,
             directory: _directory,
             ports: optPorts,
+            scalableSandboxes: optScalableSandboxes,
             ...providerOptions
-          } = options || {};
+          } = (options || {}) as CreateSandboxOptions & { scalableSandboxes?: boolean };
 
           let image: Image;
           const sourceId = snapshotId || templateId;
@@ -99,7 +101,10 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           if (envs && Object.keys(envs).length > 0) sandboxOptions.env = envs;
           if (name) sandboxOptions.name = name;
 
-          const sandbox = await client.sandboxes.create(app, image, sandboxOptions);
+          const useScalableSandboxes = optScalableSandboxes ?? config.scalableSandboxes ?? false;
+          const sandbox = useScalableSandboxes
+            ? await client.sandboxes.experimentalCreate(app, image, sandboxOptions)
+            : await client.sandboxes.create(app, image, sandboxOptions);
           const sandboxId = sandbox.sandboxId;
 
           return { sandbox: { sandbox, sandboxId }, sandboxId };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,8 +1065,8 @@ importers:
         specifier: workspace:*
         version: link:../computesdk
       modal:
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: 0.7.6
+        version: 0.7.6
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -6472,8 +6472,8 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
-  modal@0.7.4:
-    resolution: {integrity: sha512-md/+L67tM1RazAt2xvLO+gUqRz6zllyYoNNiM8h+Eb1wLy7JzliH7vnx9f9Sq4zE3qQHENpX0Tjy/LSkIyrANA==}
+  modal@0.7.6:
+    resolution: {integrity: sha512-AOFRO/eGl4fcNKxHkNLx55+tL318IeAiTDJCMh/Q1ZXhoaZFnpmlirVV2J5BhO32XLA7AiH6KYGA7gRBGA09lQ==}
 
   modern-tar@0.7.5:
     resolution: {integrity: sha512-YTefgdpKKFgoTDbEUqXqgUJct2OG6/4hs4XWLsxcHkDLj/x/V8WmKIRppPnXP5feQ7d1vuYWSp3qKkxfwaFaxA==}
@@ -14326,7 +14326,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
-  modal@0.7.4:
+  modal@0.7.6:
     dependencies:
       cbor-x: 1.6.0
       long: 5.3.2


### PR DESCRIPTION
Modal has a separate sandbox scheduler for customers that operate at a very large scale or have high performance requirements. This PR enables it as a `scalableSandboxes` Modal provider option.