### PR TITLE
feat: add Tenki provider

### DIFF
--- a/.changeset/tenki-provider.md
+++ b/.changeset/tenki-provider.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/tenki': minor
+---
+
+Add Tenki Cloud provider. MicroVM sandboxes with native filesystem operations, public preview URLs via getUrl, sh -lc command execution, and automatic workspace/project resolution from the API key.

--- a/packages/tenki/README.md
+++ b/packages/tenki/README.md
@@ -1,0 +1,102 @@
+# @computesdk/tenki
+
+[Tenki Cloud](https://tenki.cloud) provider for ComputeSDK - run code in fast microVM sandboxes with native filesystem operations, public preview URLs, snapshots, volumes, and SSH.
+
+## Installation
+
+```bash
+npm install @computesdk/tenki
+```
+
+## Setup
+
+1. Sign up at [app.tenki.cloud](https://app.tenki.cloud)
+2. Create an API key in your workspace settings
+3. Set it as an environment variable:
+
+```bash
+export TENKI_API_KEY=tk_your_api_key
+```
+
+## Usage
+
+### With ComputeSDK
+
+```typescript
+import { compute } from 'computesdk';
+import { tenki } from '@computesdk/tenki';
+
+compute.setConfig({ provider: tenki({ apiKey: process.env.TENKI_API_KEY }) });
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('echo "Hello from Tenki!"');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+### Filesystem operations
+
+Tenki exposes native file primitives over its data plane, so filesystem operations do not go through shell commands (no escaping hazards, works with any path or content):
+
+```typescript
+await sandbox.filesystem.writeFile('/home/tenki/app.py', 'print("hi")');
+const content = await sandbox.filesystem.readFile('/home/tenki/app.py');
+const entries = await sandbox.filesystem.readdir('/home/tenki');
+await sandbox.filesystem.mkdir('/home/tenki/data');
+const exists = await sandbox.filesystem.exists('/home/tenki/app.py');
+await sandbox.filesystem.remove('/home/tenki/app.py');
+```
+
+### Public preview URLs
+
+```typescript
+// Start a server (background commands are detached automatically)
+await sandbox.runCommand('python3 -m http.server 3000', { background: true });
+
+// Expose the port at a public URL
+const url = await sandbox.getUrl({ port: 3000 });
+// => https://<slug>.sb.tenki.sh
+```
+
+## Configuration
+
+| Option | Env var | Default | Description |
+|---|---|---|---|
+| `apiKey` | `TENKI_API_KEY` / `TENKI_AUTH_TOKEN` | required | Tenki API key (`tk_...`) |
+| `baseUrl` | `TENKI_API_URL` | `https://api.tenki.cloud` | API endpoint |
+| `workspaceId` | `TENKI_WORKSPACE_ID` | auto-resolved | Workspace for new sandboxes |
+| `projectId` | `TENKI_PROJECT_ID` | auto-resolved | Project for new sandboxes |
+| `timeout` | - | none | Default `runCommand` timeout (ms) |
+| `cpuCores` / `memoryMb` / `diskSizeGb` | - | Tenki defaults | Default sandbox resources |
+
+When `workspaceId`/`projectId` are not set, the provider resolves them once from the API key's identity (first workspace with a project).
+
+Per-sandbox resource overrides are accepted on `create`:
+
+```typescript
+await compute.sandbox.create({ options: { cpuCores: 4, memoryMb: 8192 } });
+```
+
+## Feature support
+
+| Feature | Supported |
+|---|---|
+| Commands (`runCommand`) | Yes - via `sh -lc`, so pipes, globs, and env expansion work |
+| Filesystem | Yes - native data-plane file API |
+| Public URLs (`getUrl`) | Yes - per-port preview URLs |
+| List / getById / destroy | Yes |
+| Background commands | Yes - `{ background: true }` detaches stdio automatically |
+| Custom images | Via Tenki templates (`templateId` maps to a Tenki image ref) |
+| Snapshots / pause-resume | In the Tenki SDK (`@tenkicloud/sandbox`); not yet wired to provider snapshot methods |
+
+## Notes
+
+- `runCommand` wraps the command in `sh -lc` because Tenki's exec runs argv directly (execve, no shell).
+- A long-running process started with a bare `&` would hold the exec output stream open; use `{ background: true }`, which detaches stdio for you.
+- For advanced features (SSH, volumes, tunnels, git operations, snapshots), use the underlying SDK directly via `sandbox.getInstance()`, which returns the `@tenkicloud/sandbox` `Session`.
+
+## License
+
+MIT

--- a/packages/tenki/package.json
+++ b/packages/tenki/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@computesdk/tenki",
+  "version": "0.1.0",
+  "description": "Tenki Cloud provider for ComputeSDK - microVM sandboxes with native filesystem, preview URLs, snapshots, and SSH",
+  "author": "Tenki Cloud <support@tenki.cloud>",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "@tenkicloud/sandbox": "^0.1.3",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "tenki",
+    "sandbox",
+    "code-execution",
+    "compute",
+    "provider",
+    "microvm"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/tenki"
+  },
+  "homepage": "https://tenki.cloud",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/tenki/src/__tests__/index.test.ts
+++ b/packages/tenki/src/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { tenki } from '../index';
+
+runProviderTestSuite({
+  name: 'tenki',
+  provider: tenki({
+    apiKey: process.env.TENKI_API_KEY,
+    workspaceId: process.env.TENKI_WORKSPACE_ID,
+    projectId: process.env.TENKI_PROJECT_ID,
+  }),
+  supportsFilesystem: true,
+  supportsGetUrl: true,
+  skipIntegration: !process.env.TENKI_API_KEY,
+  // Tenki's data-plane filesystem API operates under the sandbox user's home.
+  filesystemBasePath: '/home/tenki',
+});

--- a/packages/tenki/src/__tests__/unit.test.ts
+++ b/packages/tenki/src/__tests__/unit.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Mock-based unit tests for the Tenki provider. These run without credentials
+ * and exercise option mapping, shell wrapping, status mapping, the native
+ * filesystem path, and not-found handling. Integration coverage lives in
+ * index.test.ts via the standard provider test suite.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const enc = new TextEncoder();
+
+class SessionNotFoundError extends Error {}
+
+let lastCreateOptions: any = null;
+let lastExec: { command: string; args?: string[] } | null = null;
+
+class FakeSession {
+  id = 'sbx_123';
+  name = 'test-sandbox';
+  state = 'RUNNING';
+  cpuCores = 2;
+  memoryMb = 4096;
+  diskSizeGb = 10;
+  projectId = 'proj_1';
+  tags: string[] = [];
+  timeoutAt = new Date(Date.now() + 3_600_000);
+  closed = false;
+  private files = new Map<string, Uint8Array>();
+  private dirs = new Set<string>(['/work']);
+
+  async exec(command: string, options?: any) {
+    lastExec = { command, args: options?.args };
+    const line: string = options?.args?.[1] ?? '';
+    // Emulate `test -e "<path>"` against the fake filesystem.
+    const testMatch = line.match(/^test -e "(.+)"$/);
+    if (testMatch) {
+      const path = testMatch[1];
+      const exitCode = this.files.has(path) || this.dirs.has(path) ? 0 : 1;
+      return { stdout: new Uint8Array(), stderr: new Uint8Array(), exitCode, durationMs: 1 };
+    }
+    const stdout = enc.encode('hello\n');
+    options?.onOutput?.({ data: stdout, isStderr: false, isFinal: true });
+    return { stdout, stderr: new Uint8Array(), exitCode: 0, durationMs: 12 };
+  }
+
+  async exposePort(port: number) {
+    return { port, previewUrl: `https://sbx-123-${port}.sb.tenki.sh` };
+  }
+
+  async writeFile(path: string, data: Uint8Array | string) {
+    this.files.set(path, typeof data === 'string' ? enc.encode(data) : data);
+  }
+  async readFile(path: string): Promise<Uint8Array> {
+    const v = this.files.get(path);
+    if (!v) throw new Error('not found');
+    return v;
+  }
+  async mkdir(path: string) {
+    this.dirs.add(path);
+  }
+  async remove(path: string) {
+    this.files.delete(path);
+    this.dirs.delete(path);
+  }
+  async stat(path: string) {
+    if (!this.files.has(path) && !this.dirs.has(path)) throw new Error('not found');
+    return {
+      path,
+      size: BigInt(this.files.get(path)?.length ?? 0),
+      mode: 0o644,
+      isDir: this.dirs.has(path),
+      modifiedUnixNs: 1_700_000_000_000_000_000n,
+    };
+  }
+  async list(_path: string) {
+    return [
+      { path: '/work/a.txt', size: 5n, mode: 0o644, isDir: false, modifiedUnixNs: 1_700_000_000_000_000_000n },
+      { path: '/work/sub', size: 0n, mode: 0o755, isDir: true, modifiedUnixNs: 1_700_000_000_000_000_000n },
+    ];
+  }
+  async close() {
+    this.closed = true;
+  }
+}
+
+let shouldNotFind = false;
+const sharedSession = new FakeSession();
+
+class FakeTenkiSandbox {
+  constructor(public options: any) {}
+  async whoAmI() {
+    return {
+      ownerType: 'USER',
+      ownerId: 'user_1',
+      workspaces: [{ id: 'ws_1', name: 'WS', projects: [{ id: 'proj_1', name: 'P' }] }],
+    };
+  }
+  async createAndWait(opts: any) {
+    lastCreateOptions = opts;
+    return sharedSession;
+  }
+  async get(_id: string) {
+    if (shouldNotFind) throw new SessionNotFoundError('nope');
+    return sharedSession;
+  }
+  async list() {
+    return [sharedSession];
+  }
+}
+
+vi.mock('@tenkicloud/sandbox', () => ({
+  TenkiSandbox: FakeTenkiSandbox,
+  Session: FakeSession,
+  SessionNotFoundError,
+  stdoutText: (r: any) => new TextDecoder().decode(r.stdout).trim(),
+  stderrText: (r: any) => new TextDecoder().decode(r.stderr).trim(),
+}));
+
+// Import lazily so the hoisted vi.mock factory's classes are initialized first.
+let tenki: typeof import('../index').tenki;
+
+describe('tenki provider (mocked SDK)', () => {
+  beforeAll(async () => {
+    ({ tenki } = await import('../index'));
+  });
+
+  beforeEach(() => {
+    lastCreateOptions = null;
+    lastExec = null;
+    shouldNotFind = false;
+    sharedSession.closed = false;
+  });
+
+  it('has the right name', () => {
+    expect(tenki({ apiKey: 'tk_test' }).name).toBe('tenki');
+  });
+
+  it('create resolves scope via whoAmI and maps options', async () => {
+    const provider = tenki({ apiKey: 'tk_test', memoryMb: 8192 });
+    const sandbox = await provider.sandbox.create({
+      envs: { NODE_ENV: 'production' },
+      timeout: 60_000,
+    });
+    expect(sandbox.sandboxId).toBe('sbx_123');
+    expect(lastCreateOptions).toMatchObject({
+      workspaceId: 'ws_1',
+      projectId: 'proj_1',
+      env: { NODE_ENV: 'production' },
+      maxDurationMs: 60_000,
+      memoryMb: 8192,
+    });
+  });
+
+  it('explicit workspace/project skips whoAmI resolution', async () => {
+    const provider = tenki({ apiKey: 'tk_test', workspaceId: 'ws_x', projectId: 'proj_x' });
+    await provider.sandbox.create();
+    expect(lastCreateOptions).toMatchObject({ workspaceId: 'ws_x', projectId: 'proj_x' });
+  });
+
+  it('runCommand wraps the command in sh -lc', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+    const result = await sandbox.runCommand('echo "hello"');
+    expect(lastExec?.command).toBe('sh');
+    expect(lastExec?.args).toEqual(['-lc', 'echo "hello"']);
+    expect(result.stdout).toBe('hello');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('runCommand honors cwd by prefixing a quoted cd', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+    await sandbox.runCommand('ls', { cwd: '/work' });
+    expect(lastExec?.args?.[1]).toBe("cd '/work' && ls");
+  });
+
+  it('background commands are detached from the output stream', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+    const result = await sandbox.runCommand('python3 -m http.server 3000', { background: true });
+    expect(lastExec?.args?.[1]).toContain('>/dev/null 2>&1 </dev/null &');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('getInfo reports tenki provider and running status', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+    const info = await sandbox.getInfo();
+    expect(info.provider).toBe('tenki');
+    expect(info.status).toBe('running');
+    expect(info.id).toBe('sbx_123');
+    expect(info.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('getUrl exposes the port and returns the preview URL', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+    expect(await sandbox.getUrl({ port: 3000 })).toBe('https://sbx-123-3000.sb.tenki.sh');
+  });
+
+  it('filesystem round-trips through native Tenki fs', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+
+    await sandbox.filesystem.writeFile('/work/a.txt', 'data');
+    expect(await sandbox.filesystem.readFile('/work/a.txt')).toBe('data');
+    expect(await sandbox.filesystem.exists('/work/a.txt')).toBe(true);
+    expect(await sandbox.filesystem.exists('/work/missing')).toBe(false);
+
+    const entries = await sandbox.filesystem.readdir('/work');
+    expect(entries).toEqual([
+      expect.objectContaining({ name: 'a.txt', type: 'file', size: 5 }),
+      expect.objectContaining({ name: 'sub', type: 'directory' }),
+    ]);
+
+    await sandbox.filesystem.remove('/work/a.txt');
+    expect(await sandbox.filesystem.exists('/work/a.txt')).toBe(false);
+  });
+
+  it('getById returns null when the session is not found', async () => {
+    shouldNotFind = true;
+    const provider = tenki({ apiKey: 'tk_test' });
+    expect(await provider.sandbox.getById('nope')).toBeNull();
+  });
+
+  it('destroy closes the session and tolerates already-gone sandboxes', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+    await sandbox.destroy();
+    expect(sharedSession.closed).toBe(true);
+
+    shouldNotFind = true;
+    await expect(provider.sandbox.destroy('gone')).resolves.toBeUndefined();
+  });
+
+  it('throws a helpful error when no API key is configured', async () => {
+    const saved = { key: process.env.TENKI_API_KEY, token: process.env.TENKI_AUTH_TOKEN };
+    delete process.env.TENKI_API_KEY;
+    delete process.env.TENKI_AUTH_TOKEN;
+    try {
+      const provider = tenki({});
+      await expect(provider.sandbox.create()).rejects.toThrow(/Missing API key for Tenki/);
+    } finally {
+      if (saved.key) process.env.TENKI_API_KEY = saved.key;
+      if (saved.token) process.env.TENKI_AUTH_TOKEN = saved.token;
+    }
+  });
+});

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -1,0 +1,352 @@
+/**
+ * @computesdk/tenki — ComputeSDK provider for Tenki Cloud sandboxes.
+ *
+ * Usage:
+ *   import { tenki } from "@computesdk/tenki";
+ *   import { compute } from "computesdk";
+ *
+ *   compute.setConfig({
+ *     provider: tenki({ apiKey: "tk_..." }),
+ *   });
+ *
+ *   const sandbox = await compute.sandbox.create();
+ *   const result = await sandbox.runCommand("echo hello");
+ *   await sandbox.destroy();
+ */
+
+import { defineProvider, escapeShellArg } from "@computesdk/provider";
+import type { RunCommandOptions, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry } from "computesdk";
+import {
+  TenkiSandbox,
+  Session,
+  type SessionState,
+  type CreateOptions,
+  type Output,
+  SessionNotFoundError,
+  stdoutText,
+  stderrText,
+} from "@tenkicloud/sandbox";
+
+export interface TenkiConfig {
+  /** Tenki API key (tk_...). Falls back to TENKI_API_KEY / TENKI_AUTH_TOKEN env vars. */
+  apiKey?: string;
+  /** API base URL. Falls back to TENKI_API_URL, then https://api.tenki.cloud. */
+  baseUrl?: string;
+  /** Workspace to create sandboxes in. Falls back to TENKI_WORKSPACE_ID, then auto-resolved from the API key. */
+  workspaceId?: string;
+  /** Project to create sandboxes in. Falls back to TENKI_PROJECT_ID, then auto-resolved from the API key. */
+  projectId?: string;
+  /** Default runCommand timeout in milliseconds. */
+  timeout?: number;
+  /** Default sandbox resources applied at create() time. */
+  cpuCores?: number;
+  memoryMb?: number;
+  diskSizeGb?: number;
+}
+
+interface TenkiScope {
+  workspaceId: string;
+  projectId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client + scope resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * One TenkiSandbox client per (token, baseUrl) pair. The client owns a gRPC
+ * transport, so we memoize rather than reconnecting on every collection-level
+ * call (create/getById/list/destroy).
+ */
+const clients = new Map<string, TenkiSandbox>();
+const scopes = new Map<string, TenkiScope>();
+
+function resolveApiKey(config: TenkiConfig): string {
+  const apiKey = config.apiKey ?? process.env.TENKI_API_KEY ?? process.env.TENKI_AUTH_TOKEN;
+  if (!apiKey) {
+    throw new Error(
+      "Missing API key for Tenki.\n\n" +
+        "Create one at https://app.tenki.cloud (workspace settings > API Keys)\n" +
+        'Then pass it: tenki({ apiKey: "tk_..." })\n' +
+        "Or set TENKI_API_KEY in your environment.",
+    );
+  }
+  return apiKey;
+}
+
+function clientKey(config: TenkiConfig): string {
+  return `${resolveApiKey(config)}::${config.baseUrl ?? process.env.TENKI_API_URL ?? ""}`;
+}
+
+function getClient(config: TenkiConfig): TenkiSandbox {
+  const key = clientKey(config);
+  let client = clients.get(key);
+  if (!client) {
+    client = new TenkiSandbox({
+      authToken: resolveApiKey(config),
+      baseUrl: config.baseUrl ?? process.env.TENKI_API_URL,
+    });
+    clients.set(key, client);
+  }
+  return client;
+}
+
+/**
+ * Tenki sandboxes are created inside a workspace/project. When neither is
+ * configured we resolve the key's identity once via whoAmI() and pick the
+ * first workspace that has a project.
+ */
+async function resolveScope(config: TenkiConfig, client: TenkiSandbox): Promise<TenkiScope> {
+  const workspaceId = config.workspaceId ?? process.env.TENKI_WORKSPACE_ID;
+  const projectId = config.projectId ?? process.env.TENKI_PROJECT_ID;
+  if (workspaceId && projectId) return { workspaceId, projectId };
+
+  const key = clientKey(config);
+  const cached = scopes.get(key);
+  if (cached) return cached;
+
+  const identity = await client.whoAmI();
+  const workspace = identity.workspaces.find((w) => w.projects.length > 0);
+  const project = workspace?.projects[0];
+  if (!workspace || !project) {
+    throw new Error(
+      "Could not resolve a Tenki workspace/project for this API key.\n" +
+        "Pass them explicitly: tenki({ workspaceId, projectId })\n" +
+        "Or set TENKI_WORKSPACE_ID and TENKI_PROJECT_ID in your environment.",
+    );
+  }
+  const scope = { workspaceId: workspace.id, projectId: project.id };
+  scopes.set(key, scope);
+  return scope;
+}
+
+// ---------------------------------------------------------------------------
+// Session bookkeeping
+// ---------------------------------------------------------------------------
+
+/**
+ * created_at is on the wire but not yet surfaced by the TS SDK Session, so we
+ * record observation time as a best-effort createdAt for getInfo(). Instance
+ * methods only receive the sandbox, so exec-time defaults (timeout) are
+ * stashed per session as well.
+ */
+const observedAt = new WeakMap<Session, Date>();
+const sessionConfig = new WeakMap<Session, TenkiConfig>();
+
+function rememberSession(session: Session, config: TenkiConfig): Session {
+  if (!observedAt.has(session)) observedAt.set(session, new Date());
+  sessionConfig.set(session, config);
+  return session;
+}
+
+function mapStatus(state: SessionState): SandboxInfo["status"] {
+  switch (state) {
+    case "RUNNING":
+    case "CREATING":
+    case "RESUMING":
+      return "running";
+    case "PAUSED":
+    case "PAUSING":
+    case "TERMINATING":
+    case "TERMINATED":
+      return "stopped";
+    default:
+      return "error";
+  }
+}
+
+function toCreateOptions(config: TenkiConfig, scope: TenkiScope, options?: CreateSandboxOptions): CreateOptions {
+  const opts: CreateOptions = {
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+  };
+  if (options?.name) opts.name = options.name;
+  if (options?.envs) opts.env = options.envs;
+  if (options?.metadata) {
+    // Tenki metadata values are strings.
+    opts.metadata = Object.fromEntries(Object.entries(options.metadata).map(([k, v]) => [k, String(v)]));
+  }
+  if (options?.templateId) opts.image = options.templateId;
+  if (options?.snapshotId) opts.snapshotId = options.snapshotId;
+  if (options?.timeout) opts.maxDurationMs = options.timeout;
+
+  // Resources: per-call override (via CreateSandboxOptions' index signature)
+  // wins over provider-level defaults.
+  const cpuCores = (options as Record<string, unknown> | undefined)?.cpuCores ?? config.cpuCores;
+  const memoryMb = (options as Record<string, unknown> | undefined)?.memoryMb ?? config.memoryMb;
+  const diskSizeGb = (options as Record<string, unknown> | undefined)?.diskSizeGb ?? config.diskSizeGb;
+  if (typeof cpuCores === "number") opts.cpuCores = cpuCores;
+  if (typeof memoryMb === "number") opts.memoryMb = memoryMb;
+  if (typeof diskSizeGb === "number") opts.diskSizeGb = diskSizeGb;
+
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Command execution
+// ---------------------------------------------------------------------------
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Run a command line through a shell. ComputeSDK passes runCommand a full
+ * shell command string, whereas Tenki's Session.exec executes argv directly
+ * (execve, no shell), so we wrap with `sh -lc`.
+ */
+async function runShell(session: Session, command: string, options?: RunCommandOptions): Promise<CommandResult> {
+  const config = sessionConfig.get(session) ?? {};
+  const line = options?.cwd ? `cd ${shellQuote(options.cwd)} && ${command}` : command;
+
+  if (options?.background) {
+    // Detach stdio so the background process does not hold the exec output
+    // stream open (a bare `&` would keep exec waiting forever).
+    const detached = `{ ${line} ; } >/dev/null 2>&1 </dev/null &`;
+    await session.exec("sh", { args: ["-lc", detached] });
+    return { stdout: "", stderr: "", exitCode: 0, durationMs: 0 };
+  }
+
+  const onOutput =
+    options?.onStdout || options?.onStderr
+      ? (out: Output) => {
+          const text = new TextDecoder().decode(out.data);
+          if (out.isStderr) options?.onStderr?.(text);
+          else options?.onStdout?.(text);
+        }
+      : undefined;
+
+  const result = await session.exec("sh", {
+    args: ["-lc", line],
+    timeoutMs: options?.timeout ?? config.timeout,
+    onOutput,
+  });
+
+  return {
+    stdout: stdoutText(result),
+    stderr: stderrText(result),
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+  };
+}
+
+function basename(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export const tenki = defineProvider<Session, TenkiConfig>({
+  name: "tenki",
+  methods: {
+    sandbox: {
+      create: async (config, options) => {
+        const client = getClient(config);
+        const scope = await resolveScope(config, client);
+        const session = await client.createAndWait(toCreateOptions(config, scope, options));
+        return { sandbox: rememberSession(session, config), sandboxId: session.id };
+      },
+
+      getById: async (config, sandboxId) => {
+        const client = getClient(config);
+        try {
+          const session = await client.get(sandboxId);
+          return { sandbox: rememberSession(session, config), sandboxId: session.id };
+        } catch (err) {
+          if (err instanceof SessionNotFoundError) return null;
+          throw err;
+        }
+      },
+
+      list: async (config) => {
+        const client = getClient(config);
+        const sessions = await client.list();
+        return sessions.map((session) => ({
+          sandbox: rememberSession(session, config),
+          sandboxId: session.id,
+        }));
+      },
+
+      destroy: async (config, sandboxId) => {
+        const client = getClient(config);
+        try {
+          const session = await client.get(sandboxId);
+          await session.close();
+        } catch (err) {
+          if (err instanceof SessionNotFoundError) return; // already gone
+          throw err;
+        }
+      },
+
+      runCommand: (sandbox, command, options) => runShell(sandbox, command, options),
+
+      getInfo: async (sandbox) => {
+        const remaining = sandbox.timeoutAt.getTime() - Date.now();
+        return {
+          id: sandbox.id,
+          provider: "tenki",
+          status: mapStatus(sandbox.state),
+          createdAt: observedAt.get(sandbox) ?? new Date(),
+          timeout: remaining > 0 ? remaining : 0,
+          metadata: {
+            name: sandbox.name,
+            state: sandbox.state,
+            cpuCores: sandbox.cpuCores,
+            memoryMb: sandbox.memoryMb,
+            diskSizeGb: sandbox.diskSizeGb,
+            projectId: sandbox.projectId,
+            tags: sandbox.tags,
+          },
+        };
+      },
+
+      getUrl: async (sandbox, options) => {
+        const exposed = await sandbox.exposePort(options.port);
+        return exposed.previewUrl;
+      },
+
+      getInstance: (sandbox) => sandbox,
+
+      // Native filesystem: Tenki exposes real file primitives over its data
+      // plane, so we bypass the shell-based fallback (and its escaping
+      // hazards). The runCommand parameter is intentionally unused.
+      filesystem: {
+        readFile: async (sandbox, path) => {
+          const bytes = await sandbox.readFile(path);
+          return new TextDecoder().decode(bytes);
+        },
+        writeFile: async (sandbox, path, content) => {
+          await sandbox.writeFile(path, content);
+        },
+        mkdir: async (sandbox, path) => {
+          await sandbox.mkdir(path);
+        },
+        readdir: async (sandbox, path): Promise<FileEntry[]> => {
+          const entries = await sandbox.list(path);
+          return entries.map((entry) => ({
+            name: basename(entry.path),
+            type: entry.isDir ? ("directory" as const) : ("file" as const),
+            size: Number(entry.size),
+            modified: new Date(Number(entry.modifiedUnixNs / 1_000_000n)),
+          }));
+        },
+        // exists goes through the shell: the data-plane stat can briefly
+        // report a just-removed file as present, while `test -e` is always
+        // consistent with the guest filesystem.
+        exists: async (sandbox, path, runCommand) => {
+          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          return result.exitCode === 0;
+        },
+        remove: async (sandbox, path) => {
+          await sandbox.remove(path);
+        },
+      },
+    },
+  },
+});
+
+export default tenki;

--- a/packages/tenki/tsconfig.json
+++ b/packages/tenki/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tenki/tsup.config.ts
+++ b/packages/tenki/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/tenki/vitest.config.ts
+++ b/packages/tenki/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -76,7 +76,8 @@
     "@computesdk/upstash": "workspace:*",
     "@computesdk/k8s": "workspace:*",
     "@computesdk/northflank": "workspace:*",
-    "@computesdk/collimate": "workspace:*"
+    "@computesdk/collimate": "workspace:*",
+    "@computesdk/tenki": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@computesdk/e2b": {
@@ -140,6 +141,9 @@
       "optional": true
     },
     "@computesdk/collimate": {
+      "optional": true
+    },
+    "@computesdk/tenki": {
       "optional": true
     }
   },

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -27,6 +27,7 @@ const SHARED_PROVIDER_NAMES = [
   'k8s',
   'northflank',
   'collimate',
+  'tenki',
 ] as const;
 
 type SharedProviderName = typeof SHARED_PROVIDER_NAMES[number];
@@ -59,6 +60,7 @@ const SHARED_PROVIDER_AUTH: Record<SharedProviderName, readonly (readonly string
   k8s: [[]],
   northflank: [['NORTHFLANK_TOKEN', 'NORTHFLANK_PROJECT_ID']],
   collimate: [['COLLIMATE_API_KEY']],
+  tenki: [['TENKI_API_KEY']],
 };
 
 const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
@@ -90,6 +92,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
   k8s: {},
   northflank: { token: 'NORTHFLANK_TOKEN', projectId: 'NORTHFLANK_PROJECT_ID', teamId: 'NORTHFLANK_TEAM_ID', host: 'NORTHFLANK_API_URL' },
   collimate: { apiKey: 'COLLIMATE_API_KEY', serverUrl: 'COLLIMATE_API_URL' },
+  tenki: { apiKey: 'TENKI_API_KEY', baseUrl: 'TENKI_API_URL', workspaceId: 'TENKI_WORKSPACE_ID', projectId: 'TENKI_PROJECT_ID' },
 };
 
 function getProviderConfigFromEnv(provider: SharedProviderName): Record<string, string> {
@@ -357,6 +360,9 @@ export async function loadProvider(providerName: ProviderName): Promise<any> {
       case 'collimate':
         // @ts-ignore - package type declarations may be unavailable in local workbench typecheck
         return await import('@computesdk/collimate');
+      case 'tenki':
+        // @ts-ignore - package type declarations may be unavailable in local workbench typecheck
+        return await import('@computesdk/tenki');
       default:
         throw new Error(`Unknown provider: ${providerName}`);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1772,6 +1772,9 @@ importers:
       '@computesdk/sprites':
         specifier: workspace:*
         version: link:../sprites
+      '@computesdk/tenki':
+        specifier: workspace:*
+        version: link:../tenki
       '@computesdk/upstash':
         specifier: workspace:*
         version: link:../upstash
@@ -13983,7 +13986,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -14180,7 +14183,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,7 +682,7 @@ importers:
         version: link:../provider
       '@daytonaio/sdk':
         specifier: ^0.143.0
-        version: 0.143.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 0.143.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -1497,6 +1497,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/tenki:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@tenkicloud/sandbox':
+        specifier: ^0.1.3
+        version: 0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/tensorlake:
     dependencies:
       '@computesdk/provider':
@@ -2136,6 +2173,9 @@ packages:
   '@browserbasehq/sdk@2.9.0':
     resolution: {integrity: sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==}
 
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
   '@bufbuild/protobuf@2.7.0':
     resolution: {integrity: sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==}
 
@@ -2303,6 +2343,13 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
+  '@connectrpc/connect-node@2.1.1':
+    resolution: {integrity: sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.1
+
   '@connectrpc/connect-web@2.0.0-rc.3':
     resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
     peerDependencies:
@@ -2313,6 +2360,11 @@ packages:
     resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.2.0
+
+  '@connectrpc/connect@2.1.1':
+    resolution: {integrity: sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4367,6 +4419,10 @@ packages:
   '@smithy/uuid@1.1.2':
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
+
+  '@tenkicloud/sandbox@0.1.3':
+    resolution: {integrity: sha512-S6FYzXTQu5eV5U6m91YQi3L32Cawc0ZBzU+DHsRruimZlTQTAkZFa8Y29LOudSaIOIUuV8VkC/UOejtOGgauRQ==}
+    engines: {node: '>=18'}
 
   '@tigrisdata/storage@3.6.0':
     resolution: {integrity: sha512-l+FHRAA903MOZ/PFBlz6S73YwlJ1Fs+D5/gTPiI2/NtiyIsqj3eNRGDYB+DszT75NIxKWCRoyNornUM+7qXkVw==}
@@ -8134,6 +8190,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   x256@0.0.2:
     resolution: {integrity: sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==}
     engines: {node: '>=0.4.0'}
@@ -9256,6 +9324,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@bufbuild/protobuf@2.11.0': {}
+
   '@bufbuild/protobuf@2.7.0': {}
 
   '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
@@ -9497,6 +9567,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@connectrpc/connect-node@2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)
+
   '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.7.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.7.0))':
     dependencies:
       '@bufbuild/protobuf': 2.7.0
@@ -9505,6 +9580,10 @@ snapshots:
   '@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.7.0)':
     dependencies:
       '@bufbuild/protobuf': 2.7.0
+
+  '@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -9541,7 +9620,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@daytonaio/sdk@0.143.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@daytonaio/sdk@0.143.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -9562,7 +9641,7 @@ snapshots:
       expand-tilde: 2.0.2
       fast-glob: 3.3.3
       form-data: 4.0.4
-      isomorphic-ws: 5.0.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 5.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       pathe: 2.0.3
       shell-quote: 1.8.3
       tar: 7.5.9
@@ -11794,6 +11873,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tenkicloud/sandbox@0.1.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.11.0)
+      '@connectrpc/connect-node': 2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@tigrisdata/storage@3.6.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
@@ -14014,9 +14103,9 @@ snapshots:
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isomorphic-ws@5.0.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@5.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -16301,6 +16390,11 @@ snapshots:
       utf-8-validate: 6.0.6
 
   ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## What

Adds `@computesdk/tenki`, a provider for [Tenki Cloud](https://tenki.cloud) microVM sandboxes.

- Full sandbox lifecycle: create / getById / list / destroy
- `runCommand` via `sh -lc` (pipes, globs, env expansion work); `{ background: true }` detaches stdio so servers don't block exec
- Native filesystem: Tenki exposes real file primitives over its data plane, so read/write/mkdir/readdir/remove skip the shell fallback entirely (no escaping hazards)
- `getUrl` returns a public preview URL per port (`*.sb.tenki.sh`)
- Auto-resolves workspace/project from the API key via `whoAmI()` when not configured
- `getInstance()` exposes the underlying `@tenkicloud/sandbox` Session for advanced features (SSH, volumes, snapshots, tunnels)
- Registered in workbench: `SHARED_PROVIDER_NAMES`, env auth detection (`TENKI_API_KEY`), config env mapping, dynamic import, optional peer dependency

## How it was built

- Followed `ADD-PROVIDER.md`; package mirrors the collimate/e2b layout, workbench wiring mirrors northflank/collimate
- Standard `runProviderTestSuite` from `@computesdk/test-utils`, plus mock-based unit tests that run without credentials (12 tests)
- Changeset included

## Testing

- `build`, `typecheck`, `lint`: pass (workbench typecheck unchanged: same 15 pre-existing TS2307s as main from unbuilt sibling packages)
- Mock unit tests: 12/12, no credentials needed
- **Full integration suite against the live Tenki API: 27/27** with `supportsFilesystem: true`, `supportsGetUrl: true`, `filesystemBasePath: '/home/tenki'`

## Notes

- `filesystemBasePath` is `/home/tenki` because Tenki's data-plane filesystem operates under the sandbox user's home
- `exists` uses the shell fallback (`test -e`) rather than the native stat for consistency right after removes
- I work at Tenki; happy to maintain this package and wire up the optional snapshot/template method groups as a follow-up
