### PR TITLE
refactor(bench): pipeline-first step scheduling

### DIFF
--- a/.changeset/small-tomatoes-tell.md
+++ b/.changeset/small-tomatoes-tell.md
@@ -1,0 +1,13 @@
+---
+"@computesdk/bench": patch
+---
+
+Refine bench step scheduling for concurrent lifecycle workloads.
+
+- Make `bench.add(...)` chainable and add optional step controls:
+  - `concurrency` to cap a specific step
+  - `runOnFailed` to run cleanup/finalizer steps for failed iterations
+- Use pipeline-style stage execution by default so steps run in declaration order across iterations.
+- Keep same-stage execution resilient by continuing peer iterations when one iteration fails.
+- Skip failed iterations in later steps unless `runOnFailed` is enabled for that step.
+- Update bench README examples/docs to match the new step scheduling semantics.

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -2,7 +2,7 @@
 
 Tinybench-style benchmarking toolkit for ComputeSDK.
 
-`@computesdk/bench` runs warmups + measured iterations across a run of named tasks and emits structured benchmark events.
+`@computesdk/bench` runs warmups + measured iterations across named pipeline steps and emits structured benchmark events.
 
 ## Installation
 
@@ -18,30 +18,30 @@ import { compute } from 'computesdk';
 
 const bench = createBench({
   label: 'sandbox-lifecycle',
-  apiUrl: 'https://platform.computesdk.com/api/v1/events',
   batch: 'burst-100k-e2b',
   shard: { index: 0, count: 100 },
   captureOutput: { file: '/root/run.log' },
 });
 
-bench.add('create', async (ctx) => {
-  ctx.log('booting sandbox...');
-  const sandbox = await compute.sandbox.create();
-  ctx.log(`ready: ${sandbox.sandboxId}`);
-});
+const sandboxes: Array<{ sandboxId: string; runCommand: (cmd: string) => Promise<unknown>; destroy: () => Promise<void> } | undefined> = [];
 
-bench.add('exec', async (ctx) => {
-  ctx.log('running command');
-  // ...
-});
-
-bench.add('destroy', async (ctx) => {
-  // ...
-});
+bench
+  .add('create', async (ctx) => {
+    ctx.log('booting sandbox...');
+    sandboxes[ctx.iteration] = await compute.sandbox.create();
+  })
+  .add('exec', async (ctx) => {
+    await sandboxes[ctx.iteration]?.runCommand('node -v');
+  }, { concurrency: 100 })
+  .add('destroy', async (ctx) => {
+    await sandboxes[ctx.iteration]?.destroy();
+  }, { runOnFailed: true });
 
 const result = await bench.run({
   iterations: 25,
   warmup: 3,
+  mode: 'concurrent',
+  concurrency: 100,
   provider: 'e2b',
 });
 
@@ -50,6 +50,42 @@ for (const task of result.tasks) {
 }
 ```
 
+## Scale Lifecycle Pattern
+
+For scale/lifecycle benchmarks, model each lifecycle phase as a step and let
+`iterations` represent unit count.
+
+```ts
+import { createBench } from '@computesdk/bench';
+
+const bench = createBench({ label: 'scale.e2b' });
+const sandboxes: Array<any | undefined> = [];
+
+bench
+  .add('create', async (ctx) => {
+    sandboxes[ctx.iteration] = await compute.sandbox.create();
+  }, { concurrency: 100 })
+  .add('exec.initial', async (ctx) => {
+    await sandboxes[ctx.iteration]?.runCommand('node -v');
+  }, { concurrency: 100 })
+  .add('exec.concurrent', async (ctx) => {
+    await sandboxes[ctx.iteration]?.runCommand('node -v');
+  }, { concurrency: 100 })
+  .add('destroy', async (ctx) => {
+    await sandboxes[ctx.iteration]?.destroy();
+  }, { runOnFailed: true, concurrency: 100 });
+
+await bench.run({
+  mode: 'concurrent',
+  iterations: 100,
+  concurrency: 100,
+  warmup: 0,
+});
+```
+
+This gives step-level timing (`create`, `exec.initial`, `exec.concurrent`,
+`destroy`) where each step's `Runs` naturally maps to unit count.
+
 ## API
 
 ### `createBench(config)`
@@ -57,18 +93,28 @@ for (const task of result.tasks) {
 | Field | Type | Description |
 |-------|------|-------------|
 | `label` | `string` | Human-readable run label |
-| `apiUrl` | `string?` | Optional URL to upload benchmark events. Use `https://platform.computesdk.com/api/v1/events` for ComputeSDK Platform |
-| `apiKey` | `string?` | Optional bearer token used when `apiUrl` is set |
+| `baseUrl` | `string?` | Optional base URL for ingest/query APIs. Defaults to `https://platform.computesdk.com/api/v1` |
+| `apiKey` | `string?` | Optional bearer token used for ingest/query requests. Defaults to `process.env.COMPUTESDK_API_KEY` |
 | `batch` | `string?` | Shared logical batch id for multi-process/sharded runs |
 | `shard` | `{ index: number; count: number }?` | Shard metadata for this process. `index` is zero-based |
 | `onEvent` | `function?` | Local debug hook called with every emitted event |
 | `captureOutput` | `{ file: string; flushInterval?: number }?` | Tail a process log file and emit `benchmark.output` events. `flushInterval` is milliseconds and defaults to `30000` |
 
-Returns `{ add, run }`.
+Returns `{ add, run, emit, progress, ...query }`.
 
-### `bench.add(taskName, fn)`
+### `bench.add(taskName, fn, options?)`
 
-Register a named task. `fn` receives a `BenchContext`:
+Register a named pipeline step. `fn` receives a `BenchContext`.
+`add()` is chainable.
+
+`options`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `concurrency` | `number?` | Per-step concurrency cap (used in concurrent mode) |
+| `runOnFailed` | `boolean?` | Run this step for iterations that failed earlier steps (useful for cleanup) |
+
+`BenchContext`:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -83,6 +129,8 @@ Register a named task. `fn` receives a `BenchContext`:
 |--------|---------|-------------|
 | `iterations` | `25` | Measured iterations per task |
 | `warmup` | `3` | Warmup iterations before measuring |
+| `mode` | `'sequential'` | Run iterations sequentially or concurrently |
+| `concurrency` | `iterations` | In concurrent mode, max in-flight iterations |
 | `provider` | — | Provider name tag applied to all spans |
 | `throwOnError` | `true` | Re-throw the first error encountered |
 
@@ -111,12 +159,19 @@ benchmark.run    — once per run (label, tasks, provider, iterations, warmup)
   benchmark.output — captured process output lines when captureOutput is configured
 ```
 
+Execution semantics:
+
+- Steps run in declaration order.
+- In concurrent mode, each step runs across eligible iterations up to the step concurrency cap.
+- Failures in one iteration do not block peer iterations in the same step.
+- Later steps skip failed iterations unless that step sets `runOnFailed: true`.
+
 All span and output events carry `runId` plus `label` so results can be grouped per run.
 For sharded runs, set the same `batch` on each process and unique `shard.index` values so the API can aggregate multiple `runId`s into one logical benchmark.
 
 ## Notes
 
-- Network upload only happens when `apiUrl` is configured.
+- Network upload uses `${baseUrl}/events` (`baseUrl` defaults to `https://platform.computesdk.com/api/v1`).
 - For ingest auth, clients send a token via `apiKey` (Bearer auth header) and the server validates the API key.
 - Network uploads are batched in the background with one in-flight request, and API failures do not fail the benchmark.
 - `ctx.log()` messages are attached to span events and redacted.

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -57,6 +57,7 @@ For scale/lifecycle benchmarks, model each lifecycle phase as a step and let
 
 ```ts
 import { createBench } from '@computesdk/bench';
+import { compute } from 'computesdk';
 
 const bench = createBench({ label: 'scale.e2b' });
 const sandboxes: Array<any | undefined> = [];

--- a/packages/bench/src/__tests__/runner.test.ts
+++ b/packages/bench/src/__tests__/runner.test.ts
@@ -85,6 +85,16 @@ describe('createBench', () => {
     expect(() => bench.add('op', async () => {})).toThrow(/already registered/);
   });
 
+  it('supports chaining add calls', async () => {
+    const bench = createBench({ label: 'chain-add-test' });
+    bench
+      .add('one', async () => {})
+      .add('two', async () => {});
+
+    const result = await bench.run({ iterations: 1, warmup: 0 });
+    expect(result.tasks.map((task) => task.taskName)).toEqual(['one', 'two']);
+  });
+
   it('includes sanitized logs on spans', async () => {
     const events: BenchEvent[] = [];
     const bench = createBench({

--- a/packages/bench/src/__tests__/runner.test.ts
+++ b/packages/bench/src/__tests__/runner.test.ts
@@ -208,6 +208,31 @@ describe('createBench', () => {
     expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('op'));
   });
 
+  it('prints concurrent context and workload counters in summary', async () => {
+    const bench = createBench({ label: 'concurrent-summary-test' });
+
+    bench.add('concurrent-op', async (ctx) => {
+      ctx.emitMetric('workload', {
+        sandboxes_attempted: 100,
+        sandboxes_success: 99,
+        sandboxes_errors: 1,
+      });
+    });
+
+    await bench.run({ iterations: 1, warmup: 0, mode: 'concurrent', concurrency: 100 });
+
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Mode: concurrent (limit=100)'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Concurrency'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('100'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Iterations per task: 1'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Note: 1 benchmark iteration can still represent many concurrent workload operations.'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('Workload counters:'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('concurrency_target=100'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('sandboxes_attempted=100'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('sandboxes_success=99'));
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('sandboxes_errors=1'));
+  });
+
   it('can continue on failures when throwOnError is false', async () => {
     const events: BenchEvent[] = [];
     const bench = createBench({
@@ -351,6 +376,73 @@ describe('createBench', () => {
 
       const result = await bench.run({ iterations: 20, warmup: 0, mode: 'concurrent' });
       expect(result.tasks[0].successes).toBe(20);
+    });
+
+    it('supports pipeline execution model where each iteration runs all tasks', async () => {
+      const bench = createBench({ label: 'pipeline-concurrent' });
+      const observed: string[] = [];
+
+      bench.add('create', async (ctx) => {
+        observed.push(`create:${ctx.iteration}`);
+      });
+      bench.add('exec', async (ctx) => {
+        observed.push(`exec:${ctx.iteration}`);
+      });
+
+      const result = await bench.run({
+        iterations: 3,
+        warmup: 0,
+        mode: 'concurrent',
+        concurrency: 3,
+      });
+
+      expect(result.tasks).toHaveLength(2);
+      expect(result.tasks[0].taskName).toBe('create');
+      expect(result.tasks[0].stats.count).toBe(3);
+      expect(result.tasks[1].taskName).toBe('exec');
+      expect(result.tasks[1].stats.count).toBe(3);
+      expect(observed).toEqual(expect.arrayContaining([
+        'create:0', 'exec:0',
+        'create:1', 'exec:1',
+        'create:2', 'exec:2',
+      ]));
+    });
+
+    it('continues same stage on failures and skips failed units in next step by default', async () => {
+      const bench = createBench({ label: 'pipeline-failure-skip' });
+      const createSeen: number[] = [];
+      const execSeen: number[] = [];
+
+      bench.add('create', async (ctx) => {
+        createSeen.push(ctx.iteration);
+        if (ctx.iteration === 1) {
+          throw new Error('create failed for unit 1');
+        }
+      });
+
+      bench.add('exec', async (ctx) => {
+        execSeen.push(ctx.iteration);
+      });
+
+      const result = await bench.run({
+        iterations: 3,
+        warmup: 0,
+        mode: 'concurrent',
+        concurrency: 3,
+        throwOnError: false,
+      });
+
+      expect(createSeen.sort((a, b) => a - b)).toEqual([0, 1, 2]);
+      expect(execSeen.sort((a, b) => a - b)).toEqual([0, 2]);
+
+      const createTask = result.tasks.find((task) => task.taskName === 'create');
+      const execTask = result.tasks.find((task) => task.taskName === 'exec');
+
+      expect(createTask?.successes).toBe(2);
+      expect(createTask?.failures).toBe(1);
+      expect(execTask?.successes).toBe(2);
+      expect(execTask?.failures).toBe(0);
+      expect(execTask?.stats.count).toBe(2);
     });
 
     it('runs all iterations to completion even when some fail with throwOnError', async () => {

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -10,6 +10,7 @@ export type {
   BenchShardConfig,
   BenchConfig,
   BenchRunOptions,
+  BenchAddOptions,
   BenchContext,
   BenchSuiteResult,
   BenchTaskResult,

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -12,6 +12,7 @@ import {
 } from './events';
 import type { BenchOutputEvent, BenchRunEvent, BenchSpanEvent, BenchTransport, BenchMetricEvent, BenchProgressEvent } from './events';
 import type {
+  BenchAddOptions,
   BenchConfig,
   BenchContext,
   BenchRunOptions,
@@ -36,6 +37,7 @@ function isoNow(): string {
 }
 
 type TaskFn = (ctx: BenchContext) => Promise<unknown> | unknown;
+type RegisteredTask = { name: string; fn: TaskFn; options?: BenchAddOptions };
 
 const LOG_MAX_ENTRIES = 50;
 const OUTPUT_FLUSH_INTERVAL = 30000;
@@ -59,6 +61,10 @@ function formatMs(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
 function printSummary(result: BenchSuiteResult): void {
   const rows = result.tasks.map((task) => ({
     task: task.taskName,
@@ -67,25 +73,42 @@ function printSummary(result: BenchSuiteResult): void {
     p95: formatMs(task.stats.p95Ms),
     min: formatMs(task.stats.minMs),
     max: formatMs(task.stats.maxMs),
+    concurrency: result.mode === 'concurrent'
+      ? String(result.concurrency ?? result.iterations ?? task.stats.count)
+      : '-',
     runs: String(task.stats.count),
     errors: String(task.failures),
   }));
 
-  const headers = ['Task', 'Avg', 'P50', 'P95', 'Min', 'Max', 'Runs', 'Errors'];
+  const headers = ['Task', 'Avg', 'P50', 'P95', 'Min', 'Max', 'Concurrency', 'Runs', 'Errors'];
   const widths = headers.map((header, index) => Math.max(
     header.length,
     ...rows.map((row) => Object.values(row)[index].length),
   ));
   const line = (values: string[]) => values.map((value, index) => value.padEnd(widths[index])).join('  ');
+  const workloadCounters = result.workloadCounters ?? {};
+  const workloadCounterKeys = Object.keys(workloadCounters);
+
   const output = [
     '',
     result.label,
+    result.mode === 'concurrent'
+      ? `Mode: concurrent${typeof result.concurrency === 'number' ? ` (limit=${result.concurrency})` : ''}`
+      : undefined,
+    typeof result.iterations === 'number' ? `Iterations per task: ${result.iterations}` : undefined,
+    typeof result.warmup === 'number' ? `Warmup per task: ${result.warmup}` : undefined,
+    result.mode === 'concurrent' && result.iterations === 1 && workloadCounterKeys.length > 0
+      ? 'Note: 1 benchmark iteration can still represent many concurrent workload operations.'
+      : undefined,
+    workloadCounterKeys.length > 0
+      ? `Workload counters: ${workloadCounterKeys.sort().map((key) => `${key}=${formatNumber(workloadCounters[key])}`).join(', ')}`
+      : undefined,
     '',
     line(headers),
     line(widths.map((width) => '-'.repeat(width))),
     ...rows.map((row) => line(Object.values(row))),
     '',
-  ].join('\n');
+  ].filter((entry): entry is string => typeof entry === 'string').join('\n');
 
   if (typeof process !== 'undefined' && process.stdout?.write) {
     process.stdout.write(output);
@@ -230,21 +253,26 @@ export function createBench(config: BenchConfig) {
   });
   const query = createBenchQueryClient({ baseUrl, apiKey });
 
-  const tasks: Array<{ name: string; fn: TaskFn }> = [];
+  const tasks: RegisteredTask[] = [];
   let currentRunId: string | undefined;
   let currentProvider: string | undefined;
+  let collectWorkloadCounters: ((data?: Record<string, unknown>) => void) | undefined;
 
-  function add(taskName: string, fn: TaskFn): void {
+  let api: any;
+
+  function add(taskName: string, fn: TaskFn, options: BenchAddOptions = {}) {
     if (taskName.trim() === '') {
       throw new Error('Bench task name must be non-empty.');
     }
     if (tasks.some((task) => task.name === taskName)) {
       throw new Error(`Bench task "${taskName}" is already registered.`);
     }
-    tasks.push({ name: taskName, fn });
+    tasks.push({ name: taskName, fn, options });
+    return api;
   }
 
   function emitMetric(name: string, data: Record<string, unknown>, runId?: string): void {
+    collectWorkloadCounters?.(data);
     const event: BenchMetricEvent = {
       event: 'benchmark.metric',
       eventId: createPrefixedId('event'),
@@ -267,6 +295,7 @@ export function createBench(config: BenchConfig) {
   }
 
   function emitProgress(params: { done: number; inFlight: number; errors: number; total: number; extra?: Record<string, unknown> }, runId?: string): void {
+    collectWorkloadCounters?.(params.extra);
     const event: BenchProgressEvent = {
       event: 'benchmark.progress',
       eventId: createPrefixedId('event'),
@@ -333,197 +362,126 @@ export function createBench(config: BenchConfig) {
     outputCapture?.start();
 
     const taskResults: BenchTaskResult[] = [];
+    const workloadCounters = new Map<string, number>();
+
+    const addWorkloadCounters = (data?: Record<string, unknown>) => {
+      if (!data) return;
+      for (const [key, value] of Object.entries(data)) {
+        if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+        workloadCounters.set(key, (workloadCounters.get(key) ?? 0) + value);
+      }
+    };
+    collectWorkloadCounters = addWorkloadCounters;
+    if (mode === 'concurrent' && concurrency > 1) {
+      addWorkloadCounters({ concurrency_target: concurrency });
+    }
 
     try {
-      for (const task of tasks) {
-      const measuredDurations: number[] = [];
-      let successes = 0;
-      let failures = 0;
-
-      // Warmup runs (errors silently ignored)
-      for (let i = 0; i < warmup; i++) {
-        const logs: string[] = [];
-        const metadata: Record<string, unknown>[] = [];
-        const ctx: BenchContext = {
-          iteration: i,
-          phase: 'warmup',
-          taskName: task.name,
-          log: (...args) => logs.push(args.map(String).join(' ')),
-          setMetadata: (data) => metadata.push(data),
-          emitMetric: (name, data) => emitMetric(name, data, runId),
+      const emitMeasuredSpan = (params: {
+        taskName: string;
+        iteration: number;
+        startedAt: string;
+        durationMs: number;
+        status: 'ok' | 'error';
+        logs: string[];
+        metadata: Record<string, unknown>[];
+        error?: unknown;
+      }) => {
+        const mergedMetadata = Object.assign({}, ...params.metadata);
+        const event: BenchSpanEvent = {
+          event: 'benchmark.span',
+          eventId: createPrefixedId('event'),
+          runId,
+          label: config.label,
+          installId,
+          traceId,
+          spanId: createPrefixedId('span'),
+          operation: params.taskName,
+          startedAt: params.startedAt,
+          endedAt: isoNow(),
+          durationMs: params.durationMs,
+          status: params.status,
+          provider: options.provider ?? config.provider,
+          attemptCount: 1,
+          attempts: [{
+            provider: options.provider ?? config.provider ?? 'unknown',
+            candidateIndex: 0,
+            startedAt: params.startedAt,
+            endedAt: isoNow(),
+            durationMs: params.durationMs,
+            status: params.status,
+            errorCode: params.error ? toErrorCode(params.error) : undefined,
+          }],
+          errorCode: params.error ? toErrorCode(params.error) : undefined,
+          benchVersion: BENCH_VERSION,
+          runtime,
+          os,
+          arch,
+          batch: config.batch,
+          shardIndex: config.shard?.index,
+          shardCount: config.shard?.count,
+          taskName: params.taskName,
+          logs: finalizeLogs(params.logs),
+          iteration: params.iteration,
+          phase: 'measured',
+          metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
         };
-        try {
-          await task.fn(ctx);
-        } catch {
-          // ignore warmup errors
-        }
+        emitBenchEvent(event, transport);
+      };
+
+      const taskStats = new Map<string, { durations: number[]; successes: number; failures: number }>();
+      for (const task of tasks) {
+        taskStats.set(task.name, { durations: [], successes: 0, failures: 0 });
       }
 
-      if (mode === 'concurrent') {
-        // Concurrent mode: fire all iterations concurrently up to concurrency limit.
-        // Uses Promise.allSettled so every task runs to completion regardless of
-        // individual failures. If throwOnError is true, an aggregate error is thrown
-        // after all tasks settle.
-        let done = 0;
-        let inFlight = 0;
-        let errorCount = 0;
-        const concurrentErrors: unknown[] = [];
+      const stageErrors: unknown[] = [];
+      const unitFailed = new Array(iterations).fill(false);
 
-        const runOne = async (i: number) => {
-          inFlight++;
-          const logs: string[] = [];
-          const metadata: Record<string, unknown>[] = [];
-          const ctx: BenchContext = {
-            iteration: i,
-            phase: 'measured',
-            taskName: task.name,
-            log: (...args) => logs.push(args.map(String).join(' ')),
-            setMetadata: (data) => metadata.push(data),
-            emitMetric: (name, data) => emitMetric(name, data, runId),
-          };
-          const startedAtMs = nowMs();
-          const startedAt = isoNow();
-
-          try {
-            await task.fn(ctx);
-            const durationMs = nowMs() - startedAtMs;
-            measuredDurations.push(durationMs);
-            successes += 1;
-            done++;
-
-            const mergedMetadata = Object.assign({}, ...metadata);
-            const event: BenchSpanEvent = {
-              event: 'benchmark.span',
-              eventId: createPrefixedId('event'),
-              runId,
-              label: config.label,
-              installId,
-              traceId,
-              spanId: createPrefixedId('span'),
-              operation: task.name,
-              startedAt,
-              endedAt: isoNow(),
-              durationMs,
-              status: 'ok',
-              provider: options.provider ?? config.provider,
-              attemptCount: 1,
-              attempts: [{
-                provider: options.provider ?? config.provider ?? 'unknown',
-                candidateIndex: 0,
-                startedAt,
-                endedAt: isoNow(),
-                durationMs,
-                status: 'ok',
-              }],
-              benchVersion: BENCH_VERSION,
-              runtime,
-              os,
-              arch,
-              batch: config.batch,
-              shardIndex: config.shard?.index,
-              shardCount: config.shard?.count,
-              taskName: task.name,
-              logs: finalizeLogs(logs),
-              iteration: i,
-              phase: 'measured',
-              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
-            };
-            emitBenchEvent(event, transport);
-          } catch (error) {
-            failures += 1;
-            errorCount++;
-            done++;
-            concurrentErrors.push(error);
-            const durationMs = nowMs() - startedAtMs;
-
-            const mergedMetadata = Object.assign({}, ...metadata);
-            const event: BenchSpanEvent = {
-              event: 'benchmark.span',
-              eventId: createPrefixedId('event'),
-              runId,
-              label: config.label,
-              installId,
-              traceId,
-              spanId: createPrefixedId('span'),
-              operation: task.name,
-              startedAt,
-              endedAt: isoNow(),
-              durationMs,
-              status: 'error',
-              provider: options.provider ?? config.provider,
-              attemptCount: 1,
-              attempts: [{
-                provider: options.provider ?? config.provider ?? 'unknown',
-                candidateIndex: 0,
-                startedAt,
-                endedAt: isoNow(),
-                durationMs,
-                status: 'error',
-                errorCode: toErrorCode(error),
-              }],
-              errorCode: toErrorCode(error),
-              benchVersion: BENCH_VERSION,
-              runtime,
-              os,
-              arch,
-              batch: config.batch,
-              shardIndex: config.shard?.index,
-              shardCount: config.shard?.count,
-              taskName: task.name,
-              logs: finalizeLogs(logs),
-              iteration: i,
-              phase: 'measured',
-              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
-            };
-            emitBenchEvent(event, transport);
-          }
-
-          inFlight--;
-        };
-
-        // Simple concurrency limiter using a semaphore pattern with a queue
-        const promises: Promise<void>[] = [];
-        let activeCount = 0;
-        const waitQueue: (() => void)[] = [];
-
-        const acquire = () => new Promise<void>((resolve) => {
-          if (activeCount < concurrency) {
-            activeCount++;
-            resolve();
-          } else {
-            waitQueue.push(resolve);
+      const runWithLimit = async (indices: number[], limit: number, worker: (i: number) => Promise<void>) => {
+        if (indices.length === 0) return;
+        if (limit <= 0) throw new Error('Concurrency must be > 0.');
+        let cursor = 0;
+        const runners = Array.from({ length: Math.min(limit, indices.length) }, async () => {
+          while (cursor < indices.length) {
+            const idx = indices[cursor++];
+            await worker(idx);
           }
         });
+        await Promise.all(runners);
+      };
 
-        const release = () => {
-          activeCount--;
-          if (waitQueue.length > 0) {
-            const next = waitQueue.shift()!;
-            activeCount++;
-            next();
+      for (let i = 0; i < warmup; i++) {
+        for (const task of tasks) {
+          const logs: string[] = [];
+          const metadata: Record<string, unknown>[] = [];
+          const ctx: BenchContext = {
+            iteration: i,
+            phase: 'warmup',
+            taskName: task.name,
+            log: (...args) => logs.push(args.map(String).join(' ')),
+            setMetadata: (data) => metadata.push(data),
+            emitMetric: (name, data) => emitMetric(name, data, runId),
+          };
+          try {
+            await task.fn(ctx);
+          } catch {
+            // Ignore warmup failures.
           }
-        };
-
-        for (let i = 0; i < iterations; i++) {
-          const p = (async () => {
-            await acquire();
-            try {
-              await runOne(i);
-            } finally {
-              release();
-            }
-          })();
-          promises.push(p);
         }
+      }
 
-        await Promise.allSettled(promises);
+      for (const task of tasks) {
+        const stats = taskStats.get(task.name)!;
+        const eligible = unitFailed
+          .map((failed, index) => ({ failed, index }))
+          .filter((item) => task.options?.runOnFailed || !item.failed)
+          .map((item) => item.index);
 
-        if (throwOnError && concurrentErrors.length > 0) {
-          throw concurrentErrors[0];
-        }
-      } else {
-        // Sequential mode (default)
-        for (let i = 0; i < iterations; i++) {
+        const stageConcurrency = mode === 'concurrent'
+          ? Math.min(concurrency, task.options?.concurrency ?? concurrency)
+          : 1;
+
+        await runWithLimit(eligible, stageConcurrency, async (i) => {
           const logs: string[] = [];
           const metadata: Record<string, unknown>[] = [];
           const ctx: BenchContext = {
@@ -536,115 +494,57 @@ export function createBench(config: BenchConfig) {
           };
           const startedAtMs = nowMs();
           const startedAt = isoNow();
-          let spanError: unknown;
 
           try {
             await task.fn(ctx);
             const durationMs = nowMs() - startedAtMs;
-            measuredDurations.push(durationMs);
-            successes += 1;
-
-            const mergedMetadata = Object.assign({}, ...metadata);
-            const event: BenchSpanEvent = {
-              event: 'benchmark.span',
-              eventId: createPrefixedId('event'),
-              runId,
-              label: config.label,
-              installId,
-              traceId,
-              spanId: createPrefixedId('span'),
-              operation: task.name,
+            stats.durations.push(durationMs);
+            stats.successes += 1;
+            emitMeasuredSpan({
+              taskName: task.name,
+              iteration: i,
               startedAt,
-              endedAt: isoNow(),
               durationMs,
               status: 'ok',
-              provider: options.provider ?? config.provider,
-              attemptCount: 1,
-              attempts: [{
-                provider: options.provider ?? config.provider ?? 'unknown',
-                candidateIndex: 0,
-                startedAt,
-                endedAt: isoNow(),
-                durationMs,
-                status: 'ok',
-              }],
-              benchVersion: BENCH_VERSION,
-              runtime,
-              os,
-              arch,
-              batch: config.batch,
-              shardIndex: config.shard?.index,
-              shardCount: config.shard?.count,
-              taskName: task.name,
-              logs: finalizeLogs(logs),
-              iteration: i,
-              phase: 'measured',
-              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
-            };
-            emitBenchEvent(event, transport);
+              logs,
+              metadata,
+            });
           } catch (error) {
-            spanError = error;
-            failures += 1;
             const durationMs = nowMs() - startedAtMs;
-
-            const mergedMetadata = Object.assign({}, ...metadata);
-            const event: BenchSpanEvent = {
-              event: 'benchmark.span',
-              eventId: createPrefixedId('event'),
-              runId,
-              label: config.label,
-              installId,
-              traceId,
-              spanId: createPrefixedId('span'),
-              operation: task.name,
+            stats.failures += 1;
+            unitFailed[i] = true;
+            stageErrors.push(error);
+            emitMeasuredSpan({
+              taskName: task.name,
+              iteration: i,
               startedAt,
-              endedAt: isoNow(),
               durationMs,
               status: 'error',
-              provider: options.provider ?? config.provider,
-              attemptCount: 1,
-              attempts: [{
-                provider: options.provider ?? config.provider ?? 'unknown',
-                candidateIndex: 0,
-                startedAt,
-                endedAt: isoNow(),
-                durationMs,
-                status: 'error',
-                errorCode: toErrorCode(error),
-              }],
-              errorCode: toErrorCode(error),
-              benchVersion: BENCH_VERSION,
-              runtime,
-              os,
-              arch,
-              batch: config.batch,
-              shardIndex: config.shard?.index,
-              shardCount: config.shard?.count,
-              taskName: task.name,
-              logs: finalizeLogs(logs),
-              iteration: i,
-              phase: 'measured',
-              metadata: Object.keys(mergedMetadata).length > 0 ? mergedMetadata : undefined,
-            };
-            emitBenchEvent(event, transport);
+              logs,
+              metadata,
+              error,
+            });
           }
-
-          if (spanError && throwOnError) {
-            throw spanError;
-          }
-        }
+        });
       }
 
-      taskResults.push({
-        taskName: task.name,
-        iterations,
-        warmup,
-        successes,
-        failures,
-        stats: buildStats(measuredDurations),
-      });
+      if (throwOnError && stageErrors.length > 0) {
+        throw stageErrors[0];
+      }
+
+      for (const task of tasks) {
+        const stats = taskStats.get(task.name)!;
+        taskResults.push({
+          taskName: task.name,
+          iterations,
+          warmup,
+          successes: stats.successes,
+          failures: stats.failures,
+          stats: buildStats(stats.durations),
+        });
       }
     } finally {
+      collectWorkloadCounters = undefined;
       currentRunId = undefined;
       currentProvider = undefined;
       await outputCapture?.stop();
@@ -655,6 +555,11 @@ export function createBench(config: BenchConfig) {
       label: config.label,
       runId,
       tasks: taskResults,
+      mode,
+      concurrency: mode === 'concurrent' ? concurrency : undefined,
+      iterations,
+      warmup,
+      workloadCounters: Object.fromEntries(workloadCounters),
     };
     printSummary(result);
     return result;

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -38,6 +38,12 @@ function isoNow(): string {
 
 type TaskFn = (ctx: BenchContext) => Promise<unknown> | unknown;
 type RegisteredTask = { name: string; fn: TaskFn; options?: BenchAddOptions };
+type BenchApi = {
+  add: (taskName: string, fn: TaskFn, options?: BenchAddOptions) => BenchApi;
+  run: (options?: BenchRunOptions) => Promise<BenchSuiteResult>;
+  emit: (name: string, data: Record<string, unknown>, runId?: string) => void;
+  progress: (params: { done: number; inFlight: number; errors: number; total: number; extra?: Record<string, unknown> }, runId?: string) => void;
+} & ReturnType<typeof createBenchQueryClient>;
 
 const LOG_MAX_ENTRIES = 50;
 const OUTPUT_FLUSH_INTERVAL = 30000;
@@ -258,7 +264,7 @@ export function createBench(config: BenchConfig) {
   let currentProvider: string | undefined;
   let collectWorkloadCounters: ((data?: Record<string, unknown>) => void) | undefined;
 
-  let api: any;
+  let api: BenchApi;
 
   function add(taskName: string, fn: TaskFn, options: BenchAddOptions = {}) {
     if (taskName.trim() === '') {
@@ -326,6 +332,9 @@ export function createBench(config: BenchConfig) {
     const throwOnError = options.throwOnError ?? true;
     const mode = options.mode ?? 'sequential';
     const concurrency = options.concurrency ?? iterations;
+    if (!Number.isFinite(concurrency) || concurrency <= 0) {
+      throw new Error('Bench concurrency must be a positive number.');
+    }
     const runId = createPrefixedId('run');
     currentRunId = runId;
     currentProvider = options.provider ?? config.provider;
@@ -388,6 +397,7 @@ export function createBench(config: BenchConfig) {
         error?: unknown;
       }) => {
         const mergedMetadata = Object.assign({}, ...params.metadata);
+        const endedAt = isoNow();
         const event: BenchSpanEvent = {
           event: 'benchmark.span',
           eventId: createPrefixedId('event'),
@@ -398,7 +408,7 @@ export function createBench(config: BenchConfig) {
           spanId: createPrefixedId('span'),
           operation: params.taskName,
           startedAt: params.startedAt,
-          endedAt: isoNow(),
+          endedAt,
           durationMs: params.durationMs,
           status: params.status,
           provider: options.provider ?? config.provider,
@@ -407,7 +417,7 @@ export function createBench(config: BenchConfig) {
             provider: options.provider ?? config.provider ?? 'unknown',
             candidateIndex: 0,
             startedAt: params.startedAt,
-            endedAt: isoNow(),
+            endedAt,
             durationMs: params.durationMs,
             status: params.status,
             errorCode: params.error ? toErrorCode(params.error) : undefined,
@@ -480,6 +490,9 @@ export function createBench(config: BenchConfig) {
         const stageConcurrency = mode === 'concurrent'
           ? Math.min(concurrency, task.options?.concurrency ?? concurrency)
           : 1;
+        if (!Number.isFinite(stageConcurrency) || stageConcurrency <= 0) {
+          throw new Error(`Bench step "${task.name}" has invalid concurrency: ${String(task.options?.concurrency)}.`);
+        }
 
         await runWithLimit(eligible, stageConcurrency, async (i) => {
           const logs: string[] = [];
@@ -565,5 +578,6 @@ export function createBench(config: BenchConfig) {
     return result;
   }
 
-  return { add, run, emit: emitMetric, progress: emitProgress, ...query };
+  api = { add, run, emit: emitMetric, progress: emitProgress, ...query };
+  return api;
 }

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -49,6 +49,13 @@ export interface BenchRunOptions {
   concurrency?: number;
 }
 
+export interface BenchAddOptions {
+  /** Per-step concurrency cap (defaults to run concurrency/iterations) */
+  concurrency?: number;
+  /** Run this step for units that failed earlier steps (useful for cleanup) */
+  runOnFailed?: boolean;
+}
+
 export interface BenchContext {
   /** Current iteration index within the current phase (0-based) */
   iteration: number;
@@ -92,4 +99,9 @@ export interface BenchSuiteResult {
   label: string;
   runId: string;
   tasks: BenchTaskResult[];
+  mode?: 'sequential' | 'concurrent';
+  concurrency?: number;
+  iterations?: number;
+  warmup?: number;
+  workloadCounters?: Record<string, number>;
 }


### PR DESCRIPTION
## What changed
- make bench.add chainable and add step options: concurrency and runOnFailed
- move bench runner to pipeline-first stage execution semantics
- remove legacy non-pipeline runner branch
- keep stage execution resilient so one iteration failure does not block peer iterations in the same step
- skip failed iterations in later steps unless runOnFailed is enabled
- update bench README with pipeline and scale lifecycle examples
- add regression coverage for stage failure plus next-step skip behavior
- add a patch changeset for @computesdk/bench

## Validation
- pnpm --filter @computesdk/bench test -- runner.test.ts
- pnpm --filter @computesdk/bench typecheck