### PR TITLE
Await stdout, stderr, and process.wait in parallel in modal exec calls

### DIFF
--- a/.changeset/modal-parallel-exec-wait.md
+++ b/.changeset/modal-parallel-exec-wait.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/modal": patch
+---
+
+Await `process.stdout.readText()`, `process.stderr.readText()`, and `process.wait()` in parallel inside `runCommand` and filesystem ops (`readFile` cat-fallback, `mkdir`, `readdir`, `remove`), removing a serial round trip per exec.

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -159,8 +159,7 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
           
           const process = await modalSandbox.sandbox.exec(['sh', '-c', fullCommand], { stdout: 'pipe', stderr: 'pipe' });
-          const [stdout, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
-          const exitCode = await process.wait();
+          const [stdout, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
           return { stdout: stdout || '', stderr: stderr || '', exitCode: exitCode || 0, durationMs: Date.now() - startTime };
         } catch (error) {
           return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
@@ -211,8 +210,7 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           } catch (error) {
             try {
               const process = await modalSandbox.sandbox.exec(['cat', path], { stdout: 'pipe', stderr: 'pipe' });
-              const [content, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
-              const exitCode = await process.wait();
+              const [content, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
               if (exitCode !== 0) throw new Error(`cat failed: ${stderr}`);
               return content.trim();
             } catch {
@@ -230,14 +228,12 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
         },
         mkdir: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
           const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
-          const exitCode = await process.wait();
+          const [, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
           if (exitCode !== 0) throw new Error(`mkdir failed: ${stderr}`);
         },
         readdir: async (modalSandbox: ModalSandbox, path: string): Promise<FileEntry[]> => {
           const process = await modalSandbox.sandbox.exec(['ls', '-la', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [output, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
-          const exitCode = await process.wait();
+          const [output, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
           if (exitCode !== 0) throw new Error(`ls failed: ${stderr}`);
           const lines = output.split('\n').slice(1);
           return lines.filter((l: string) => l.trim()).map((line: string) => {
@@ -255,8 +251,7 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
         },
         remove: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
           const process = await modalSandbox.sandbox.exec(['rm', '-rf', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [, stderr] = await Promise.all([process.stdout.readText(), process.stderr.readText()]);
-          const exitCode = await process.wait();
+          const [, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
           if (exitCode !== 0) throw new Error(`rm failed: ${stderr}`);
         }
       },


### PR DESCRIPTION
Each exec'd process previously awaited stdout/stderr together and then serially awaited the exit code. Fold process.wait() into the same Promise.all so the round trips run concurrently. Applied to runCommand and the four filesystem ops (cat-fallback readFile, mkdir, readdir, remove).