### PR TITLE
feat(bench): add local raw telemetry storage

### DIFF
--- a/.changeset/polite-pens-glow.md
+++ b/.changeset/polite-pens-glow.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/bench": patch
+---
+
+Add optional local raw-event storage for benchmark telemetry. When enabled, benchmark events are written to chunked JSONL files with a per-run manifest under a configurable directory (defaulting to `~/.benchmark`).

--- a/packages/bench/src/__tests__/runner.test.ts
+++ b/packages/bench/src/__tests__/runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -138,6 +138,45 @@ describe('createBench', () => {
     expect(spans).toHaveLength(1);
     expect(spans[0].logs).toHaveLength(75);
     expect(spans[0].logs[74]).toBe('entry 74');
+  });
+
+  it('writes raw events and manifest to local storage', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'bench-raw-store-'));
+    try {
+      const bench = createBench({
+        label: 'raw-store-test',
+        batch: 'group_test',
+        shard: { index: 1, count: 4 },
+        rawStorage: { dir },
+      });
+
+      bench.add('raw-task', async (ctx) => {
+        ctx.log('hello');
+      });
+
+      const result = await bench.run({ iterations: 2, warmup: 0, provider: 'just-bash' });
+      const runPath = join(dir, 'bench', 'v1', 'group_id=group_test', `run_id=${result.runId}`, 'shard=1');
+      const files = await readdir(runPath);
+
+      expect(files).toContain('manifest.json');
+      expect(files.some((name) => name.startsWith('part-') && name.endsWith('.jsonl'))).toBe(true);
+
+      const manifest = JSON.parse(await readFile(join(runPath, 'manifest.json'), 'utf8')) as any;
+      expect(manifest.schemaVersion).toBe('bench.manifest.v1');
+      expect(manifest.runId).toBe(result.runId);
+      expect(manifest.groupId).toBe('group_test');
+      expect(manifest.shardIndex).toBe(1);
+      expect(manifest.parts.length).toBeGreaterThan(0);
+
+      const partFile = manifest.parts[0].path as string;
+      const firstLine = (await readFile(partFile, 'utf8')).split('\n').find(Boolean);
+      const rawRecord = JSON.parse(firstLine ?? '{}');
+      expect(rawRecord.schemaVersion).toBe('bench.raw.v1');
+      expect(rawRecord.runId).toBe(result.runId);
+      expect(rawRecord.groupId).toBe('group_test');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('defaults ingest endpoint to platform and supports baseUrl override', async () => {

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -7,6 +7,7 @@ export type {
   BenchMetricEvent,
   BenchProgressEvent,
   BenchCaptureOutputConfig,
+  BenchRawStorageConfig,
   BenchShardConfig,
   BenchConfig,
   BenchRunOptions,

--- a/packages/bench/src/raw-store.ts
+++ b/packages/bench/src/raw-store.ts
@@ -1,0 +1,182 @@
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { BenchEvent } from './events';
+import type { BenchRawStorageConfig } from './types';
+
+const DEFAULT_MAX_PART_BYTES = 16 * 1024 * 1024;
+
+type RawPart = {
+  path: string;
+  records: number;
+  bytes: number;
+  firstTimestamp: string;
+  lastTimestamp: string;
+};
+
+function eventTimestamp(event: BenchEvent): string {
+  if ('timestamp' in event && typeof event.timestamp === 'string') return event.timestamp;
+  if ('startedAt' in event && typeof event.startedAt === 'string') return event.startedAt;
+  return new Date().toISOString();
+}
+
+function defaultDir(): string {
+  return join(homedir(), '.benchmark');
+}
+
+export function shouldEnableRawStorage(config?: BenchRawStorageConfig): boolean {
+  if (!config) return false;
+  return config.enabled !== false;
+}
+
+export function createRawEventStore(params: {
+  config?: BenchRawStorageConfig;
+  runId: string;
+  batch?: string;
+  shardIndex?: number;
+  shardCount?: number;
+  provider?: string;
+  label: string;
+}) {
+  const baseDir = params.config?.dir ?? defaultDir();
+  const maxPartBytes = Math.max(1024, params.config?.maxPartBytes ?? DEFAULT_MAX_PART_BYTES);
+  const groupId = params.batch ?? 'none';
+  const shard = typeof params.shardIndex === 'number' ? String(params.shardIndex) : 'none';
+  const runDir = join(baseDir, 'bench', 'v1', `group_id=${groupId}`, `run_id=${params.runId}`, `shard=${shard}`);
+
+  let initialized = false;
+  let closing = false;
+  let partIndex = 0;
+  let currentPartBytes = 0;
+  let currentPartRecords = 0;
+  let currentPartFirstTimestamp = '';
+  let currentPartLastTimestamp = '';
+  let currentPartPath = '';
+  const partStats: RawPart[] = [];
+
+  const queue: string[] = [];
+  let draining: Promise<void> | undefined;
+
+  async function ensureReady(): Promise<void> {
+    if (initialized) return;
+    await fs.mkdir(runDir, { recursive: true });
+    initialized = true;
+  }
+
+  function nextPartPath(): string {
+    return join(runDir, `part-${String(partIndex).padStart(6, '0')}.jsonl`);
+  }
+
+  async function rotateIfNeeded(nextLineBytes: number): Promise<void> {
+    if (currentPartPath === '') {
+      currentPartPath = nextPartPath();
+      partIndex += 1;
+      currentPartBytes = 0;
+      currentPartRecords = 0;
+      currentPartFirstTimestamp = '';
+      currentPartLastTimestamp = '';
+      return;
+    }
+    if (currentPartBytes + nextLineBytes <= maxPartBytes) return;
+    partStats.push({
+      path: currentPartPath,
+      records: currentPartRecords,
+      bytes: currentPartBytes,
+      firstTimestamp: currentPartFirstTimestamp,
+      lastTimestamp: currentPartLastTimestamp,
+    });
+    currentPartPath = nextPartPath();
+    partIndex += 1;
+    currentPartBytes = 0;
+    currentPartRecords = 0;
+    currentPartFirstTimestamp = '';
+    currentPartLastTimestamp = '';
+  }
+
+  async function drain(): Promise<void> {
+    await ensureReady();
+    while (queue.length > 0) {
+      const line = queue.shift()!;
+      const bytes = Buffer.byteLength(line, 'utf8');
+      await rotateIfNeeded(bytes);
+      await fs.appendFile(currentPartPath, line, 'utf8');
+      currentPartBytes += bytes;
+      currentPartRecords += 1;
+    }
+  }
+
+  function scheduleDrain(): void {
+    if (draining) return;
+    draining = (async () => {
+      try {
+        await drain();
+      } finally {
+        draining = undefined;
+      }
+    })();
+  }
+
+  function write(event: BenchEvent): void {
+    if (closing) return;
+    const ts = eventTimestamp(event);
+    if (currentPartFirstTimestamp === '') currentPartFirstTimestamp = ts;
+    currentPartLastTimestamp = ts;
+    const record = {
+      schemaVersion: 'bench.raw.v1',
+      eventType: event.event,
+      ts,
+      runId: 'runId' in event ? event.runId : params.runId,
+      groupId: 'batch' in event ? (event.batch ?? params.batch ?? null) : (params.batch ?? null),
+      shardIndex: 'shardIndex' in event ? (event.shardIndex ?? params.shardIndex ?? null) : (params.shardIndex ?? null),
+      shardCount: 'shardCount' in event ? (event.shardCount ?? params.shardCount ?? null) : (params.shardCount ?? null),
+      provider: 'provider' in event ? (event.provider ?? params.provider ?? null) : (params.provider ?? null),
+      eventId: 'eventId' in event ? event.eventId : null,
+      payload: event,
+    };
+    queue.push(`${JSON.stringify(record)}\n`);
+    scheduleDrain();
+  }
+
+  async function close(): Promise<void> {
+    closing = true;
+    if (draining) await draining;
+    if (queue.length > 0) await drain();
+    if (!initialized) return;
+
+    if (currentPartPath !== '' && currentPartRecords > 0) {
+      partStats.push({
+        path: currentPartPath,
+        records: currentPartRecords,
+        bytes: currentPartBytes,
+        firstTimestamp: currentPartFirstTimestamp,
+        lastTimestamp: currentPartLastTimestamp,
+      });
+    }
+
+    const manifest = {
+      schemaVersion: 'bench.manifest.v1',
+      label: params.label,
+      runId: params.runId,
+      groupId: params.batch ?? null,
+      shardIndex: params.shardIndex ?? null,
+      shardCount: params.shardCount ?? null,
+      provider: params.provider ?? null,
+      createdAt: new Date().toISOString(),
+      parts: partStats.map((part) => ({
+        path: part.path,
+        records: part.records,
+        bytes: part.bytes,
+        firstTimestamp: part.firstTimestamp,
+        lastTimestamp: part.lastTimestamp,
+      })),
+      totals: {
+        records: partStats.reduce((sum, part) => sum + part.records, 0),
+        bytes: partStats.reduce((sum, part) => sum + part.bytes, 0),
+      },
+    };
+
+    await fs.writeFile(join(runDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+  }
+
+  return { write, close, runDir };
+}

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -20,6 +20,7 @@ import type {
   BenchTaskResult,
 } from './types';
 import { createBenchQueryClient } from './query';
+import { createRawEventStore, shouldEnableRawStorage } from './raw-store';
 
 declare const __BENCH_VERSION__: string;
 const BENCH_VERSION =
@@ -251,8 +252,13 @@ export function createBench(config: BenchConfig) {
   const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
   const apiUrl = `${baseUrl}/events`;
   const apiKey = config.apiKey ?? process.env.COMPUTESDK_API_KEY;
+  const userOnEvent = config.onEvent;
+  let currentRawStore: ReturnType<typeof createRawEventStore> | undefined;
   const transport: BenchTransport = createBenchTransport({
-    onEvent: config.onEvent,
+    onEvent: (event) => {
+      userOnEvent?.(event);
+      currentRawStore?.write(event);
+    },
     apiUrl,
     apiKey,
   });
@@ -338,6 +344,17 @@ export function createBench(config: BenchConfig) {
     currentRunId = runId;
     currentProvider = options.provider ?? config.provider;
     const traceId = createPrefixedId('trace');
+    if (shouldEnableRawStorage(config.rawStorage)) {
+      currentRawStore = createRawEventStore({
+        config: config.rawStorage,
+        runId,
+        batch: config.batch,
+        shardIndex: config.shard?.index,
+        shardCount: config.shard?.count,
+        provider: options.provider ?? config.provider,
+        label: config.label,
+      });
+    }
     const outputCapture = createOutputCapture({
       config,
       installId,
@@ -561,6 +578,8 @@ export function createBench(config: BenchConfig) {
       currentProvider = undefined;
       await outputCapture?.stop();
       await flushBenchTransportBestEffort(transport);
+      await currentRawStore?.close();
+      currentRawStore = undefined;
     }
 
     const result = {

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -8,6 +8,15 @@ export interface BenchCaptureOutputConfig {
   flushInterval?: number;
 }
 
+export interface BenchRawStorageConfig {
+  /** Enable local raw-event spooling to disk */
+  enabled?: boolean;
+  /** Base directory for raw output (default: ~/.benchmark) */
+  dir?: string;
+  /** Rotate part files after this many bytes (default: 16MB) */
+  maxPartBytes?: number;
+}
+
 export interface BenchShardConfig {
   /** Zero-based shard index for this process */
   index: number;
@@ -32,6 +41,8 @@ export interface BenchConfig {
   onEvent?: (event: BenchEvent) => void;
   /** Capture process/coordinator output from a log file */
   captureOutput?: BenchCaptureOutputConfig;
+  /** Write full-fidelity benchmark events to local chunked files */
+  rawStorage?: BenchRawStorageConfig;
 }
 
 export interface BenchRunOptions {


### PR DESCRIPTION
## What
- add optional `rawStorage` config to `@computesdk/bench`
- write full-fidelity bench events to local chunked JSONL files under a structured run directory
- emit a per-run `manifest.json` with part metadata and totals
- keep existing network ingest behavior unchanged
- add runner tests covering raw storage output + manifest shape
- add a patch changeset for `@computesdk/bench`

## Validation
- pnpm --filter @computesdk/bench test -- src/__tests__/runner.test.ts