### PR TITLE
feat: add Collimate provider

### DIFF
--- a/packages/collimate/README.md
+++ b/packages/collimate/README.md
@@ -1,0 +1,50 @@
+# @computesdk/collimate
+
+[Collimate](https://collimate.ai) provider for [ComputeSDK](https://www.computesdk.com).
+
+## Installation
+
+```bash
+npm install @computesdk/collimate computesdk
+```
+
+## Usage
+
+```typescript
+import { collimate } from "@computesdk/collimate";
+import { compute } from "computesdk";
+
+compute.setConfig({
+  provider: collimate({
+    apiKey: "col_live_...",
+    templateId: "node",
+  }),
+});
+
+const sandbox = await compute.sandbox.create();
+const result = await sandbox.runCommand("node -v");
+console.log(result.stdout); // v22.x.x
+await sandbox.destroy();
+```
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `apiKey` | `string` | `COLLIMATE_API_KEY` env | API key for authentication |
+| `serverUrl` | `string` | `https://api.collimate.ai` | API server URL |
+| `templateId` | `string` | — | Template ID (`node`, `python`, etc.) |
+| `timeout` | `number` | `900` | Execution timeout in seconds |
+
+## Supported operations
+
+- `create()` / `destroy()` — sandbox lifecycle
+- `runCommand()` — shell execution with stdout/stderr/exitCode
+- `writeFile()` / `readFile()` — filesystem operations
+- `mkdir()` / `readdir()` / `exists()` / `remove()` — directory operations
+- `getById()` / `list()` / `getInfo()` — sandbox management
+
+## Links
+
+- [Collimate](https://collimate.ai)
+- [ComputeSDK](https://www.computesdk.com)

--- a/packages/collimate/package.json
+++ b/packages/collimate/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@computesdk/collimate",
+  "version": "0.1.0",
+  "description": "Collimate provider for ComputeSDK",
+  "author": "Collimate <hello@collimate.ai>",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "collimate",
+    "sandbox",
+    "code-execution",
+    "compute",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/collimate"
+  },
+  "homepage": "https://collimate.ai",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/collimate/src/__tests__/index.test.ts
+++ b/packages/collimate/src/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import { collimate } from '../index';
 runProviderTestSuite({
   name: 'collimate',
   provider: collimate({
-    serverUrl: process.env.COLLIMATE_SERVER_URL || 'https://api.collimate.ai',
+    serverUrl: process.env.COLLIMATE_API_URL || 'https://api.collimate.ai',
     apiKey: process.env.COLLIMATE_API_KEY,
     templateId: process.env.COLLIMATE_TEMPLATE_ID || 'node',
   }),

--- a/packages/collimate/src/__tests__/index.test.ts
+++ b/packages/collimate/src/__tests__/index.test.ts
@@ -1,0 +1,14 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { collimate } from '../index';
+
+runProviderTestSuite({
+  name: 'collimate',
+  provider: collimate({
+    serverUrl: process.env.COLLIMATE_SERVER_URL || 'https://api.collimate.ai',
+    apiKey: process.env.COLLIMATE_API_KEY,
+    templateId: process.env.COLLIMATE_TEMPLATE_ID || 'node',
+  }),
+  supportsFilesystem: true,
+  skipIntegration: !process.env.COLLIMATE_API_KEY,
+  supportsGetUrl: false,
+});

--- a/packages/collimate/src/client.ts
+++ b/packages/collimate/src/client.ts
@@ -1,0 +1,152 @@
+/**
+ * HTTP client for the Collimate API.
+ * Zero dependencies — uses native fetch.
+ */
+
+export interface CreateSessionResponse {
+  session_id: string;
+  template_id: string;
+  fork_time_ms: number;
+  create_time_ms: number;
+}
+
+export interface ExecResponse {
+  id: string;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  fork_time_ms: number;
+  exec_time_ms: number;
+  total_time_ms: number;
+  results?: Array<{ stdout: string; stderr: string; exit_code: number }>;
+}
+
+export interface SessionInfo {
+  session_id: string;
+  template_id: string;
+  age_secs: number;
+  idle_secs: number;
+  exec_count: number;
+}
+
+export interface FileSpec {
+  path: string;
+  content: string;
+}
+
+export interface ExecRequest {
+  code?: string;
+  commands?: string[][];
+  files?: FileSpec[];
+  timeout_seconds?: number;
+}
+
+export class CollimateError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = "CollimateError";
+  }
+}
+
+export interface CollimateClientConfig {
+  serverUrl: string;
+  apiKey: string;
+}
+
+export class CollimateClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(config: CollimateClientConfig) {
+    this.baseUrl = config.serverUrl.replace(/\/+$/, "");
+    this.apiKey = config.apiKey;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      "Authorization": `Bearer ${this.apiKey}`,
+      "User-Agent": "computesdk-collimate/0.1.0",
+    };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const resp = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      let message = `Collimate API error: ${resp.status}`;
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed.error) message = parsed.error;
+        else if (parsed.stderr) message = parsed.stderr;
+      } catch {
+        if (text) message = text;
+      }
+      throw new CollimateError(message, resp.status, text);
+    }
+
+    const text = await resp.text();
+    if (!text) return undefined as T;
+    return JSON.parse(text) as T;
+  }
+
+  async createSession(templateId: string): Promise<CreateSessionResponse> {
+    return this.request<CreateSessionResponse>("POST", "/v1/sessions", {
+      template_id: templateId,
+    });
+  }
+
+  async execSession(
+    sessionId: string,
+    body: ExecRequest,
+  ): Promise<ExecResponse> {
+    return this.request<ExecResponse>(
+      "POST",
+      `/v1/sessions/${encodeURIComponent(sessionId)}/exec`,
+      body,
+    );
+  }
+
+  async getSession(sessionId: string): Promise<SessionInfo | null> {
+    try {
+      return await this.request<SessionInfo>(
+        "GET",
+        `/v1/sessions/${encodeURIComponent(sessionId)}`,
+      );
+    } catch (err) {
+      if (err instanceof CollimateError && err.status === 404) return null;
+      throw err;
+    }
+  }
+
+  async listSessions(): Promise<SessionInfo[]> {
+    return this.request<SessionInfo[]>("GET", "/v1/sessions");
+  }
+
+  async deleteSession(sessionId: string, force = true): Promise<void> {
+    const qs = force ? "?force=true" : "";
+    try {
+      await this.request<unknown>(
+        "DELETE",
+        `/v1/sessions/${encodeURIComponent(sessionId)}${qs}`,
+      );
+    } catch (err) {
+      if (err instanceof CollimateError && err.status === 404) return;
+      throw err;
+    }
+  }
+}

--- a/packages/collimate/src/index.ts
+++ b/packages/collimate/src/index.ts
@@ -120,7 +120,12 @@ function buildCommand(
 
   if (options?.env) {
     const prefix = Object.entries(options.env)
-      .map(([k, v]) => `${k}=${escapeShellArg(v)}`)
+      .map(([k, v]) => {
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) {
+          throw new Error(`Invalid environment variable name: ${JSON.stringify(k)}`);
+        }
+        return `${k}=${escapeShellArg(v)}`;
+      })
       .join(" ");
     cmd = `${prefix} ${cmd}`;
   }
@@ -218,11 +223,11 @@ export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
         return {
           id: info.session_id,
           provider: "collimate",
-          runtime: (sandbox.templateId.includes("node") ? "node" : "python") as "node" | "python",
           status: "running" as const,
           createdAt: sandbox.createdAt,
           timeout: sandbox.timeoutMs,
           metadata: {
+            runtime: sandbox.templateId.includes("node") ? "node" : "python",
             templateId: info.template_id,
             ageSecs: info.age_secs,
             idleSecs: info.idle_secs,
@@ -231,9 +236,12 @@ export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
         };
       },
 
-      async getUrl(sandbox, options: { port: number; protocol?: string }) {
-        const protocol = options.protocol || "https";
-        return `${protocol}://${new URL(sandbox.serverUrl).host}/v1/sessions/${sandbox.sessionId}`;
+      async getUrl(_sandbox, options: { port: number; protocol?: string }) {
+        throw new Error(
+          `Collimate sandboxes are accessed through the exec API, not a per-port ` +
+            `public URL, so there is no address to expose port ${options.port} on. ` +
+            `getUrl is not supported.`,
+        );
       },
 
       getInstance(sandbox) {
@@ -252,7 +260,7 @@ export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
 
         async readFile(sandbox, path, _runCommand) {
           const resp = await sandbox.client.execSession(sandbox.sessionId, {
-            commands: [["cat", path]],
+            commands: [["cat", "--", path]],
           });
           if (resp.exit_code !== 0) {
             throw new Error(`readFile failed: ${resp.stderr}`);
@@ -262,7 +270,7 @@ export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
 
         async mkdir(sandbox, path, _runCommand) {
           const resp = await sandbox.client.execSession(sandbox.sessionId, {
-            commands: [["mkdir", "-p", path]],
+            commands: [["mkdir", "-p", "--", path]],
           });
           if (resp.exit_code !== 0) {
             throw new Error(`mkdir failed: ${resp.stderr}`);
@@ -271,7 +279,7 @@ export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
 
         async readdir(sandbox, path, _runCommand): Promise<FileEntry[]> {
           const resp = await sandbox.client.execSession(sandbox.sessionId, {
-            commands: [["ls", "-1aF", path]],
+            commands: [["ls", "-1aF", "--", path]],
           });
           if (resp.exit_code !== 0) {
             throw new Error(`readdir failed: ${resp.stderr}`);
@@ -289,14 +297,14 @@ export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
 
         async exists(sandbox, path, _runCommand) {
           const resp = await sandbox.client.execSession(sandbox.sessionId, {
-            commands: [["test", "-e", "--", path]],
+            commands: [["test", "-e", path]],
           });
           return resp.exit_code === 0;
         },
 
         async remove(sandbox, path, _runCommand) {
           const resp = await sandbox.client.execSession(sandbox.sessionId, {
-            commands: [["rm", "-rf", path]],
+            commands: [["rm", "-rf", "--", path]],
           });
           if (resp.exit_code !== 0) {
             throw new Error(`remove failed: ${resp.stderr}`);

--- a/packages/collimate/src/index.ts
+++ b/packages/collimate/src/index.ts
@@ -1,0 +1,318 @@
+/**
+ * @computesdk/collimate — ComputeSDK provider for Collimate sandboxes.
+ *
+ * Usage:
+ *   import { collimate } from "@computesdk/collimate";
+ *   import { compute } from "computesdk";
+ *
+ *   compute.setConfig({
+ *     provider: collimate({ apiKey: "col_live_...", templateId: "python" }),
+ *   });
+ *
+ *   const sandbox = await compute.sandbox.create();
+ *   const result = await sandbox.runCommand("echo hello");
+ *   await sandbox.destroy();
+ */
+
+import { defineProvider } from "@computesdk/provider";
+import type { RunCommandOptions, CommandResult, SandboxInfo, FileEntry } from "computesdk";
+import {
+  CollimateClient,
+  CollimateError,
+  type CreateSessionResponse,
+  type ExecRequest,
+  type SessionInfo,
+} from "./client.js";
+
+export interface CollimateConfig {
+  /** Collimate API server URL. Default: "https://api.collimate.ai" */
+  serverUrl?: string;
+  /** API key. Falls back to COLLIMATE_API_KEY env var. */
+  apiKey?: string;
+  /** Default template ID for sandbox creation. */
+  templateId?: string;
+  /** Default execution timeout in seconds. Default: 900 */
+  timeout?: number;
+}
+
+export interface CollimateSandbox {
+  sessionId: string;
+  templateId: string;
+  client: CollimateClient;
+  serverUrl: string;
+  createdAt: Date;
+  createTimeMs: number;
+  timeoutMs: number;
+}
+
+function resolveConfig(config: CollimateConfig): {
+  serverUrl: string;
+  apiKey: string;
+} {
+  const serverUrl = config.serverUrl || "https://api.collimate.ai";
+  const apiKey =
+    config.apiKey ||
+    (typeof process !== "undefined" ? process.env?.COLLIMATE_API_KEY : undefined);
+
+  if (!apiKey) {
+    throw new Error(
+      "Collimate API key is required. Set `apiKey` in config or the " +
+        "COLLIMATE_API_KEY environment variable.\n" +
+        "Get your key at https://collimate.ai",
+    );
+  }
+
+  return { serverUrl, apiKey };
+}
+
+function makeClient(config: CollimateConfig): { client: CollimateClient; serverUrl: string } {
+  const { serverUrl, apiKey } = resolveConfig(config);
+  return { client: new CollimateClient({ serverUrl, apiKey }), serverUrl };
+}
+
+function toSandbox(
+  client: CollimateClient,
+  serverUrl: string,
+  session: CreateSessionResponse,
+  timeoutMs: number,
+): CollimateSandbox {
+  return {
+    sessionId: session.session_id,
+    templateId: session.template_id,
+    client,
+    serverUrl,
+    createdAt: new Date(),
+    createTimeMs: session.create_time_ms,
+    timeoutMs,
+  };
+}
+
+function toSandboxFromInfo(
+  client: CollimateClient,
+  serverUrl: string,
+  info: SessionInfo,
+  timeoutMs: number,
+): CollimateSandbox {
+  return {
+    sessionId: info.session_id,
+    templateId: info.template_id,
+    client,
+    serverUrl,
+    createdAt: new Date(Date.now() - info.age_secs * 1000),
+    createTimeMs: 0,
+    timeoutMs,
+  };
+}
+
+function escapeShellArg(arg: string): string {
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+function buildCommand(
+  command: string,
+  options?: { cwd?: string; env?: Record<string, string> },
+): string {
+  let cmd = command;
+
+  if (options?.cwd) {
+    cmd = `cd ${escapeShellArg(options.cwd)} && ${cmd}`;
+  }
+
+  if (options?.env) {
+    const prefix = Object.entries(options.env)
+      .map(([k, v]) => `${k}=${escapeShellArg(v)}`)
+      .join(" ");
+    cmd = `${prefix} ${cmd}`;
+  }
+
+  return cmd;
+}
+
+export const collimate = defineProvider<CollimateSandbox, CollimateConfig>({
+  name: "collimate",
+  methods: {
+    sandbox: {
+      async create(config, options) {
+        const { client, serverUrl } = makeClient(config);
+        const templateId =
+          (options as { templateId?: string } | undefined)?.templateId ||
+          config.templateId;
+
+        if (!templateId) {
+          throw new Error(
+            "templateId is required. Pass it in create options or set it " +
+              "in the provider config.",
+          );
+        }
+
+        const timeoutMs = (config.timeout ?? 900) * 1000;
+        const session = await client.createSession(templateId);
+        return {
+          sandbox: toSandbox(client, serverUrl, session, timeoutMs),
+          sandboxId: session.session_id,
+        };
+      },
+
+      async getById(config, sandboxId) {
+        const { client, serverUrl } = makeClient(config);
+        const info = await client.getSession(sandboxId);
+        if (!info) return null;
+        const timeoutMs = (config.timeout ?? 900) * 1000;
+        return {
+          sandbox: toSandboxFromInfo(client, serverUrl, info, timeoutMs),
+          sandboxId: info.session_id,
+        };
+      },
+
+      async list(config) {
+        const { client, serverUrl } = makeClient(config);
+        const sessions = await client.listSessions();
+        const timeoutMs = (config.timeout ?? 900) * 1000;
+        return sessions.map((info) => ({
+          sandbox: toSandboxFromInfo(client, serverUrl, info, timeoutMs),
+          sandboxId: info.session_id,
+        }));
+      },
+
+      async destroy(config, sandboxId) {
+        const { client } = makeClient(config);
+        await client.deleteSession(sandboxId, true);
+      },
+
+      async runCommand(sandbox, command, options?: RunCommandOptions): Promise<CommandResult> {
+        const fullCmd = buildCommand(command, options as {
+          cwd?: string;
+          env?: Record<string, string>;
+        });
+
+        const timeoutSecs = options?.timeout
+          ? Math.ceil(options.timeout / 1000)
+          : undefined;
+
+        const body: ExecRequest = {
+          commands: [["bash", "-lc", fullCmd]],
+          ...(timeoutSecs !== undefined && { timeout_seconds: timeoutSecs }),
+        };
+
+        const resp = await sandbox.client.execSession(
+          sandbox.sessionId,
+          body,
+        );
+
+        return {
+          stdout: resp.stdout,
+          stderr: resp.stderr,
+          exitCode: resp.exit_code,
+          durationMs: resp.exec_time_ms,
+        };
+      },
+
+      async getInfo(sandbox): Promise<SandboxInfo> {
+        const info = await sandbox.client.getSession(sandbox.sessionId);
+        if (!info) {
+          throw new CollimateError(
+            "Session not found",
+            404,
+          );
+        }
+        return {
+          id: info.session_id,
+          provider: "collimate",
+          runtime: (sandbox.templateId.includes("node") ? "node" : "python") as "node" | "python",
+          status: "running" as const,
+          createdAt: sandbox.createdAt,
+          timeout: sandbox.timeoutMs,
+          metadata: {
+            templateId: info.template_id,
+            ageSecs: info.age_secs,
+            idleSecs: info.idle_secs,
+            execCount: info.exec_count,
+          },
+        };
+      },
+
+      async getUrl(sandbox, options: { port: number; protocol?: string }) {
+        const protocol = options.protocol || "https";
+        return `${protocol}://${new URL(sandbox.serverUrl).host}/v1/sessions/${sandbox.sessionId}`;
+      },
+
+      getInstance(sandbox) {
+        return sandbox;
+      },
+
+      filesystem: {
+        async writeFile(sandbox, path, content, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            files: [{ path, content }],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`writeFile failed: ${resp.stderr}`);
+          }
+        },
+
+        async readFile(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["cat", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`readFile failed: ${resp.stderr}`);
+          }
+          return resp.stdout;
+        },
+
+        async mkdir(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["mkdir", "-p", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`mkdir failed: ${resp.stderr}`);
+          }
+        },
+
+        async readdir(sandbox, path, _runCommand): Promise<FileEntry[]> {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["ls", "-1aF", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`readdir failed: ${resp.stderr}`);
+          }
+          return resp.stdout
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l && l !== "./" && l !== "../")
+            .map((entry): FileEntry => {
+              const isDir = entry.endsWith("/");
+              const name = isDir ? entry.slice(0, -1) : entry.replace(/[*@|=]$/, "");
+              return { name, type: isDir ? "directory" : "file" };
+            });
+        },
+
+        async exists(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["test", "-e", "--", path]],
+          });
+          return resp.exit_code === 0;
+        },
+
+        async remove(sandbox, path, _runCommand) {
+          const resp = await sandbox.client.execSession(sandbox.sessionId, {
+            commands: [["rm", "-rf", path]],
+          });
+          if (resp.exit_code !== 0) {
+            throw new Error(`remove failed: ${resp.stderr}`);
+          }
+        },
+      },
+    },
+  },
+});
+
+export { CollimateClient, CollimateError } from "./client.js";
+export type {
+  CollimateClientConfig,
+  CreateSessionResponse,
+  ExecRequest,
+  ExecResponse,
+  SessionInfo,
+  FileSpec,
+} from "./client.js";

--- a/packages/collimate/tsconfig.json
+++ b/packages/collimate/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/collimate/tsconfig.json
+++ b/packages/collimate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/collimate/tsup.config.ts
+++ b/packages/collimate/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/collimate/vitest.config.ts
+++ b/packages/collimate/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -75,7 +75,8 @@
     "@computesdk/secure-exec": "workspace:*",
     "@computesdk/upstash": "workspace:*",
     "@computesdk/k8s": "workspace:*",
-    "@computesdk/northflank": "workspace:*"
+    "@computesdk/northflank": "workspace:*",
+    "@computesdk/collimate": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@computesdk/e2b": {
@@ -136,6 +137,9 @@
       "optional": true
     },
     "@computesdk/northflank": {
+      "optional": true
+    },
+    "@computesdk/collimate": {
       "optional": true
     }
   },

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -26,6 +26,7 @@ const SHARED_PROVIDER_NAMES = [
   'upstash',
   'k8s',
   'northflank',
+  'collimate',
 ] as const;
 
 type SharedProviderName = typeof SHARED_PROVIDER_NAMES[number];
@@ -57,6 +58,7 @@ const SHARED_PROVIDER_AUTH: Record<SharedProviderName, readonly (readonly string
   upstash: [['UPSTASH_BOX_API_KEY']],
   k8s: [[]],
   northflank: [['NORTHFLANK_TOKEN', 'NORTHFLANK_PROJECT_ID']],
+  collimate: [['COLLIMATE_API_KEY']],
 };
 
 const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
@@ -87,6 +89,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
   upstash: { apiKey: 'UPSTASH_BOX_API_KEY' },
   k8s: {},
   northflank: { token: 'NORTHFLANK_TOKEN', projectId: 'NORTHFLANK_PROJECT_ID', teamId: 'NORTHFLANK_TEAM_ID', host: 'NORTHFLANK_API_URL' },
+  collimate: { apiKey: 'COLLIMATE_API_KEY', host: 'COLLIMATE_API_URL' },
 };
 
 function getProviderConfigFromEnv(provider: SharedProviderName): Record<string, string> {
@@ -351,6 +354,8 @@ export async function loadProvider(providerName: ProviderName): Promise<any> {
       case 'northflank':
         // @ts-ignore - package type declarations may be unavailable in local workbench typecheck
         return await import('@computesdk/northflank');
+      case 'collimate':
+        return await import('@computesdk/collimate');
       default:
         throw new Error(`Unknown provider: ${providerName}`);
     }

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -89,7 +89,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
   upstash: { apiKey: 'UPSTASH_BOX_API_KEY' },
   k8s: {},
   northflank: { token: 'NORTHFLANK_TOKEN', projectId: 'NORTHFLANK_PROJECT_ID', teamId: 'NORTHFLANK_TEAM_ID', host: 'NORTHFLANK_API_URL' },
-  collimate: { apiKey: 'COLLIMATE_API_KEY', host: 'COLLIMATE_API_URL' },
+  collimate: { apiKey: 'COLLIMATE_API_KEY', serverUrl: 'COLLIMATE_API_URL' },
 };
 
 function getProviderConfigFromEnv(provider: SharedProviderName): Record<string, string> {

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -355,6 +355,7 @@ export async function loadProvider(providerName: ProviderName): Promise<any> {
         // @ts-ignore - package type declarations may be unavailable in local workbench typecheck
         return await import('@computesdk/northflank');
       case 'collimate':
+        // @ts-ignore - package type declarations may be unavailable in local workbench typecheck
         return await import('@computesdk/collimate');
       default:
         throw new Error(`Unknown provider: ${providerName}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1690,6 +1690,9 @@ importers:
       '@computesdk/codesandbox':
         specifier: workspace:*
         version: link:../codesandbox
+      '@computesdk/collimate':
+        specifier: workspace:*
+        version: link:../collimate
       '@computesdk/daytona':
         specifier: workspace:*
         version: link:../daytona

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,40 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/collimate:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/computesdk:
     dependencies:
       '@computesdk/cmd':


### PR DESCRIPTION
Adds `@computesdk/collimate` with full provider interface and workbench integration.

- create/destroy, runCommand, filesystem ops, getById, list, getInfo
- Standard test suite (`runProviderTestSuite`)
- Workbench registration with `COLLIMATE_API_KEY` env detection
- Zero external dependencies — uses native fetch

API endpoint: `https://api.collimate.ai`
API key provided separately for testing.