### PR TITLE
Run image.build() once so it is not re-called by sandbox creates

### DIFF
--- a/.changeset/modal-prebuild-cached-image.md
+++ b/.changeset/modal-prebuild-cached-image.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/modal": patch
+---
+
+Build the cached `Image` once per provider instance instead of deferring to each `sandbox.create()` call. Concurrent `sandbox.create()` callers now share a single `ImageGetOrCreate` RPC for the default image (or a given template/snapshot id), instead of each call independently triggering one.

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -23,13 +23,18 @@ function mergeExposedPorts(primary?: number[], fallback?: number[], daemonSsePor
   return Array.from(new Set(merged.filter((port) => Number.isInteger(port) && port > 0 && port <= 65535)));
 }
 
-async function loadImage(client: ModalClient, sourceId: string | undefined): Promise<Image> {
-  if (!sourceId) return client.images.fromRegistry(DEFAULT_IMAGE);
-  try {
-    return await client.images.fromId(sourceId);
-  } catch {
-    return client.images.fromRegistry(sourceId);
+async function loadImage(client: ModalClient, app: App, sourceId: string | undefined): Promise<Image> {
+  let image: Image;
+  if (sourceId) {
+    try {
+      image = await client.images.fromId(sourceId);
+    } catch {
+      image = client.images.fromRegistry(sourceId);
+    }
+  } else {
+    image = client.images.fromRegistry(DEFAULT_IMAGE);
   }
+  return image.build(app);
 }
 
 
@@ -96,7 +101,7 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           const cacheKey = sourceId ?? DEFAULT_IMAGE;
           let promise = config._imageCache.get(cacheKey);
           if (!promise) {
-            promise = loadImage(client, sourceId).catch((err) => {
+            promise = loadImage(client, app, sourceId).catch((err) => {
               config._imageCache.delete(cacheKey);
               throw err;
             });


### PR DESCRIPTION
In the Modal provider, sandbox.Create will call ImageGetOrCreate until the first call returns after which it will cache. In burst situations, this can still lead to rate limiting. Call image.build explicitly to avoid this. The Modal App passed is only used for metrics/logging purposes.