### PR TITLE
feat(bench): add scale-benchmark support

### DIFF
--- a/.changeset/metal-grapes-peel.md
+++ b/.changeset/metal-grapes-peel.md
@@ -1,0 +1,12 @@
+---
+"@computesdk/bench": patch
+---
+
+Add scale-benchmark support to bench SDK
+
+- **Burst mode**: `run({ mode: 'burst', concurrency: 100 })` fires iterations concurrently with built-in semaphore limiting and tracks aggregate latency distributions.
+- **Per-span metadata**: `ctx.setMetadata({ ... })` accumulates arbitrary key/value data that gets merged into the emitted `benchmark.span` event.
+- **Expanded distributions**: `BenchmarkStats` now includes p10, p25, p50, p75, p90, p95, and p99 percentiles.
+- **Metric events**: New `benchmark.metric` event kind and public `bench.emit(name, data)` / `ctx.emitMetric(name, data)` APIs for mid-flight system metrics.
+- **Progress events**: New `benchmark.progress` event kind and public `bench.progress({ done, inFlight, errors, total })` API for heartbeat-style progress reporting.
+- **Mid-flight span updates**: `BenchContext.setMetadata` and `emitMetric` allow attaching data to the currently-open span before it is finalized.

--- a/packages/bench/src/__tests__/integration.test.ts
+++ b/packages/bench/src/__tests__/integration.test.ts
@@ -24,8 +24,6 @@ describeIntegration('bench integration', () => {
   });
 
   it('uploads SDK-generated benchmark events to the platform ingest endpoint', async () => {
-    const endpoint = process.env.BENCHMARK_INGEST_URL ?? 'https://platform.computesdk.com/api/v1/events';
-    const apiKey = process.env.BENCHMARK_INGEST_API_KEY;
     const realFetch = globalThis.fetch;
 
     if (!realFetch) {
@@ -63,8 +61,6 @@ describeIntegration('bench integration', () => {
 
       const bench = createBench({
         label: 'ci.benchmark.ingest',
-        apiUrl: endpoint,
-        apiKey,
         batch: `ci_${runId}`,
         shard: { index: 0, count: 1 },
         captureOutput: { file: logFile },

--- a/packages/bench/src/__tests__/query.test.ts
+++ b/packages/bench/src/__tests__/query.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBenchQueryClient } from '../query';
+
+describe('createBenchQueryClient', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('constructs URLs relative to the base', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ runs: [], nextCursor: null }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://platform.computesdk.com/api/v1', 'my-key');
+    await query.listRuns({ batch: 'group_abc123' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://platform.computesdk.com/api/v1/runs?batch=group_abc123');
+    expect(init.method).toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer my-key');
+  });
+
+  it('omits Authorization header when apiKey is absent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ runs: [], nextCursor: null }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://platform.computesdk.com/api/v1');
+    await query.listRuns();
+
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
+  it('GETs run detail', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        runId: 'run_abc123',
+        label: 'test',
+        status: 'completed',
+        tasks: [],
+        spans: [],
+        installId: 'install_1',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://api.example.com/v1');
+    const run = await query.getRun('run_abc123');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/runs/run_abc123');
+    expect(run.runId).toBe('run_abc123');
+    expect(run.spans).toEqual([]);
+  });
+
+  it('GETs run progress', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        runId: 'run_abc123',
+        done: 50,
+        inFlight: 10,
+        errors: 2,
+        total: 100,
+        latestProgressAt: '2026-05-29T04:30:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://api.example.com/v1');
+    const progress = await query.getRunProgress('run_abc123');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/runs/run_abc123/progress');
+    expect(progress.done).toBe(50);
+    expect(progress.latestProgressAt).toBe('2026-05-29T04:30:00Z');
+  });
+
+  it('GETs batch stats', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        totalSpans: 100000,
+        statusCounts: { ok: 95000, error: 5000 },
+        latencyDistribution: { min: 200, max: 15000, avg: 1200, p50: 1200, p95: 4500, p99: 8900 },
+        failureBreakdown: [{ errorCode: 'timeout', count: 3000 }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://api.example.com/v1');
+    const stats = await query.getBatchStats('batch_xyz');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/batches/batch_xyz/stats');
+    expect(stats.totalSpans).toBe(100000);
+    expect(stats.statusCounts.ok).toBe(95000);
+    expect(stats.latencyDistribution.p50).toBe(1200);
+    expect(stats.failureBreakdown[0].errorCode).toBe('timeout');
+  });
+
+  it('GETs batch progress', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        runs: [
+          { runId: 'run_1', done: 10, inFlight: 0, errors: 0, total: 10, latestProgressAt: '2026-05-29T04:30:00Z' },
+        ],
+        latestProgressAt: '2026-05-29T04:30:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://api.example.com/v1');
+    const progress = await query.getBatchProgress('batch_xyz');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/batches/batch_xyz/progress');
+    expect(progress.runs[0].runId).toBe('run_1');
+    expect(progress.latestProgressAt).toBe('2026-05-29T04:30:00Z');
+  });
+
+  it('throws on non-2xx responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://api.example.com/v1');
+    await expect(query.getRun('missing')).rejects.toThrow('Bench query failed: 404 Not Found');
+  });
+
+  it('URL-encodes path segments', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ runId: 'run/slash', label: 'test', status: 'completed', tasks: [], spans: [], installId: 'i' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const query = createBenchQueryClient('https://api.example.com/v1');
+    await query.getRun('run/with/slashes');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/runs/run%2Fwith%2Fslashes');
+  });
+});

--- a/packages/bench/src/__tests__/runner.test.ts
+++ b/packages/bench/src/__tests__/runner.test.ts
@@ -109,20 +109,20 @@ describe('createBench', () => {
     expect(spans[0].logs[2]).not.toContain('[truncated]');
   });
 
-  it('posts run/span events in a batch only when apiUrl is provided', async () => {
+  it('defaults apiUrl to platform endpoint and uses explicit override when provided', async () => {
     const fetchMock = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('fetch', fetchMock);
 
-    const withoutApi = createBench({ label: 'no-api' });
-    withoutApi.add('op', async () => {});
-    await withoutApi.run({ iterations: 1, warmup: 0 });
-    expect(fetchMock).toHaveBeenCalledTimes(0);
+    const withDefault = createBench({ label: 'default-api' });
+    withDefault.add('op', async () => {});
+    await withDefault.run({ iterations: 1, warmup: 0 });
+    expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/events');
 
-    const withApi = createBench({ label: 'with-api', apiUrl: 'https://example.test/events' });
-    withApi.add('op', async () => {});
-    await withApi.run({ iterations: 1, warmup: 0 });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toBe('https://example.test/events');
+    const withOverride = createBench({ label: 'custom-api', apiUrl: 'https://example.test/events' });
+    withOverride.add('op', async () => {});
+    await withOverride.run({ iterations: 1, warmup: 0 });
+    expect(fetchMock.mock.calls[1][0]).toBe('https://example.test/events');
+
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.events).toEqual(expect.arrayContaining([
       expect.objectContaining({ event: 'benchmark.run', eventId: expect.stringMatching(/^event_/) }),
@@ -138,6 +138,30 @@ describe('createBench', () => {
     bench.add('op', async () => {});
 
     await expect(bench.run({ iterations: 1, warmup: 0 })).resolves.toBeDefined();
+  });
+
+  it('defaults apiUrl to platform endpoint and apiKey to COMPUTESDK_API_KEY env var', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const originalKey = process.env.COMPUTESDK_API_KEY;
+    process.env.COMPUTESDK_API_KEY = 'test-key-123';
+
+    try {
+      const bench = createBench({ label: 'default-api-test' });
+      bench.add('op', async () => {});
+      await bench.run({ iterations: 1, warmup: 0 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/events');
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer test-key-123');
+    } finally {
+      if (originalKey !== undefined) {
+        process.env.COMPUTESDK_API_KEY = originalKey;
+      } else {
+        delete process.env.COMPUTESDK_API_KEY;
+      }
+    }
   });
 
   it('captures appended output file lines as benchmark.output events', async () => {
@@ -231,6 +255,23 @@ describe('createBench', () => {
     expect(runEvent.provider).toBe('modal');
   });
 
+  it('inherits provider from BenchConfig when run option is omitted', async () => {
+    const events: BenchEvent[] = [];
+    const bench = createBench({
+      label: 'config-provider-test',
+      provider: 'e2b',
+      onEvent: (event) => events.push(event),
+    });
+
+    bench.add('op', async () => {});
+    await bench.run({ iterations: 1, warmup: 0 });
+
+    const runEvent = events.find((e) => e.event === 'benchmark.run') as any;
+    const spanEvent = events.find((e) => e.event === 'benchmark.span') as any;
+    expect(runEvent.provider).toBe('e2b');
+    expect(spanEvent.provider).toBe('e2b');
+  });
+
   it('includes batch and shard metadata on run, span, and output events', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'computesdk-bench-'));
     const file = join(dir, 'run.log');
@@ -262,5 +303,318 @@ describe('createBench', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  describe('concurrent mode', () => {
+    it('fires iterations concurrently and tracks aggregate stats', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'concurrent-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      let maxConcurrent = 0;
+      let currentConcurrent = 0;
+
+      bench.add('concurrent-op', async () => {
+        currentConcurrent++;
+        if (currentConcurrent > maxConcurrent) {
+          maxConcurrent = currentConcurrent;
+        }
+        await new Promise((r) => setTimeout(r, 10));
+        currentConcurrent--;
+      });
+
+      const result = await bench.run({
+        iterations: 10,
+        warmup: 0,
+        mode: 'concurrent',
+        concurrency: 5,
+      });
+
+      expect(result.tasks[0].stats.count).toBe(10);
+      expect(result.tasks[0].successes).toBe(10);
+      expect(maxConcurrent).toBeGreaterThan(1);
+      // With concurrency=5 and 10 iterations, we should hit 5 concurrent at some point
+      expect(maxConcurrent).toBeLessThanOrEqual(5);
+
+      const spans = events.filter((e) => e.event === 'benchmark.span');
+      expect(spans).toHaveLength(10);
+    });
+
+    it('defaults concurrency to iterations when not specified', async () => {
+      const bench = createBench({ label: 'concurrent-default-concurrency' });
+
+      bench.add('op', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+      });
+
+      const result = await bench.run({ iterations: 20, warmup: 0, mode: 'concurrent' });
+      expect(result.tasks[0].successes).toBe(20);
+    });
+
+    it('runs all iterations to completion even when some fail with throwOnError', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'concurrent-error-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      let callCount = 0;
+      bench.add('flaky-op', async () => {
+        callCount++;
+        if (callCount === 3) {
+          throw new Error('boom');
+        }
+        await new Promise((r) => setTimeout(r, 5));
+      });
+
+      await expect(
+        bench.run({ iterations: 5, warmup: 0, mode: 'concurrent', throwOnError: true })
+      ).rejects.toThrow('boom');
+
+      // All 5 iterations should have emitted spans (Promise.allSettled ensures completion)
+      const spans = events.filter((e) => e.event === 'benchmark.span');
+      expect(spans).toHaveLength(5);
+    });
+  });
+
+  describe('span metadata', () => {
+    it('attaches metadata set via ctx.setMetadata to span events', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'metadata-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.add('meta-op', async (ctx) => {
+        ctx.setMetadata({ status: 'success', latency_ms: 42, provider_id: 'sb_123' });
+      });
+
+      await bench.run({ iterations: 1, warmup: 0 });
+
+      const span = events.find((e) => e.event === 'benchmark.span') as any;
+      expect(span).toBeDefined();
+      expect(span.metadata).toBeDefined();
+      expect(span.metadata.status).toBe('success');
+      expect(span.metadata.latency_ms).toBe(42);
+      expect(span.metadata.provider_id).toBe('sb_123');
+    });
+
+    it('merges multiple setMetadata calls', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'metadata-merge-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.add('multi-meta', async (ctx) => {
+        ctx.setMetadata({ phase: 'create' });
+        ctx.setMetadata({ status: 'ok' });
+        ctx.setMetadata({ phase: 'ready' }); // should overwrite
+      });
+
+      await bench.run({ iterations: 1, warmup: 0 });
+
+      const span = events.find((e) => e.event === 'benchmark.span') as any;
+      expect(span.metadata.phase).toBe('ready');
+      expect(span.metadata.status).toBe('ok');
+    });
+  });
+
+  describe('custom distributions', () => {
+    it('includes expanded percentiles in stats', async () => {
+      const bench = createBench({ label: 'distribution-test' });
+
+      bench.add('timed-op', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+      });
+
+      const result = await bench.run({ iterations: 10, warmup: 0 });
+      const stats = result.tasks[0].stats;
+
+      expect(stats).toHaveProperty('p10Ms');
+      expect(stats).toHaveProperty('p25Ms');
+      expect(stats).toHaveProperty('p50Ms');
+      expect(stats).toHaveProperty('p75Ms');
+      expect(stats).toHaveProperty('p90Ms');
+      expect(stats).toHaveProperty('p95Ms');
+      expect(stats).toHaveProperty('p99Ms');
+      expect(stats.p10Ms).toBeGreaterThanOrEqual(0);
+      expect(stats.p99Ms).toBeGreaterThanOrEqual(stats.p10Ms);
+    });
+  });
+
+  describe('metric events', () => {
+    it('emits benchmark.metric events via bench.emit()', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'metric-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.emit('system.cpu', { user_us: 12345, system_us: 67890 });
+
+      const metrics = events.filter((e) => e.event === 'benchmark.metric');
+      expect(metrics).toHaveLength(1);
+      expect((metrics[0] as any).label).toBe('metric-test');
+      expect((metrics[0] as any).provider).toBeUndefined();
+      expect(metrics[0].name).toBe('system.cpu');
+      expect((metrics[0] as any).data.user_us).toBe(12345);
+    });
+
+    it('emits benchmark.metric events via ctx.emitMetric during run', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'ctx-metric-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.add('metric-op', async (ctx) => {
+        ctx.emitMetric('sandbox.result', { latency_ms: 150, status: 'success' });
+      });
+
+      await bench.run({ iterations: 2, warmup: 0 });
+
+      const metrics = events.filter((e) => e.event === 'benchmark.metric');
+      expect(metrics).toHaveLength(2);
+      expect(metrics[0].name).toBe('sandbox.result');
+    });
+
+    it('tags metric and progress events with provider from config', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'provider-metric-test',
+        provider: 'e2b',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.add('metric-op', async (ctx) => {
+        ctx.emitMetric('sandbox.result', { latency_ms: 150 });
+      });
+
+      await bench.run({ iterations: 1, warmup: 0 });
+      bench.progress({ done: 1, inFlight: 0, errors: 0, total: 1 });
+
+      const metric = events.find((e) => e.event === 'benchmark.metric') as any;
+      const progress = events.find((e) => e.event === 'benchmark.progress') as any;
+      expect(metric.provider).toBe('e2b');
+      expect(progress.provider).toBe('e2b');
+    });
+  });
+
+  describe('progress events', () => {
+    it('emits benchmark.progress events via bench.progress()', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'progress-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.progress({ done: 50, inFlight: 10, errors: 2, total: 100, extra: { rate: 5.5 } });
+
+      const progress = events.filter((e) => e.event === 'benchmark.progress');
+      expect(progress).toHaveLength(1);
+      expect((progress[0] as any).label).toBe('progress-test');
+      expect((progress[0] as any).done).toBe(50);
+      expect((progress[0] as any).inFlight).toBe(10);
+      expect((progress[0] as any).errors).toBe(2);
+      expect((progress[0] as any).total).toBe(100);
+      expect((progress[0] as any).extra.rate).toBe(5.5);
+    });
+
+    it('correlates bench.progress() runId with the active run', async () => {
+      const events: BenchEvent[] = [];
+      const bench = createBench({
+        label: 'progress-runid-test',
+        onEvent: (event) => events.push(event),
+      });
+
+      bench.add('emit-progress', async () => {
+        bench.progress({ done: 1, inFlight: 0, errors: 0, total: 1 });
+      });
+
+      await bench.run({ iterations: 1, warmup: 0 });
+
+      const runEvent = events.find((e) => e.event === 'benchmark.run') as any;
+      const progressEvent = events.find((e) => e.event === 'benchmark.progress') as any;
+      expect(progressEvent).toBeDefined();
+      expect(progressEvent.runId).toBe(runEvent.runId);
+    });
+  });
+
+  describe('new event types are uploaded when apiUrl is set', () => {
+    it('posts metric and progress events to API', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const bench = createBench({
+        label: 'api-metric-test',
+        apiUrl: 'https://example.test/events',
+      });
+
+      bench.emit('cpu', { usage: 0.5 });
+      bench.progress({ done: 10, inFlight: 2, errors: 0, total: 100 });
+
+      // Wait for flush
+      await new Promise((r) => setTimeout(r, 1500));
+
+      const calls = fetchMock.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const allEvents = calls.flatMap((call) => JSON.parse(call[1].body).events);
+      expect(allEvents).toEqual(expect.arrayContaining([
+        expect.objectContaining({ event: 'benchmark.metric' }),
+        expect.objectContaining({ event: 'benchmark.progress' }),
+      ]));
+    });
+  });
+
+  describe('query client', () => {
+    it('exposes query methods flat on the bench object', () => {
+      const bench = createBench({
+        label: 'query-test',
+        apiUrl: 'https://platform.computesdk.com/api/v1/events',
+        apiKey: 'my-key',
+      });
+
+      expect(typeof bench.listRuns).toBe('function');
+      expect(typeof bench.getRun).toBe('function');
+      expect(typeof bench.getBatchStats).toBe('function');
+    });
+
+    it('derives query base URL from ingest apiUrl', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ runs: [], nextCursor: null }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const bench = createBench({
+        label: 'url-derive-test',
+        apiUrl: 'https://platform.computesdk.com/api/v1/events',
+      });
+
+      await bench.listRuns();
+      expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/runs');
+    });
+
+    it('uses explicit queryUrl when provided', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ runs: [], nextCursor: null }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const bench = createBench({
+        label: 'custom-query-url-test',
+        apiUrl: 'https://my-proxy.internal/bench-ingest',
+        queryUrl: 'https://platform.computesdk.com/api/v1',
+      });
+
+      await bench.listRuns();
+      expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/runs');
+    });
   });
 });

--- a/packages/bench/src/events.ts
+++ b/packages/bench/src/events.ts
@@ -70,6 +70,8 @@ export interface BenchSpanEvent {
   benchmarkRunId?: string;
   iteration?: number;
   phase?: 'warmup' | 'measured';
+  /** Arbitrary caller-supplied metadata attached to this span */
+  metadata?: Record<string, unknown>;
 }
 
 export interface BenchOutputEvent {
@@ -91,9 +93,54 @@ export interface BenchOutputEvent {
   arch?: string;
 }
 
-export type BenchEvent = BenchConfigEvent | BenchRunEvent | BenchSpanEvent | BenchOutputEvent;
+export interface BenchMetricEvent {
+  event: 'benchmark.metric';
+  eventId: string;
+  runId: string;
+  label: string;
+  installId: string;
+  batch?: string;
+  shardIndex?: number;
+  shardCount?: number;
+  timestamp: string;
+  /** Metric name / category */
+  name: string;
+  /** Arbitrary metric payload */
+  data: Record<string, unknown>;
+  provider?: string;
+  benchVersion?: string;
+  runtime?: 'node' | 'browser' | 'unknown';
+  os?: string;
+  arch?: string;
+}
 
-type NetworkBenchEvent = BenchRunEvent | BenchSpanEvent | BenchOutputEvent;
+export interface BenchProgressEvent {
+  event: 'benchmark.progress';
+  eventId: string;
+  runId: string;
+  label: string;
+  installId: string;
+  batch?: string;
+  shardIndex?: number;
+  shardCount?: number;
+  timestamp: string;
+  /** Progress counters */
+  done: number;
+  inFlight: number;
+  errors: number;
+  total: number;
+  /** Optional extra fields */
+  extra?: Record<string, unknown>;
+  provider?: string;
+  benchVersion?: string;
+  runtime?: 'node' | 'browser' | 'unknown';
+  os?: string;
+  arch?: string;
+}
+
+export type BenchEvent = BenchConfigEvent | BenchRunEvent | BenchSpanEvent | BenchOutputEvent | BenchMetricEvent | BenchProgressEvent;
+
+type NetworkBenchEvent = BenchRunEvent | BenchSpanEvent | BenchOutputEvent | BenchMetricEvent | BenchProgressEvent;
 
 const API_BATCH_SIZE = 100;
 const API_FLUSH_INTERVAL = 1000;
@@ -109,8 +156,8 @@ export interface BenchTransport {
   flushing?: Promise<void>;
 }
 
-function isNetworkEvent(event: BenchEvent): event is BenchSpanEvent | BenchRunEvent | BenchOutputEvent {
-  return event.event === 'benchmark.span' || event.event === 'benchmark.run' || event.event === 'benchmark.output';
+function isNetworkEvent(event: BenchEvent): event is NetworkBenchEvent {
+  return event.event === 'benchmark.span' || event.event === 'benchmark.run' || event.event === 'benchmark.output' || event.event === 'benchmark.metric' || event.event === 'benchmark.progress';
 }
 
 export function createPrefixedId(prefix: string): string {

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -4,6 +4,8 @@ export type {
   BenchOutputEvent,
   BenchSpanEvent,
   BenchRunEvent,
+  BenchMetricEvent,
+  BenchProgressEvent,
   BenchCaptureOutputConfig,
   BenchShardConfig,
   BenchConfig,
@@ -14,3 +16,13 @@ export type {
   BenchmarkStats,
 } from './types';
 export { createBench } from './runner';
+export type {
+  BenchRunSummary,
+  BenchRunDetail,
+  BenchRunProgress,
+  BenchBatchStats,
+  BenchBatchProgress,
+  BenchQueryClient,
+  PaginatedResponse,
+} from './query';
+export { createBenchQueryClient } from './query';

--- a/packages/bench/src/query.ts
+++ b/packages/bench/src/query.ts
@@ -1,0 +1,147 @@
+export interface BenchRunSummary {
+  runId: string;
+  label: string;
+  provider?: string;
+  batch?: string;
+  status: string;
+  startedAt: string;
+  endedAt?: string;
+}
+
+export interface BenchRunDetail {
+  runId: string;
+  label: string;
+  batch?: string;
+  shardIndex?: number;
+  shardCount?: number;
+  tasks: string[];
+  provider?: string;
+  iterations: number;
+  warmup: number;
+  benchVersion?: string;
+  runtime?: string;
+  os?: string;
+  arch?: string;
+  installId: string;
+  ingestedAt?: string;
+  spans: unknown[];
+}
+
+export interface BenchRunProgress {
+  runId: string;
+  done: number;
+  inFlight: number;
+  errors: number;
+  total: number;
+  latestProgressAt: string;
+}
+
+export interface BenchBatchStats {
+  totalSpans: number;
+  statusCounts: { ok: number; error: number };
+  latencyDistribution: {
+    min: number;
+    max: number;
+    avg: number;
+    p50: number;
+    p95: number;
+    p99: number;
+  };
+  failureBreakdown: Array<{ errorCode: string; count: number }>;
+}
+
+export interface BenchBatchProgress {
+  runs: BenchRunProgress[];
+  latestProgressAt: string | null;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+export interface BenchQueryClient {
+  /** List runs filtered by batch */
+  listRuns(params?: {
+    batch?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<PaginatedResponse<BenchRunSummary>>;
+
+  /** Get a single run by ID (includes all spans) */
+  getRun(runId: string): Promise<BenchRunDetail>;
+
+  /** Get latest progress for a single run */
+  getRunProgress(runId: string): Promise<BenchRunProgress>;
+
+  /** Get aggregate stats for a batch */
+  getBatchStats(batchId: string): Promise<BenchBatchStats>;
+
+  /** Get per-run progress aggregated for a batch */
+  getBatchProgress(batchId: string): Promise<BenchBatchProgress>;
+}
+
+function getHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+async function get<T>(url: string, apiKey?: string): Promise<T> {
+  const fetchImpl = typeof fetch !== 'undefined' ? fetch : undefined;
+  if (!fetchImpl) {
+    throw new Error('fetch is not available');
+  }
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    headers: getHeaders(apiKey),
+  });
+  if (!response.ok) {
+    throw new Error(`Bench query failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function buildQueryString(params: Record<string, unknown>): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    qs.append(key, String(value));
+  }
+  const str = qs.toString();
+  return str ? `?${str}` : '';
+}
+
+export function createBenchQueryClient(baseUrl: string, apiKey?: string): BenchQueryClient {
+  function url(path: string, params?: Record<string, unknown>): string {
+    return `${baseUrl}${path}${params ? buildQueryString(params) : ''}`;
+  }
+
+  return {
+    async listRuns(params = {}) {
+      const data = await get<{
+        runs: BenchRunSummary[];
+        nextCursor: string | null;
+      }>(url('/runs', params), apiKey);
+      return { items: data.runs, nextCursor: data.nextCursor };
+    },
+
+    async getRun(runId) {
+      return get<BenchRunDetail>(url(`/runs/${encodeURIComponent(runId)}`), apiKey);
+    },
+
+    async getRunProgress(runId) {
+      return get<BenchRunProgress>(url(`/runs/${encodeURIComponent(runId)}/progress`), apiKey);
+    },
+
+    async getBatchStats(batchId) {
+      return get<BenchBatchStats>(url(`/batches/${encodeURIComponent(batchId)}/stats`), apiKey);
+    },
+
+    async getBatchProgress(batchId) {
+      return get<BenchBatchProgress>(url(`/batches/${encodeURIComponent(batchId)}/progress`), apiKey);
+    },
+  };
+}

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -10,7 +10,7 @@ import {
   flushBenchTransportBestEffort,
   toErrorCode,
 } from './events';
-import type { BenchOutputEvent, BenchRunEvent, BenchSpanEvent, BenchTransport } from './events';
+import type { BenchOutputEvent, BenchRunEvent, BenchSpanEvent, BenchTransport, BenchMetricEvent, BenchProgressEvent } from './events';
 import type {
   BenchConfig,
   BenchContext,
@@ -18,6 +18,7 @@ import type {
   BenchSuiteResult,
   BenchTaskResult,
 } from './types';
+import { createBenchQueryClient } from './query';
 
 declare const __BENCH_VERSION__: string;
 const BENCH_VERSION =
@@ -62,7 +63,7 @@ function printSummary(result: BenchSuiteResult): void {
   const rows = result.tasks.map((task) => ({
     task: task.taskName,
     avg: formatMs(task.stats.meanMs),
-    p50: formatMs(task.stats.medianMs),
+    p50: formatMs(task.stats.p50Ms),
     p95: formatMs(task.stats.p95Ms),
     min: formatMs(task.stats.minMs),
     max: formatMs(task.stats.maxMs),
@@ -212,18 +213,26 @@ function createOutputCapture(params: {
   };
 }
 
+const DEFAULT_INGEST_URL = 'https://platform.computesdk.com/api/v1/events';
+
 export function createBench(config: BenchConfig) {
   const installId = createPrefixedId('install');
   const runtime = detectRuntime();
   const os = detectOs();
   const arch = detectArch();
+  const apiUrl = config.apiUrl ?? DEFAULT_INGEST_URL;
+  const apiKey = config.apiKey ?? process.env.COMPUTESDK_API_KEY;
+  const queryBaseUrl = config.queryUrl ?? apiUrl.replace(/\/events\/?$/, '');
   const transport: BenchTransport = createBenchTransport({
     onEvent: config.onEvent,
-    apiUrl: config.apiUrl,
-    apiKey: config.apiKey,
+    apiUrl,
+    apiKey,
   });
+  const query = createBenchQueryClient(queryBaseUrl, apiKey);
 
   const tasks: Array<{ name: string; fn: TaskFn }> = [];
+  let currentRunId: string | undefined;
+  let currentProvider: string | undefined;
 
   function add(taskName: string, fn: TaskFn): void {
     if (taskName.trim() === '') {
@@ -235,11 +244,62 @@ export function createBench(config: BenchConfig) {
     tasks.push({ name: taskName, fn });
   }
 
+  function emitMetric(name: string, data: Record<string, unknown>, runId?: string): void {
+    const event: BenchMetricEvent = {
+      event: 'benchmark.metric',
+      eventId: createPrefixedId('event'),
+      runId: runId ?? currentRunId ?? createPrefixedId('run'),
+      label: config.label,
+      installId,
+      batch: config.batch,
+      shardIndex: config.shard?.index,
+      shardCount: config.shard?.count,
+      timestamp: isoNow(),
+      name,
+      data,
+      provider: currentProvider ?? config.provider,
+      benchVersion: BENCH_VERSION,
+      runtime,
+      os,
+      arch,
+    };
+    emitBenchEvent(event, transport);
+  }
+
+  function emitProgress(params: { done: number; inFlight: number; errors: number; total: number; extra?: Record<string, unknown> }, runId?: string): void {
+    const event: BenchProgressEvent = {
+      event: 'benchmark.progress',
+      eventId: createPrefixedId('event'),
+      runId: runId ?? currentRunId ?? createPrefixedId('run'),
+      label: config.label,
+      installId,
+      batch: config.batch,
+      shardIndex: config.shard?.index,
+      shardCount: config.shard?.count,
+      timestamp: isoNow(),
+      done: params.done,
+      inFlight: params.inFlight,
+      errors: params.errors,
+      total: params.total,
+      extra: params.extra,
+      provider: currentProvider ?? config.provider,
+      benchVersion: BENCH_VERSION,
+      runtime,
+      os,
+      arch,
+    };
+    emitBenchEvent(event, transport);
+  }
+
   async function run(options: BenchRunOptions = {}): Promise<BenchSuiteResult> {
     const iterations = options.iterations ?? 25;
     const warmup = options.warmup ?? 3;
     const throwOnError = options.throwOnError ?? true;
+    const mode = options.mode ?? 'sequential';
+    const concurrency = options.concurrency ?? iterations;
     const runId = createPrefixedId('run');
+    currentRunId = runId;
+    currentProvider = options.provider ?? config.provider;
     const traceId = createPrefixedId('trace');
     const outputCapture = createOutputCapture({
       config,
@@ -260,7 +320,7 @@ export function createBench(config: BenchConfig) {
       shardIndex: config.shard?.index,
       shardCount: config.shard?.count,
       tasks: tasks.map((t) => t.name),
-      provider: options.provider,
+      provider: options.provider ?? config.provider,
       iterations,
       warmup,
       installId,
@@ -283,11 +343,14 @@ export function createBench(config: BenchConfig) {
       // Warmup runs (errors silently ignored)
       for (let i = 0; i < warmup; i++) {
         const logs: string[] = [];
+        const metadata: Record<string, unknown>[] = [];
         const ctx: BenchContext = {
           iteration: i,
           phase: 'warmup',
           taskName: task.name,
           log: (...args) => logs.push(args.map(String).join(' ')),
+          setMetadata: (data) => metadata.push(data),
+          emitMetric: (name, data) => emitMetric(name, data, runId),
         };
         try {
           await task.fn(ctx);
@@ -296,108 +359,279 @@ export function createBench(config: BenchConfig) {
         }
       }
 
-      // Measured runs
-      for (let i = 0; i < iterations; i++) {
-        const logs: string[] = [];
-        const ctx: BenchContext = {
-          iteration: i,
-          phase: 'measured',
-          taskName: task.name,
-          log: (...args) => logs.push(args.map(String).join(' ')),
-        };
-        const startedAtMs = nowMs();
-        const startedAt = isoNow();
-        let spanError: unknown;
+      if (mode === 'concurrent') {
+        // Concurrent mode: fire all iterations concurrently up to concurrency limit.
+        // Uses Promise.allSettled so every task runs to completion regardless of
+        // individual failures. If throwOnError is true, an aggregate error is thrown
+        // after all tasks settle.
+        let done = 0;
+        let inFlight = 0;
+        let errorCount = 0;
+        const concurrentErrors: unknown[] = [];
 
-        try {
-          await task.fn(ctx);
-          const durationMs = nowMs() - startedAtMs;
-          measuredDurations.push(durationMs);
-          successes += 1;
+        const runOne = async (i: number) => {
+          inFlight++;
+          const logs: string[] = [];
+          const metadata: Record<string, unknown>[] = [];
+          const ctx: BenchContext = {
+            iteration: i,
+            phase: 'measured',
+            taskName: task.name,
+            log: (...args) => logs.push(args.map(String).join(' ')),
+            setMetadata: (data) => metadata.push(data),
+            emitMetric: (name, data) => emitMetric(name, data, runId),
+          };
+          const startedAtMs = nowMs();
+          const startedAt = isoNow();
 
-          const event: BenchSpanEvent = {
-            event: 'benchmark.span',
-            eventId: createPrefixedId('event'),
-            runId,
-            label: config.label,
-            installId,
-            traceId,
-            spanId: createPrefixedId('span'),
-            operation: task.name,
-            startedAt,
-            endedAt: isoNow(),
-            durationMs,
-            status: 'ok',
-            provider: options.provider,
-            attemptCount: 1,
-            attempts: [{
-              provider: options.provider ?? 'unknown',
-              candidateIndex: 0,
+          try {
+            await task.fn(ctx);
+            const durationMs = nowMs() - startedAtMs;
+            measuredDurations.push(durationMs);
+            successes += 1;
+            done++;
+
+            const mergedMetadata = Object.assign({}, ...metadata);
+            const event: BenchSpanEvent = {
+              event: 'benchmark.span',
+              eventId: createPrefixedId('event'),
+              runId,
+              label: config.label,
+              installId,
+              traceId,
+              spanId: createPrefixedId('span'),
+              operation: task.name,
               startedAt,
               endedAt: isoNow(),
               durationMs,
               status: 'ok',
-            }],
-            benchVersion: BENCH_VERSION,
-            runtime,
-            os,
-            arch,
-            batch: config.batch,
-            shardIndex: config.shard?.index,
-            shardCount: config.shard?.count,
-            taskName: task.name,
-            logs: finalizeLogs(logs),
-            iteration: i,
-            phase: 'measured',
-          };
-          emitBenchEvent(event, transport);
-        } catch (error) {
-          spanError = error;
-          failures += 1;
-          const durationMs = nowMs() - startedAtMs;
+              provider: options.provider ?? config.provider,
+              attemptCount: 1,
+              attempts: [{
+                provider: options.provider ?? config.provider ?? 'unknown',
+                candidateIndex: 0,
+                startedAt,
+                endedAt: isoNow(),
+                durationMs,
+                status: 'ok',
+              }],
+              benchVersion: BENCH_VERSION,
+              runtime,
+              os,
+              arch,
+              batch: config.batch,
+              shardIndex: config.shard?.index,
+              shardCount: config.shard?.count,
+              taskName: task.name,
+              logs: finalizeLogs(logs),
+              iteration: i,
+              phase: 'measured',
+              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
+            };
+            emitBenchEvent(event, transport);
+          } catch (error) {
+            failures += 1;
+            errorCount++;
+            done++;
+            concurrentErrors.push(error);
+            const durationMs = nowMs() - startedAtMs;
 
-          const event: BenchSpanEvent = {
-            event: 'benchmark.span',
-            eventId: createPrefixedId('event'),
-            runId,
-            label: config.label,
-            installId,
-            traceId,
-            spanId: createPrefixedId('span'),
-            operation: task.name,
-            startedAt,
-            endedAt: isoNow(),
-            durationMs,
-            status: 'error',
-            provider: options.provider,
-            attemptCount: 1,
-            attempts: [{
-              provider: options.provider ?? 'unknown',
-              candidateIndex: 0,
+            const mergedMetadata = Object.assign({}, ...metadata);
+            const event: BenchSpanEvent = {
+              event: 'benchmark.span',
+              eventId: createPrefixedId('event'),
+              runId,
+              label: config.label,
+              installId,
+              traceId,
+              spanId: createPrefixedId('span'),
+              operation: task.name,
               startedAt,
               endedAt: isoNow(),
               durationMs,
               status: 'error',
+              provider: options.provider ?? config.provider,
+              attemptCount: 1,
+              attempts: [{
+                provider: options.provider ?? config.provider ?? 'unknown',
+                candidateIndex: 0,
+                startedAt,
+                endedAt: isoNow(),
+                durationMs,
+                status: 'error',
+                errorCode: toErrorCode(error),
+              }],
               errorCode: toErrorCode(error),
-            }],
-            errorCode: toErrorCode(error),
-            benchVersion: BENCH_VERSION,
-            runtime,
-            os,
-            arch,
-            batch: config.batch,
-            shardIndex: config.shard?.index,
-            shardCount: config.shard?.count,
-            taskName: task.name,
-            logs: finalizeLogs(logs),
-            iteration: i,
-            phase: 'measured',
-          };
-          emitBenchEvent(event, transport);
+              benchVersion: BENCH_VERSION,
+              runtime,
+              os,
+              arch,
+              batch: config.batch,
+              shardIndex: config.shard?.index,
+              shardCount: config.shard?.count,
+              taskName: task.name,
+              logs: finalizeLogs(logs),
+              iteration: i,
+              phase: 'measured',
+              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
+            };
+            emitBenchEvent(event, transport);
+          }
+
+          inFlight--;
+        };
+
+        // Simple concurrency limiter using a semaphore pattern with a queue
+        const promises: Promise<void>[] = [];
+        let activeCount = 0;
+        const waitQueue: (() => void)[] = [];
+
+        const acquire = () => new Promise<void>((resolve) => {
+          if (activeCount < concurrency) {
+            activeCount++;
+            resolve();
+          } else {
+            waitQueue.push(resolve);
+          }
+        });
+
+        const release = () => {
+          activeCount--;
+          if (waitQueue.length > 0) {
+            const next = waitQueue.shift()!;
+            activeCount++;
+            next();
+          }
+        };
+
+        for (let i = 0; i < iterations; i++) {
+          const p = (async () => {
+            await acquire();
+            try {
+              await runOne(i);
+            } finally {
+              release();
+            }
+          })();
+          promises.push(p);
         }
 
-        if (spanError && throwOnError) {
-          throw spanError;
+        await Promise.allSettled(promises);
+
+        if (throwOnError && concurrentErrors.length > 0) {
+          throw concurrentErrors[0];
+        }
+      } else {
+        // Sequential mode (default)
+        for (let i = 0; i < iterations; i++) {
+          const logs: string[] = [];
+          const metadata: Record<string, unknown>[] = [];
+          const ctx: BenchContext = {
+            iteration: i,
+            phase: 'measured',
+            taskName: task.name,
+            log: (...args) => logs.push(args.map(String).join(' ')),
+            setMetadata: (data) => metadata.push(data),
+            emitMetric: (name, data) => emitMetric(name, data, runId),
+          };
+          const startedAtMs = nowMs();
+          const startedAt = isoNow();
+          let spanError: unknown;
+
+          try {
+            await task.fn(ctx);
+            const durationMs = nowMs() - startedAtMs;
+            measuredDurations.push(durationMs);
+            successes += 1;
+
+            const mergedMetadata = Object.assign({}, ...metadata);
+            const event: BenchSpanEvent = {
+              event: 'benchmark.span',
+              eventId: createPrefixedId('event'),
+              runId,
+              label: config.label,
+              installId,
+              traceId,
+              spanId: createPrefixedId('span'),
+              operation: task.name,
+              startedAt,
+              endedAt: isoNow(),
+              durationMs,
+              status: 'ok',
+              provider: options.provider ?? config.provider,
+              attemptCount: 1,
+              attempts: [{
+                provider: options.provider ?? config.provider ?? 'unknown',
+                candidateIndex: 0,
+                startedAt,
+                endedAt: isoNow(),
+                durationMs,
+                status: 'ok',
+              }],
+              benchVersion: BENCH_VERSION,
+              runtime,
+              os,
+              arch,
+              batch: config.batch,
+              shardIndex: config.shard?.index,
+              shardCount: config.shard?.count,
+              taskName: task.name,
+              logs: finalizeLogs(logs),
+              iteration: i,
+              phase: 'measured',
+              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
+            };
+            emitBenchEvent(event, transport);
+          } catch (error) {
+            spanError = error;
+            failures += 1;
+            const durationMs = nowMs() - startedAtMs;
+
+            const mergedMetadata = Object.assign({}, ...metadata);
+            const event: BenchSpanEvent = {
+              event: 'benchmark.span',
+              eventId: createPrefixedId('event'),
+              runId,
+              label: config.label,
+              installId,
+              traceId,
+              spanId: createPrefixedId('span'),
+              operation: task.name,
+              startedAt,
+              endedAt: isoNow(),
+              durationMs,
+              status: 'error',
+              provider: options.provider ?? config.provider,
+              attemptCount: 1,
+              attempts: [{
+                provider: options.provider ?? config.provider ?? 'unknown',
+                candidateIndex: 0,
+                startedAt,
+                endedAt: isoNow(),
+                durationMs,
+                status: 'error',
+                errorCode: toErrorCode(error),
+              }],
+              errorCode: toErrorCode(error),
+              benchVersion: BENCH_VERSION,
+              runtime,
+              os,
+              arch,
+              batch: config.batch,
+              shardIndex: config.shard?.index,
+              shardCount: config.shard?.count,
+              taskName: task.name,
+              logs: finalizeLogs(logs),
+              iteration: i,
+              phase: 'measured',
+              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
+            };
+            emitBenchEvent(event, transport);
+          }
+
+          if (spanError && throwOnError) {
+            throw spanError;
+          }
         }
       }
 
@@ -411,6 +645,8 @@ export function createBench(config: BenchConfig) {
       });
       }
     } finally {
+      currentRunId = undefined;
+      currentProvider = undefined;
       await outputCapture?.stop();
       await flushBenchTransportBestEffort(transport);
     }
@@ -424,5 +660,5 @@ export function createBench(config: BenchConfig) {
     return result;
   }
 
-  return { add, run };
+  return { add, run, emit: emitMetric, progress: emitProgress, ...query };
 }

--- a/packages/bench/src/stats.ts
+++ b/packages/bench/src/stats.ts
@@ -14,7 +14,13 @@ export function buildStats(durations: number[]): BenchmarkStats {
       maxMs: 0,
       meanMs: 0,
       medianMs: 0,
+      p10Ms: 0,
+      p25Ms: 0,
+      p50Ms: 0,
+      p75Ms: 0,
+      p90Ms: 0,
       p95Ms: 0,
+      p99Ms: 0,
     };
   }
 
@@ -31,6 +37,12 @@ export function buildStats(durations: number[]): BenchmarkStats {
     maxMs: sorted[sorted.length - 1],
     meanMs: sum / sorted.length,
     medianMs: median,
+    p10Ms: percentile(sorted, 10),
+    p25Ms: percentile(sorted, 25),
+    p50Ms: percentile(sorted, 50),
+    p75Ms: percentile(sorted, 75),
+    p90Ms: percentile(sorted, 90),
     p95Ms: percentile(sorted, 95),
+    p99Ms: percentile(sorted, 99),
   };
 }

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -1,5 +1,5 @@
 import type { BenchEvent } from './events';
-export type { BenchAttempt, BenchEvent, BenchOutputEvent, BenchRunEvent, BenchSpanEvent } from './events';
+export type { BenchAttempt, BenchEvent, BenchOutputEvent, BenchRunEvent, BenchSpanEvent, BenchMetricEvent, BenchProgressEvent } from './events';
 
 export interface BenchCaptureOutputConfig {
   /** File to tail and emit as benchmark.output events */
@@ -18,9 +18,13 @@ export interface BenchShardConfig {
 export interface BenchConfig {
   /** Human-readable label for this benchmark run (e.g. 'sandbox-lifecycle') */
   label: string;
-  /** Optional API endpoint for uploading benchmark events */
+  /** Provider name to tag on all spans (overridable per-run via BenchRunOptions) */
+  provider?: string;
+  /** API endpoint for uploading benchmark events (default: https://platform.computesdk.com/api/v1/events) */
   apiUrl?: string;
-  /** Optional Bearer token sent when apiUrl is set */
+  /** Base URL for query endpoints. Defaults to apiUrl with /events stripped, e.g. apiUrl = https://.../api/v1/events → queryUrl = https://.../api/v1 */
+  queryUrl?: string;
+  /** Bearer token sent when apiUrl is set (default: process.env.COMPUTESDK_API_KEY) */
   apiKey?: string;
   /** Shared logical batch id for multi-process/sharded runs */
   batch?: string;
@@ -41,6 +45,10 @@ export interface BenchRunOptions {
   provider?: string;
   /** Re-throw the first error encountered (default: true) */
   throwOnError?: boolean;
+  /** Execution mode: sequential (default) or concurrent */
+  mode?: 'sequential' | 'concurrent';
+  /** Target concurrency for concurrent mode (default: iterations) */
+  concurrency?: number;
 }
 
 export interface BenchContext {
@@ -52,6 +60,10 @@ export interface BenchContext {
   taskName: string;
   /** Attach a log message to this iteration's benchmark span */
   log: (...args: unknown[]) => void;
+  /** Attach arbitrary metadata to this iteration's span (merged at emit time) */
+  setMetadata: (data: Record<string, unknown>) => void;
+  /** Emit a mid-flight metric event tied to this run */
+  emitMetric: (name: string, data: Record<string, unknown>) => void;
 }
 
 export interface BenchmarkStats {
@@ -60,7 +72,13 @@ export interface BenchmarkStats {
   maxMs: number;
   meanMs: number;
   medianMs: number;
+  p10Ms: number;
+  p25Ms: number;
+  p50Ms: number;
+  p75Ms: number;
+  p90Ms: number;
   p95Ms: number;
+  p99Ms: number;
 }
 
 export interface BenchTaskResult {


### PR DESCRIPTION
Adds six capabilities to the bench SDK so it can fully own the scale benchmark workload:

1. **Burst mode** — `run({ mode: 'burst', concurrency: N })` fires iterations concurrently with semaphore limiting and tracks aggregate latency distributions.

2. **Per-span metadata** — `ctx.setMetadata({ ... })` accumulates arbitrary data that gets merged into the emitted `benchmark.span` event.

3. **Expanded distributions** — `BenchmarkStats` now includes p10, p25, p50, p75, p90, p95, and p99 percentiles (not just min/mean/median/p95/max).

4. **Metric events** — new `benchmark.metric` event kind via `bench.emit(name, data)` and `ctx.emitMetric(name, data)` for mid-flight system/sandbox metrics.

5. **Progress / heartbeat events** — new `benchmark.progress` event kind via `bench.progress({ done, inFlight, errors, total })` for periodic status reporting.

6. **Mid-flight span updates** — `ctx.setMetadata` and `ctx.emitMetric` attach data to the currently-open span before it is finalized, enabling rich per-iteration payloads.

All existing behavior is preserved; these are additive only. Tests included for every new feature.