### PR TITLE
Update Tensorlake SDK dependency

### DIFF
--- a/.changeset/fuzzy-tensorlake-sdk.md
+++ b/.changeset/fuzzy-tensorlake-sdk.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/tensorlake": patch
+---
+
+Update the Tensorlake SDK dependency to 0.5.31.

--- a/packages/tensorlake/CHANGELOG.md
+++ b/packages/tensorlake/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @computesdk/tensorlake
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies [2835c0d]
+  - tensorlake@0.5.31
+
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/tensorlake/CHANGELOG.md
+++ b/packages/tensorlake/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @computesdk/tensorlake
 
-## 0.1.7
-
-### Patch Changes
-
-- Updated dependencies [2835c0d]
-  - tensorlake@0.5.31
-
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/tensorlake/package.json
+++ b/packages/tensorlake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/tensorlake",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Tensorlake provider for ComputeSDK - stateful MicroVM sandboxes for agentic applications and LLM-generated code execution",
   "author": "Garrison",
   "license": "MIT",

--- a/packages/tensorlake/package.json
+++ b/packages/tensorlake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/tensorlake",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Tensorlake provider for ComputeSDK - stateful MicroVM sandboxes for agentic applications and LLM-generated code execution",
   "author": "Garrison",
   "license": "MIT",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*",
-    "tensorlake": "0.5.7"
+    "tensorlake": "0.5.31"
   },
   "devDependencies": {
     "@computesdk/test-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1506,8 +1506,8 @@ importers:
         specifier: workspace:*
         version: link:../computesdk
       tensorlake:
-        specifier: 0.5.7
-        version: 0.5.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 0.5.31
+        version: 0.5.31(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -7602,8 +7602,8 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  tensorlake@0.5.7:
-    resolution: {integrity: sha512-wtJ16m2wdN3IsZXRDOP5EgmWIIgsvria6CFVAOOcsbfiupnSxkHP9hjW+0m+T5dPPi1kRblAnMxIPz8A6HNu0w==}
+  tensorlake@0.5.31:
+    resolution: {integrity: sha512-uZrbQmT77VDig6mLnkfxIoETKug4AN5a1VKIULN5b/PeaVhU0NkNJvjgh88JkJPGLjMFabS7u+bC7xNyXfjnEw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -14950,7 +14950,7 @@ snapshots:
 
   pyodide@0.28.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15649,7 +15649,7 @@ snapshots:
       - bare-abort-controller
     optional: true
 
-  tensorlake@0.5.7(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  tensorlake@0.5.31(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       undici: 8.2.0
       ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)


### PR DESCRIPTION
This pull request updates the `@computesdk/tensorlake` package to use the latest `tensorlake` dependency version. The changes are primarily dependency updates and version bumps to ensure compatibility and access to the latest features and fixes.

**Dependency updates:**

* Updated the `tensorlake` dependency from version `0.5.7` to `0.5.31` in `package.json` and `pnpm-lock.yaml`, ensuring the package uses the latest features and bug fixes from `tensorlake`. [[1]](diffhunk://#diff-c813b31553fb757fe4ef5ceb483e9c4e36031262dbacac1db8129002dcef3094L33-R33) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1509-R1510) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7605-R7606) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15652-R15652)
* Updated the transitive dependency `ws` for `pyodide` and `tensorlake` to version `8.20.1` in `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14953-R14953) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15652-R15652)

**Version bump and changelog:**

* Bumped the version of `@computesdk/tensorlake` from `0.1.6` to `0.1.7` in `package.json` and documented the change in `CHANGELOG.md`. [[1]](diffhunk://#diff-c813b31553fb757fe4ef5ceb483e9c4e36031262dbacac1db8129002dcef3094L3-R3) [[2]](diffhunk://#diff-c813b31553fb757fe4ef5ceb483e9c4e36031262dbacac1db8129002dcef3094L3-R3)