### PR TITLE
feat: add Collimate provider

### DIFF
--- a/packages/collimate/README.md
+++ b/packages/collimate/README.md
@@ -1,0 +1,57 @@
+# @computesdk/collimate
+
+[Collimate](https://collimate.ai) provider for [ComputeSDK](https://www.computesdk.com) — sub-millisecond CoW-forked microVM sandboxes with DAX shared runtimes.
+
+## Installation
+
+```bash
+npm install @computesdk/collimate computesdk
+```
+
+## Usage
+
+```typescript
+import { collimate } from "@computesdk/collimate";
+import { compute } from "computesdk";
+
+compute.setConfig({
+  provider: collimate({
+    apiKey: "col_live_...",
+    templateId: "node",
+  }),
+});
+
+const sandbox = await compute.sandbox.create();
+const result = await sandbox.runCommand("node -v");
+console.log(result.stdout); // v20.x.x
+await sandbox.destroy();
+```
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `COLLIMATE_API_KEY` env | API key for authentication |
+| `serverUrl` | `string` | `https://api.collimate.ai` | API server URL |
+| `templateId` | `string` | — | Template ID (`node`, `python`, etc.) |
+| `timeout` | `number` | `900` | Execution timeout in seconds |
+
+## How it works
+
+Each sandbox is a full KVM virtual machine forked via copy-on-write from a pre-warmed template snapshot. Fork latency is sub-millisecond; the guest resumes at the snapshot's instruction pointer with all devices restored.
+
+**DAX (Direct Access)** maps a shared read-only erofs image via virtio-pmem so all sandboxes execute binaries in-place from a single host copy — ~133 KB per sandbox instead of hundreds of MB.
+
+## Supported operations
+
+- `create()` / `destroy()` — sandbox lifecycle
+- `runCommand()` — shell execution with stdout/stderr/exitCode
+- `writeFile()` / `readFile()` — filesystem operations
+- `mkdir()` / `readdir()` / `exists()` / `remove()` — directory operations
+- `getById()` / `list()` / `getInfo()` — sandbox management
+
+## Links
+
+- [Collimate](https://collimate.ai)
+- [Documentation](https://docs.collimate.ai)
+- [ComputeSDK](https://www.computesdk.com)

--- a/packages/collimate/package.json
+++ b/packages/collimate/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@computesdk/collimate",
+  "version": "0.1.0",
+  "description": "Collimate provider for ComputeSDK — sub-millisecond CoW-forked microVM sandboxes with DAX shared runtimes",
+  "author": "Collimate <hello@collimate.ai>",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "collimate",
+    "sandbox",
+    "code-execution",
+    "microvm",
+    "kvm",
+    "cow",
+    "dax",
+    "compute",
+    "provider",
+    "sub-millisecond"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/collimate"
+  },
+  "homepage": "https://collimate.ai",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/collimate/src/__tests__/benchmark.test.ts
+++ b/packages/collimate/src/__tests__/benchmark.test.ts
@@ -1,0 +1,167 @@
+/**
+ * ComputeSDK-style benchmark: measures TTI (Time-to-Interactive).
+ *
+ * TTI = time from create() to first successful runCommand("node -v").
+ * This mirrors exactly what ComputeSDK measures on their leaderboard.
+ *
+ * Modes:
+ *   - Sequential: one sandbox at a time (baseline)
+ *   - Staggered: 200ms delays between launches
+ *   - Burst: all launched concurrently
+ *
+ * Usage:
+ *   BENCHMARK=1 COLLIMATE_SERVER_URL=http://localhost:8080 \
+ *   COLLIMATE_TEMPLATE_ID=node \
+ *   npx vitest run benchmark
+ */
+
+import { describe, it, expect } from "vitest";
+import { CollimateClient } from "../client.js";
+
+const SKIP = !process.env.BENCHMARK;
+const SERVER_URL = process.env.COLLIMATE_SERVER_URL || "http://localhost:18080";
+const API_KEY = process.env.COLLIMATE_API_KEY || "dummy";
+const TEMPLATE_ID = process.env.COLLIMATE_TEMPLATE_ID || "node";
+const N = parseInt(process.env.BENCH_N || "20", 10);
+const COMMAND = process.env.BENCH_CMD || "node -v";
+
+interface TTIResult {
+  sandboxId: string;
+  createMs: number;
+  execMs: number;
+  ttiMs: number;
+  stdout: string;
+  success: boolean;
+}
+
+async function measureTTI(client: CollimateClient): Promise<TTIResult> {
+  const t0 = performance.now();
+
+  // Create sandbox (session)
+  const session = await client.createSession(TEMPLATE_ID);
+  const tCreate = performance.now();
+  const createMs = tCreate - t0;
+
+  // Run command (the "Interactive" part of TTI)
+  const resp = await client.execSession(session.session_id, {
+    commands: [["bash", "-lc", COMMAND]],
+    timeout_seconds: 30,
+  });
+  const tExec = performance.now();
+  const execMs = tExec - tCreate;
+  const ttiMs = tExec - t0;
+
+  // Destroy
+  await client.deleteSession(session.session_id, true);
+
+  return {
+    sandboxId: session.session_id,
+    createMs,
+    execMs,
+    ttiMs,
+    stdout: resp.stdout.trim(),
+    success: resp.exit_code === 0,
+  };
+}
+
+function stats(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const pct = (p: number) => sorted[Math.min(Math.floor(p / 100 * n), n - 1)];
+  return {
+    min: sorted[0],
+    max: sorted[n - 1],
+    avg: sum / n,
+    median: pct(50),
+    p95: pct(95),
+    p99: pct(99),
+    count: n,
+  };
+}
+
+function printStats(label: string, values: number[]) {
+  const s = stats(values);
+  console.log(`\n  ${label} (${s.count} iterations):`);
+  console.log(`    Min:    ${s.min.toFixed(1)} ms`);
+  console.log(`    Median: ${s.median.toFixed(1)} ms`);
+  console.log(`    Avg:    ${s.avg.toFixed(1)} ms`);
+  console.log(`    P95:    ${s.p95.toFixed(1)} ms`);
+  console.log(`    P99:    ${s.p99.toFixed(1)} ms`);
+  console.log(`    Max:    ${s.max.toFixed(1)} ms`);
+}
+
+describe.skipIf(SKIP)(`ComputeSDK Benchmark (N=${N}, cmd="${COMMAND}")`, () => {
+  let client: CollimateClient;
+
+  it("connects", () => {
+    client = new CollimateClient({ serverUrl: SERVER_URL, apiKey: API_KEY });
+    console.log(`\n  Server: ${SERVER_URL}`);
+    console.log(`  Template: ${TEMPLATE_ID}`);
+    console.log(`  Command: ${COMMAND}`);
+    console.log(`  Iterations: ${N}`);
+  });
+
+  // ── Sequential: one at a time ─────────────────────────────────────
+  it(`Sequential: ${N} iterations`, async () => {
+    const results: TTIResult[] = [];
+
+    for (let i = 0; i < N; i++) {
+      const r = await measureTTI(client);
+      results.push(r);
+      expect(r.success).toBe(true);
+    }
+
+    const ttis = results.map((r) => r.ttiMs);
+    const creates = results.map((r) => r.createMs);
+    const execs = results.map((r) => r.execMs);
+
+    console.log("\n=== SEQUENTIAL ===");
+    printStats("TTI (create + exec)", ttis);
+    printStats("Create only", creates);
+    printStats("Exec only", execs);
+    console.log(`  First stdout: ${results[0].stdout}`);
+    console.log(`  Success: ${results.filter((r) => r.success).length}/${N}`);
+
+    const s = stats(ttis);
+    // ComputeSDK scoring: 100 * (1 - median_ms / 10000)
+    const score = 100 * (1 - s.median / 10000);
+    console.log(`\n  ComputeSDK composite (median-only): ${score.toFixed(1)}`);
+  }, 300_000);
+
+  // ── Staggered: 200ms delays ───────────────────────────────────────
+  it(`Staggered (200ms delay): ${N} iterations`, async () => {
+    const promises: Promise<TTIResult>[] = [];
+
+    for (let i = 0; i < N; i++) {
+      promises.push(measureTTI(client));
+      if (i < N - 1) await new Promise((r) => setTimeout(r, 200));
+    }
+
+    const results = await Promise.all(promises);
+    const ttis = results.map((r) => r.ttiMs);
+
+    console.log("\n=== STAGGERED (200ms) ===");
+    printStats("TTI", ttis);
+    console.log(`  Success: ${results.filter((r) => r.success).length}/${N}`);
+
+    expect(results.every((r) => r.success)).toBe(true);
+  }, 300_000);
+
+  // ── Burst: all concurrent ─────────────────────────────────────────
+  it(`Burst: ${N} concurrent`, async () => {
+    const t0 = performance.now();
+    const promises = Array.from({ length: N }, () => measureTTI(client));
+    const results = await Promise.all(promises);
+    const wallMs = performance.now() - t0;
+
+    const ttis = results.map((r) => r.ttiMs);
+
+    console.log("\n=== BURST (all concurrent) ===");
+    console.log(`  Wall-clock: ${wallMs.toFixed(0)} ms`);
+    printStats("TTI", ttis);
+    console.log(`  Success: ${results.filter((r) => r.success).length}/${N}`);
+
+    expect(results.every((r) => r.success)).toBe(true);
+  }, 300_000);
+});

--- a/packages/collimate/src/__tests__/index.test.ts
+++ b/packages/collimate/src/__tests__/index.test.ts
@@ -1,0 +1,14 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { collimate } from '../index';
+
+runProviderTestSuite({
+  name: 'collimate',
+  provider: collimate({
+    serverUrl: process.env.COLLIMATE_SERVER_URL || 'https://api.collimate.ai',
+    apiKey: process.env.COLLIMATE_API_KEY,
+    templateId: process.env.COLLIMATE_TEMPLATE_ID || 'node',
+  }),
+  supportsFilesystem: true,
+  skipIntegration: !process.env.COLLIMATE_API_KEY,
+  supportsGetUrl: false, // Collimate sandboxes are accessed via session API, not direct URLs
+});

--- a/packages/collimate/src/client.ts
+++ b/packages/collimate/src/client.ts
@@ -1,0 +1,158 @@
+/**
+ * Thin HTTP client for the Collimate session API.
+ * Zero dependencies — uses native fetch.
+ */
+
+// ── Response types (mirror server-side Rust structs) ─────────────────────
+
+export interface CreateSessionResponse {
+  session_id: string;
+  template_id: string;
+  fork_time_ms: number;
+  create_time_ms: number;
+}
+
+export interface ExecResponse {
+  id: string;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  fork_time_ms: number;
+  exec_time_ms: number;
+  total_time_ms: number;
+  results?: Array<{ stdout: string; stderr: string; exit_code: number }>;
+}
+
+export interface SessionInfo {
+  session_id: string;
+  template_id: string;
+  age_secs: number;
+  idle_secs: number;
+  exec_count: number;
+}
+
+export interface FileSpec {
+  path: string;
+  content: string;
+}
+
+export interface ExecRequest {
+  code?: string;
+  commands?: string[][];
+  files?: FileSpec[];
+  timeout_seconds?: number;
+}
+
+// ── Error ────────────────────────────────────────────────────────────────
+
+export class CollimateError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = "CollimateError";
+  }
+}
+
+// ── Client ───────────────────────────────────────────────────────────────
+
+export interface CollimateClientConfig {
+  serverUrl: string;
+  apiKey: string;
+}
+
+export class CollimateClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(config: CollimateClientConfig) {
+    this.baseUrl = config.serverUrl.replace(/\/+$/, "");
+    this.apiKey = config.apiKey;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      "Authorization": `Bearer ${this.apiKey}`,
+      "User-Agent": "computesdk-collimate/0.1.0",
+    };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const resp = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      let message = `Collimate API error: ${resp.status}`;
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed.error) message = parsed.error;
+        else if (parsed.stderr) message = parsed.stderr;
+      } catch {
+        if (text) message = text;
+      }
+      throw new CollimateError(message, resp.status, text);
+    }
+
+    const text = await resp.text();
+    if (!text) return undefined as T;
+    return JSON.parse(text) as T;
+  }
+
+  async createSession(templateId: string): Promise<CreateSessionResponse> {
+    return this.request<CreateSessionResponse>("POST", "/v1/sessions", {
+      template_id: templateId,
+    });
+  }
+
+  async execSession(
+    sessionId: string,
+    body: ExecRequest,
+  ): Promise<ExecResponse> {
+    return this.request<ExecResponse>(
+      "POST",
+      `/v1/sessions/${encodeURIComponent(sessionId)}/exec`,
+      body,
+    );
+  }
+
+  async getSession(sessionId: string): Promise<SessionInfo | null> {
+    try {
+      return await this.request<SessionInfo>(
+        "GET",
+        `/v1/sessions/${encodeURIComponent(sessionId)}`,
+      );
+    } catch (err) {
+      if (err instanceof CollimateError && err.status === 404) return null;
+      throw err;
+    }
+  }
+
+  async listSessions(): Promise<SessionInfo[]> {
+    return this.request<SessionInfo[]>("GET", "/v1/sessions");
+  }
+
+  async deleteSession(sessionId: string, force = true): Promise<void> {
+    const qs = force ? "?force=true" : "";
+    try {
+      await this.request<unknown>(
+        "DELETE",
+        `/v1/sessions/${encodeURIComponent(sessionId)}${qs}`,
+      );
+    } catch (err) {
+      if (err instanceof CollimateError && err.status === 404) return;
+      throw err;
+    }
+  }
+}

--- a/packages/collimate/src/index.ts
+++ b/packages/collimate/src/index.ts
@@ -1,0 +1,329 @@
+/**
+ * @computesdk/collimate — ComputeSDK provider for Collimate sandboxes.
+ *
+ * Usage:
+ *   import { collimate } from "@computesdk/collimate";
+ *   import { compute } from "computesdk";
+ *
+ *   compute.setConfig({
+ *     provider: collimate({ apiKey: "col_live_...", templateId: "python" }),
+ *   });
+ *
+ *   const sandbox = await compute.sandbox.create();
+ *   const result = await sandbox.runCommand("echo hello");
+ *   await sandbox.destroy();
+ */
+
+import { defineProvider } from "@computesdk/provider";
+import type { RunCommandOptions, CommandResult, SandboxInfo, FileEntry } from "computesdk";
+import {
+  CollimateClient,
+  CollimateError,
+  type CreateSessionResponse,
+  type ExecRequest,
+  type SessionInfo,
+} from "./client.js";
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export interface CollimateConfig {
+  /** Collimate API server URL. Default: "https://api.collimate.ai" */
+  serverUrl?: string;
+  /** API key. Falls back to COLLIMATE_API_KEY env var. */
+  apiKey?: string;
+  /** Default template ID for sandbox creation. */
+  templateId?: string;
+  /** Default execution timeout in seconds. Default: 900 */
+  timeout?: number;
+}
+
+export interface CollimateSandbox {
+  sessionId: string;
+  templateId: string;
+  client: CollimateClient;
+  serverUrl: string;
+  createdAt: Date;
+  forkTimeMs: number;
+  createTimeMs: number;
+  timeoutMs: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function resolveConfig(config: CollimateConfig): {
+  serverUrl: string;
+  apiKey: string;
+} {
+  const serverUrl = config.serverUrl || "https://api.collimate.ai";
+  const apiKey =
+    config.apiKey ||
+    (typeof process !== "undefined" ? process.env?.COLLIMATE_API_KEY : undefined);
+
+  if (!apiKey) {
+    throw new Error(
+      "Collimate API key is required. Set `apiKey` in config or the " +
+        "COLLIMATE_API_KEY environment variable.\n" +
+        "Get your key at https://collimate.ai",
+    );
+  }
+
+  return { serverUrl, apiKey };
+}
+
+function makeClient(config: CollimateConfig): { client: CollimateClient; serverUrl: string } {
+  const { serverUrl, apiKey } = resolveConfig(config);
+  return { client: new CollimateClient({ serverUrl, apiKey }), serverUrl };
+}
+
+function toSandbox(
+  client: CollimateClient,
+  serverUrl: string,
+  session: CreateSessionResponse,
+  timeoutMs: number,
+): CollimateSandbox {
+  return {
+    sessionId: session.session_id,
+    templateId: session.template_id,
+    client,
+    serverUrl,
+    createdAt: new Date(),
+    forkTimeMs: session.fork_time_ms,
+    createTimeMs: session.create_time_ms,
+    timeoutMs,
+  };
+}
+
+function toSandboxFromInfo(
+  client: CollimateClient,
+  serverUrl: string,
+  info: SessionInfo,
+  timeoutMs: number,
+): CollimateSandbox {
+  return {
+    sessionId: info.session_id,
+    templateId: info.template_id,
+    client,
+    serverUrl,
+    createdAt: new Date(Date.now() - info.age_secs * 1000),
+    forkTimeMs: 0,
+    createTimeMs: 0,
+    timeoutMs,
+  };
+}
+
+function escapeShellArg(arg: string): string {
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+function buildCommand(
+  command: string,
+  options?: { cwd?: string; env?: Record<string, string> },
+): string {
+  let cmd = command;
+
+  if (options?.cwd) {
+    cmd = `cd ${escapeShellArg(options.cwd)} && ${cmd}`;
+  }
+
+  if (options?.env) {
+    const prefix = Object.entries(options.env)
+      .map(([k, v]) => `${k}=${escapeShellArg(v)}`)
+      .join(" ");
+    cmd = `${prefix} ${cmd}`;
+  }
+
+  return cmd;
+}
+
+// ── Provider definition ──────────────────────────────────────────────────
+
+export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
+  name: "collimate",
+  methods: {
+    sandbox: {
+      async create(config, options) {
+        const { client, serverUrl } = makeClient(config);
+        const templateId =
+          (options as { templateId?: string } | undefined)?.templateId ||
+          config.templateId;
+
+        if (!templateId) {
+          throw new Error(
+            "templateId is required. Pass it in create options or set it " +
+              "in the provider config.",
+          );
+        }
+
+        const timeoutMs = (config.timeout ?? 900) * 1000;
+        const session = await client.createSession(templateId);
+        return {
+          sandbox: toSandbox(client, serverUrl, session, timeoutMs),
+          sandboxId: session.session_id,
+        };
+      },
+
+      async getById(config, sandboxId) {
+        const { client, serverUrl } = makeClient(config);
+        const info = await client.getSession(sandboxId);
+        if (!info) return null;
+        const timeoutMs = (config.timeout ?? 900) * 1000;
+        return {
+          sandbox: toSandboxFromInfo(client, serverUrl, info, timeoutMs),
+          sandboxId: info.session_id,
+        };
+      },
+
+      async list(config) {
+        const { client, serverUrl } = makeClient(config);
+        const sessions = await client.listSessions();
+        const timeoutMs = (config.timeout ?? 900) * 1000;
+        return sessions.map((info) => ({
+          sandbox: toSandboxFromInfo(client, serverUrl, info, timeoutMs),
+          sandboxId: info.session_id,
+        }));
+      },
+
+      async destroy(config, sandboxId) {
+        const { client } = makeClient(config);
+        await client.deleteSession(sandboxId, true);
+      },
+
+      async runCommand(sandbox, command, options?: RunCommandOptions): Promise<CommandResult> {
+        const fullCmd = buildCommand(command, options as {
+          cwd?: string;
+          env?: Record<string, string>;
+        });
+
+        const timeoutSecs = options?.timeout
+          ? Math.ceil(options.timeout / 1000)
+          : undefined;
+
+        const body: ExecRequest = {
+          commands: [["bash", "-lc", fullCmd]],
+          ...(timeoutSecs !== undefined && { timeout_seconds: timeoutSecs }),
+        };
+
+        const resp = await sandbox.client.execSession(
+          sandbox.sessionId,
+          body,
+        );
+
+        return {
+          stdout: resp.stdout,
+          stderr: resp.stderr,
+          exitCode: resp.exit_code,
+          durationMs: resp.exec_time_ms,
+        };
+      },
+
+      async getInfo(sandbox): Promise<SandboxInfo> {
+        const info = await sandbox.client.getSession(sandbox.sessionId);
+        if (!info) {
+          throw new CollimateError(
+            "Session not found — it may have been reaped due to inactivity",
+            404,
+          );
+        }
+        return {
+          id: info.session_id,
+          provider: "collimate",
+          runtime: (sandbox.templateId.includes("node") ? "node" : "python") as "node" | "python",
+          status: "running" as const,
+          createdAt: sandbox.createdAt,
+          timeout: sandbox.timeoutMs,
+          metadata: {
+            templateId: info.template_id,
+            ageSecs: info.age_secs,
+            idleSecs: info.idle_secs,
+            execCount: info.exec_count,
+            forkTimeMs: sandbox.forkTimeMs,
+          },
+        };
+      },
+
+      async getUrl(sandbox, options: { port: number; protocol?: string }) {
+        const protocol = options.protocol || "https";
+        return `${protocol}://${new URL(sandbox.serverUrl).host}/v1/sessions/${sandbox.sessionId}`;
+      },
+
+      getInstance(sandbox) {
+        return sandbox;
+      },
+
+      filesystem: {
+        async writeFile(sandbox, path, content, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            files: [{ path, content }],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`writeFile failed: ${resp.stderr}`);
+          }
+        },
+
+        async readFile(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["cat", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`readFile failed: ${resp.stderr}`);
+          }
+          return resp.stdout;
+        },
+
+        async mkdir(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["mkdir", "-p", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`mkdir failed: ${resp.stderr}`);
+          }
+        },
+
+        async readdir(sandbox, path, _runCommand): Promise<FileEntry[]> {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["ls", "-1aF", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`readdir failed: ${resp.stderr}`);
+          }
+          return resp.stdout
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l && l !== "./" && l !== "../")
+            .map((entry): FileEntry => {
+              const isDir = entry.endsWith("/");
+              const name = isDir ? entry.slice(0, -1) : entry.replace(/[*@|=]$/, "");
+              return { name, type: isDir ? "directory" : "file" };
+            });
+        },
+
+        async exists(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["test", "-e", path]],
+          });
+          return resp.exit_code === 0;
+        },
+
+        async remove(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["rm", "-rf", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`remove failed: ${resp.stderr}`);
+          }
+        },
+      },
+    },
+  },
+});
+
+// Re-export client types for advanced users
+export { CollimateClient, CollimateError } from "./client.js";
+export type {
+  CollimateClientConfig,
+  CreateSessionResponse,
+  ExecRequest,
+  ExecResponse,
+  SessionInfo,
+  FileSpec,
+} from "./client.js";

--- a/packages/collimate/tsconfig.json
+++ b/packages/collimate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/collimate/tsup.config.ts
+++ b/packages/collimate/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/collimate/vitest.config.ts
+++ b/packages/collimate/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Adds `@computesdk/collimate` provider.

- Full provider interface: create, destroy, runCommand, filesystem ops, getById, list, getInfo
- Standard test suite (`runProviderTestSuite`) + TTI benchmark
- Zero external dependencies — uses native fetch

## API Endpoint

`https://api.collimate.ai` — live, serving `node` and `python` templates.

## Test

```bash
COLLIMATE_API_KEY=<key> COLLIMATE_TEMPLATE_ID=node pnpm --filter @computesdk/collimate test
```

API key provided separately.