### PR TITLE
refactor(bench): unify baseUrl config for ingest/query

### DIFF
--- a/packages/bench/src/__tests__/query.test.ts
+++ b/packages/bench/src/__tests__/query.test.ts
@@ -15,7 +15,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://platform.computesdk.com/api/v1', 'my-key');
+    const query = createBenchQueryClient({ baseUrl: 'https://platform.computesdk.com/api/v1', apiKey: 'my-key' });
     await query.listRuns({ batch: 'group_abc123' });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -33,7 +33,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://platform.computesdk.com/api/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://platform.computesdk.com/api/v1' });
     await query.listRuns();
 
     expect(fetchMock.mock.calls[0][1].headers.Authorization).toBeUndefined();
@@ -54,7 +54,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://api.example.com/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://api.example.com/v1' });
     const run = await query.getRun('run_abc123');
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/runs/run_abc123');
@@ -77,7 +77,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://api.example.com/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://api.example.com/v1' });
     const progress = await query.getRunProgress('run_abc123');
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/runs/run_abc123/progress');
@@ -98,7 +98,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://api.example.com/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://api.example.com/v1' });
     const stats = await query.getBatchStats('batch_xyz');
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/batches/batch_xyz/stats');
@@ -121,7 +121,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://api.example.com/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://api.example.com/v1' });
     const progress = await query.getBatchProgress('batch_xyz');
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/batches/batch_xyz/progress');
@@ -137,7 +137,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://api.example.com/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://api.example.com/v1' });
     await expect(query.getRun('missing')).rejects.toThrow('Bench query failed: 404 Not Found');
   });
 
@@ -149,7 +149,7 @@ describe('createBenchQueryClient', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const query = createBenchQueryClient('https://api.example.com/v1');
+    const query = createBenchQueryClient({ baseUrl: 'https://api.example.com/v1' });
     await query.getRun('run/with/slashes');
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/runs/run%2Fwith%2Fslashes');

--- a/packages/bench/src/__tests__/runner.test.ts
+++ b/packages/bench/src/__tests__/runner.test.ts
@@ -109,7 +109,7 @@ describe('createBench', () => {
     expect(spans[0].logs[2]).not.toContain('[truncated]');
   });
 
-  it('defaults apiUrl to platform endpoint and uses explicit override when provided', async () => {
+  it('defaults ingest endpoint to platform and supports baseUrl override', async () => {
     const fetchMock = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('fetch', fetchMock);
 
@@ -118,7 +118,7 @@ describe('createBench', () => {
     await withDefault.run({ iterations: 1, warmup: 0 });
     expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/events');
 
-    const withOverride = createBench({ label: 'custom-api', apiUrl: 'https://example.test/events' });
+    const withOverride = createBench({ label: 'custom-api', baseUrl: 'https://example.test' });
     withOverride.add('op', async () => {});
     await withOverride.run({ iterations: 1, warmup: 0 });
     expect(fetchMock.mock.calls[1][0]).toBe('https://example.test/events');
@@ -134,13 +134,13 @@ describe('createBench', () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
     vi.stubGlobal('fetch', fetchMock);
 
-    const bench = createBench({ label: 'api-failure-test', apiUrl: 'https://example.test/events' });
+    const bench = createBench({ label: 'api-failure-test', baseUrl: 'https://example.test' });
     bench.add('op', async () => {});
 
     await expect(bench.run({ iterations: 1, warmup: 0 })).resolves.toBeDefined();
   });
 
-  it('defaults apiUrl to platform endpoint and apiKey to COMPUTESDK_API_KEY env var', async () => {
+  it('defaults baseUrl to platform endpoint and apiKey to COMPUTESDK_API_KEY env var', async () => {
     const fetchMock = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('fetch', fetchMock);
 
@@ -543,14 +543,14 @@ describe('createBench', () => {
     });
   });
 
-  describe('new event types are uploaded when apiUrl is set', () => {
+  describe('new event types are uploaded when baseUrl is set', () => {
     it('posts metric and progress events to API', async () => {
       const fetchMock = vi.fn().mockResolvedValue(undefined);
       vi.stubGlobal('fetch', fetchMock);
 
       const bench = createBench({
         label: 'api-metric-test',
-        apiUrl: 'https://example.test/events',
+        baseUrl: 'https://example.test',
       });
 
       bench.emit('cpu', { usage: 0.5 });
@@ -573,7 +573,7 @@ describe('createBench', () => {
     it('exposes query methods flat on the bench object', () => {
       const bench = createBench({
         label: 'query-test',
-        apiUrl: 'https://platform.computesdk.com/api/v1/events',
+        baseUrl: 'https://platform.computesdk.com/api/v1',
         apiKey: 'my-key',
       });
 
@@ -582,7 +582,7 @@ describe('createBench', () => {
       expect(typeof bench.getBatchStats).toBe('function');
     });
 
-    it('derives query base URL from ingest apiUrl', async () => {
+    it('uses baseUrl for query methods', async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
@@ -591,30 +591,13 @@ describe('createBench', () => {
       vi.stubGlobal('fetch', fetchMock);
 
       const bench = createBench({
-        label: 'url-derive-test',
-        apiUrl: 'https://platform.computesdk.com/api/v1/events',
+        label: 'base-url-query-test',
+        baseUrl: 'https://platform.computesdk.com/api/v1',
       });
 
       await bench.listRuns();
       expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/runs');
     });
 
-    it('uses explicit queryUrl when provided', async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ runs: [], nextCursor: null }),
       });
-      vi.stubGlobal('fetch', fetchMock);
-
-      const bench = createBench({
-        label: 'custom-query-url-test',
-        apiUrl: 'https://my-proxy.internal/bench-ingest',
-        queryUrl: 'https://platform.computesdk.com/api/v1',
-      });
-
-      await bench.listRuns();
-      expect(fetchMock.mock.calls[0][0]).toBe('https://platform.computesdk.com/api/v1/runs');
-    });
-  });
 });

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -23,6 +23,7 @@ export type {
   BenchBatchStats,
   BenchBatchProgress,
   BenchQueryClient,
+  BenchQueryClientConfig,
   PaginatedResponse,
 } from './query';
 export { createBenchQueryClient } from './query';

--- a/packages/bench/src/query.ts
+++ b/packages/bench/src/query.ts
@@ -81,6 +81,13 @@ export interface BenchQueryClient {
   getBatchProgress(batchId: string): Promise<BenchBatchProgress>;
 }
 
+export interface BenchQueryClientConfig {
+  /** Base URL for query endpoints (default: https://platform.computesdk.com/api/v1) */
+  baseUrl?: string;
+  /** Bearer token for query requests (default: process.env.COMPUTESDK_API_KEY) */
+  apiKey?: string;
+}
+
 function getHeaders(apiKey?: string): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (apiKey) {
@@ -114,7 +121,12 @@ function buildQueryString(params: Record<string, unknown>): string {
   return str ? `?${str}` : '';
 }
 
-export function createBenchQueryClient(baseUrl: string, apiKey?: string): BenchQueryClient {
+const DEFAULT_BASE_URL = 'https://platform.computesdk.com/api/v1';
+
+export function createBenchQueryClient(config: BenchQueryClientConfig = {}): BenchQueryClient {
+  const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+  const apiKey = config.apiKey ?? process.env.COMPUTESDK_API_KEY;
+
   function url(path: string, params?: Record<string, unknown>): string {
     return `${baseUrl}${path}${params ? buildQueryString(params) : ''}`;
   }

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -213,22 +213,22 @@ function createOutputCapture(params: {
   };
 }
 
-const DEFAULT_INGEST_URL = 'https://platform.computesdk.com/api/v1/events';
+const DEFAULT_BASE_URL = 'https://platform.computesdk.com/api/v1';
 
 export function createBench(config: BenchConfig) {
   const installId = createPrefixedId('install');
   const runtime = detectRuntime();
   const os = detectOs();
   const arch = detectArch();
-  const apiUrl = config.apiUrl ?? DEFAULT_INGEST_URL;
+  const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+  const apiUrl = `${baseUrl}/events`;
   const apiKey = config.apiKey ?? process.env.COMPUTESDK_API_KEY;
-  const queryBaseUrl = config.queryUrl ?? apiUrl.replace(/\/events\/?$/, '');
   const transport: BenchTransport = createBenchTransport({
     onEvent: config.onEvent,
     apiUrl,
     apiKey,
   });
-  const query = createBenchQueryClient(queryBaseUrl, apiKey);
+  const query = createBenchQueryClient({ baseUrl, apiKey });
 
   const tasks: Array<{ name: string; fn: TaskFn }> = [];
   let currentRunId: string | undefined;

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -20,11 +20,9 @@ export interface BenchConfig {
   label: string;
   /** Provider name to tag on all spans (overridable per-run via BenchRunOptions) */
   provider?: string;
-  /** API endpoint for uploading benchmark events (default: https://platform.computesdk.com/api/v1/events) */
-  apiUrl?: string;
-  /** Base URL for query endpoints. Defaults to apiUrl with /events stripped, e.g. apiUrl = https://.../api/v1/events → queryUrl = https://.../api/v1 */
-  queryUrl?: string;
-  /** Bearer token sent when apiUrl is set (default: process.env.COMPUTESDK_API_KEY) */
+  /** Base URL for ingest/query APIs (default: https://platform.computesdk.com/api/v1) */
+  baseUrl?: string;
+  /** Bearer token sent for ingest/query requests (default: process.env.COMPUTESDK_API_KEY) */
   apiKey?: string;
   /** Shared logical batch id for multi-process/sharded runs */
   batch?: string;


### PR DESCRIPTION
This pull request refactors the configuration of API endpoints in the `bench` package, consolidating and simplifying how base URLs and API keys are provided for both ingest and query operations. The changes replace the previous `apiUrl` and `queryUrl` options with a single `baseUrl` parameter, update related types and documentation, and adjust all usages and tests accordingly.

**Configuration refactor and API simplification:**

- Replaced `apiUrl` and `queryUrl` options in `BenchConfig` with a single `baseUrl` parameter, which now controls both ingest and query endpoints. Updated documentation comments to reflect this unified approach. (`packages/bench/src/types.ts`, `packages/bench/src/runner.ts`) [[1]](diffhunk://#diff-07e2029a01d1bad7b6c604c96c885d89996e3aa9c53d53199e0c94ba4a2be24eL23-R25) [[2]](diffhunk://#diff-0b91e0384ab05cabae11cf78ff35af98392c90f896e35d1e8a01e31f658865dfL216-R231)
- Updated the `createBenchQueryClient` function to accept a `BenchQueryClientConfig` object instead of positional arguments, defaulting `baseUrl` and `apiKey` if not provided. Added the new `BenchQueryClientConfig` type. (`packages/bench/src/query.ts`, `packages/bench/src/index.ts`) [[1]](diffhunk://#diff-c2642ac6b00a68509713cbf2da6dabeb4609a1b2cab0b85bc7bbe24eb2372bc1R84-R90) [[2]](diffhunk://#diff-c2642ac6b00a68509713cbf2da6dabeb4609a1b2cab0b85bc7bbe24eb2372bc1L117-R129) [[3]](diffhunk://#diff-a39e13eaa5a01ec9e84c9090e2b83fa7742d189ed0b6df4931b3504096ca0d67R26)

**Test updates for new configuration:**

- Modified all tests in `runner.test.ts` and `query.test.ts` to use the new `baseUrl` parameter and updated test descriptions to match the new configuration terminology. (`packages/bench/src/__tests__/runner.test.ts`, `packages/bench/src/__tests__/query.test.ts`) [[1]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL112-R112) [[2]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL121-R121) [[3]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL137-R143) [[4]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL546-R553) [[5]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL576-R576) [[6]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL585-R585) [[7]](diffhunk://#diff-887d0acb854bc32834f89cd91e61be8d0aa6f20c1a776f8de530c5091341f8faL594-L618) [[8]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L18-R18) [[9]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L36-R36) [[10]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L57-R57) [[11]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L80-R80) [[12]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L101-R101) [[13]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L124-R124) [[14]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L140-R140) [[15]](diffhunk://#diff-954abddafb692d80de20c5bd0e9715f252f8a94ef027cee7aa2bc99621aa9395L152-R152)

**Cleanup and removal of legacy options:**

- Removed all handling and documentation for the now-deprecated `apiUrl` and `queryUrl` parameters throughout the codebase. (`packages/bench/src/types.ts`, `packages/bench/src/runner.ts`) [[1]](diffhunk://#diff-07e2029a01d1bad7b6c604c96c885d89996e3aa9c53d53199e0c94ba4a2be24eL23-R25) [[2]](diffhunk://#diff-0b91e0384ab05cabae11cf78ff35af98392c90f896e35d1e8a01e31f658865dfL216-R231)

These changes make endpoint configuration more consistent and easier to use, reducing potential confusion and simplifying future maintenance.