### PR TITLE
Cache resolved Images in Modal provider

### DIFF
--- a/.changeset/modal-cache-image-lookup.md
+++ b/.changeset/modal-cache-image-lookup.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/modal": patch
+---
+
+Cache resolved `Image` per provider instance in `modal.sandbox.create`, sharing a single Modal API call across concurrent bursts of sandbox creations for the same template/snapshot id (or default image).

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -94,13 +94,15 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
 
           const sourceId = snapshotId || templateId;
           const cacheKey = sourceId ?? DEFAULT_IMAGE;
-          const cached = config._imageCache.get(cacheKey);
-          let image = cached ? await cached.catch(() => null) : null;
-          if (!image) {
-            const promise = loadImage(client, sourceId);
+          let promise = config._imageCache.get(cacheKey);
+          if (!promise) {
+            promise = loadImage(client, sourceId).catch((err) => {
+              config._imageCache.delete(cacheKey);
+              throw err;
+            });
             config._imageCache.set(cacheKey, promise);
-            image = await promise;
           }
+          const image = await promise;
 
           const sandboxOptions: SandboxCreateParams = {
             ...(providerOptions as Partial<SandboxCreateParams>),

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -23,6 +23,15 @@ function mergeExposedPorts(primary?: number[], fallback?: number[], daemonSsePor
   return Array.from(new Set(merged.filter((port) => Number.isInteger(port) && port > 0 && port <= 65535)));
 }
 
+async function loadImage(client: ModalClient, sourceId: string | undefined): Promise<Image> {
+  if (!sourceId) return client.images.fromRegistry(DEFAULT_IMAGE);
+  try {
+    return await client.images.fromId(sourceId);
+  } catch {
+    return client.images.fromRegistry(sourceId);
+  }
+}
+
 
 export interface ModalConfig {
   tokenId?: string;
@@ -41,6 +50,7 @@ export interface ModalConfig {
 interface ModalInternalConfig extends ModalConfig {
   _client: ModalClient;
   _appPromise: Promise<App>;
+  _imageCache: Map<string, Promise<Image>>;
 }
 
 
@@ -73,16 +83,14 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
             ...providerOptions
           } = options || {};
 
-          let image: Image;
           const sourceId = snapshotId || templateId;
-          if (sourceId) {
-            try {
-              image = await client.images.fromId(sourceId);
-            } catch {
-              image = client.images.fromRegistry(sourceId);
-            }
-          } else {
-            image = client.images.fromRegistry(DEFAULT_IMAGE);
+          const cacheKey = sourceId ?? DEFAULT_IMAGE;
+          const cached = config._imageCache.get(cacheKey);
+          let image = cached ? await cached.catch(() => null) : null;
+          if (!image) {
+            const promise = loadImage(client, sourceId);
+            config._imageCache.set(cacheKey, promise);
+            image = await promise;
           }
 
           const sandboxOptions: SandboxCreateParams = {
@@ -283,5 +291,6 @@ export function modal(config: ModalConfig = {}): ReturnType<typeof _modal> {
     appName,
     _client: client,
     _appPromise: appPromise,
+    _imageCache: new Map(),
   });
 }


### PR DESCRIPTION
Image lookups (fromId / fromRegistry) were repeated on every sandbox.create call. Images persist indefinitely in Modal, so these repeated calls are unnecessary. Resolve once per sourceId and reuse.