### PR TITLE
Add Railway provider

### DIFF
--- a/.changeset/add-railway-provider.md
+++ b/.changeset/add-railway-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/railway": patch
+---
+
+Add Railway provider

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Cloudflare** | `CLOUDFLARE_SANDBOX_URL`, `CLOUDFLARE_SANDBOX_SECRET` | Edge computing |
 | **CodeSandbox** | `CSB_API_KEY` | Collaborative development |
 | **Tensorlake** | `TENSORLAKE_API_KEY` | Stateful MicroVM sandboxes |
+| **Railway** | `RAILWAY_API_TOKEN`, `RAILWAY_ENVIRONMENT_ID` | Ephemeral command execution sandboxes |
 
 ## Configuration
 
@@ -263,6 +264,7 @@ npm install @computesdk/modal      # Modal provider
 npm install @computesdk/daytona    # Daytona provider
 npm install @computesdk/vercel     # Vercel provider
 npm install @computesdk/tensorlake # Tensorlake provider
+npm install @computesdk/railway    # Railway provider
 npm install @computesdk/just-bash  # Local bash sandbox (no auth needed)
 ```
 
@@ -281,6 +283,7 @@ See individual provider READMEs for details:
 - **[@computesdk/daytona](./packages/daytona)** - Development workspaces
 - **[@computesdk/vercel](./packages/vercel)** - Serverless functions
 - **[@computesdk/tensorlake](./packages/tensorlake)** - Stateful MicroVM sandboxes for agentic applications, with snapshot support
+- **[@computesdk/railway](./packages/railway)** - Ephemeral command-execution sandboxes on Railway, with shell-based filesystem
 - **[@computesdk/just-bash](./packages/just-bash)** - Local bash sandbox with virtual filesystem (no auth required)
 
 ## Building Custom Providers

--- a/packages/railway/README.md
+++ b/packages/railway/README.md
@@ -8,6 +8,8 @@ Railway provider for ComputeSDK - run commands in [Railway Sandboxes](https://do
 npm install @computesdk/railway
 ```
 
+> **Requires Node.js >= 22** — the underlying `railway` SDK depends on Node 22 APIs (e.g. global `WebSocket`).
+
 ## Setup
 
 1. Create a Railway API token at [railway.com/account/tokens](https://railway.com/account/tokens).
@@ -66,9 +68,10 @@ const sandbox = await sdk.sandbox.create();
 railway({
   token: '...',          // defaults to RAILWAY_API_TOKEN
   environmentId: '...',  // defaults to RAILWAY_ENVIRONMENT_ID
-  timeout: 300000,       // reported via getInfo(); milliseconds
 });
 ```
+
+Per-command execution timeouts are supported via `runCommand`'s options (`{ timeout: ms }`), which maps to Railway's `timeoutSec`.
 
 ## Supported Features
 

--- a/packages/railway/README.md
+++ b/packages/railway/README.md
@@ -1,0 +1,92 @@
+# @computesdk/railway
+
+Railway provider for ComputeSDK - run commands in [Railway Sandboxes](https://docs.railway.com/sandboxes), ephemeral compute environments backed by the Railway platform.
+
+## Installation
+
+```bash
+npm install @computesdk/railway
+```
+
+## Setup
+
+1. Create a Railway API token at [railway.com/account/tokens](https://railway.com/account/tokens).
+2. Find the environment ID you want sandboxes to run in (Railway project → environment settings).
+3. Set the environment variables:
+
+```bash
+export RAILWAY_API_TOKEN=your_token_here
+export RAILWAY_ENVIRONMENT_ID=your_environment_id_here
+```
+
+## Quick Start
+
+Configure `compute` with the Railway provider and create a sandbox:
+
+```typescript
+import { compute } from 'computesdk';
+import { railway } from '@computesdk/railway';
+
+compute.setConfig({
+  provider: railway({
+    token: process.env.RAILWAY_API_TOKEN,
+    environmentId: process.env.RAILWAY_ENVIRONMENT_ID,
+  }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('echo "hello from Railway"');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+Alternatively, call the provider factory directly when you only need one provider:
+
+```typescript
+import { railway } from '@computesdk/railway';
+
+const sdk = railway({ token: process.env.RAILWAY_API_TOKEN });
+const sandbox = await sdk.sandbox.create();
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `RAILWAY_API_TOKEN` | Yes | Railway API token used to authenticate. |
+| `RAILWAY_ENVIRONMENT_ID` | Recommended | Railway environment the sandbox runs in. |
+
+### Config options
+
+```typescript
+railway({
+  token: '...',          // defaults to RAILWAY_API_TOKEN
+  environmentId: '...',  // defaults to RAILWAY_ENVIRONMENT_ID
+  timeout: 300000,       // reported via getInfo(); milliseconds
+});
+```
+
+## Supported Features
+
+| Feature | Supported | Notes |
+|---|---|---|
+| Command execution (`runCommand`) | ✅ | Backed by `sandbox.exec`. `timeout` is mapped to Railway's `timeoutSec`. |
+| Filesystem (`filesystem.*`) | ✅ | Implemented over the shell (`cat`/`base64`/`mkdir`/`ls`/`rm`) since Railway has no dedicated filesystem API. |
+| List sandboxes (`list`) | ✅ | Enumerates sandboxes in the configured environment. |
+| Get / destroy by ID | ✅ | Via `Sandbox.connect` / `sandbox.destroy`. |
+| Port exposure (`getUrl`) | ❌ | Railway sandboxes do not expose public per-port URLs. |
+| Templates / snapshots | ❌ | Railway templates are a build-time builder (`Sandbox.template()`), not an ID-addressable resource, so they are not mapped to ComputeSDK templates/snapshots. |
+
+## Limitations
+
+- **No port exposure.** `getUrl` throws — Railway sandboxes don't publish public URLs per port.
+- **Filesystem is shell-based.** File operations run shell commands inside the sandbox, so they require a POSIX shell with `base64`, `ls`, and the usual coreutils (present on Railway's default image).
+- **Templates/snapshots are not exposed.** Use the underlying `railway` SDK's `Sandbox.template()` builder directly if you need custom base images.
+
+## License
+
+MIT

--- a/packages/railway/package.json
+++ b/packages/railway/package.json
@@ -4,6 +4,9 @@
   "description": "Railway Sandboxes provider for ComputeSDK - run commands in Railway-hosted sandboxes",
   "author": "ComputeSDK",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/railway/package.json
+++ b/packages/railway/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@computesdk/railway",
+  "version": "1.0.0",
+  "description": "Railway Sandboxes provider for ComputeSDK - run commands in Railway-hosted sandboxes",
+  "author": "ComputeSDK",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*",
+    "railway": "^3.1.1"
+  },
+  "keywords": [
+    "computesdk",
+    "railway",
+    "sandbox",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/railway"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/railway/src/__tests__/index.test.ts
+++ b/packages/railway/src/__tests__/index.test.ts
@@ -1,0 +1,10 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { railway } from '../index';
+
+runProviderTestSuite({
+  name: 'railway',
+  provider: railway({}),
+  supportsFilesystem: true, // implemented over the shell via exec
+  supportsGetUrl: false, // Railway sandboxes do not expose public per-port URLs
+  skipIntegration: !process.env.RAILWAY_API_TOKEN,
+});

--- a/packages/railway/src/index.ts
+++ b/packages/railway/src/index.ts
@@ -29,8 +29,6 @@ export interface RailwayConfig {
   token?: string;
   /** Railway environment ID - falls back to the RAILWAY_ENVIRONMENT_ID environment variable */
   environmentId?: string;
-  /** Default execution timeout in milliseconds (used for getInfo reporting) */
-  timeout?: number;
 }
 
 /** Options accepted by the Railway SDK's create/connect/list calls. */
@@ -148,8 +146,9 @@ export const railway = defineProvider<RailwaySandbox, RailwayConfig>({
           const sandbox = await Sandbox.connect(sandboxId, client);
           return { sandbox, sandboxId };
         } catch (error) {
+          // Only a missing sandbox maps to null; surface auth/network/config errors.
           if (error instanceof SandboxNotFoundError) return null;
-          return null;
+          throw error;
         }
       },
 
@@ -259,8 +258,10 @@ export const railway = defineProvider<RailwaySandbox, RailwayConfig>({
             .split('\n')
             .filter((line) => line.trim() && !line.startsWith('total'))
             .map((line) => {
+              // `ls -la` columns: perms links owner group size month day time name…
+              // The name is everything from the 9th column on, so it survives spaces.
               const parts = line.trim().split(/\s+/);
-              const name = parts[parts.length - 1];
+              const name = parts.slice(8).join(' ');
               const isDirectory = line.startsWith('d');
               return {
                 name,
@@ -269,7 +270,7 @@ export const railway = defineProvider<RailwaySandbox, RailwayConfig>({
                 modified: new Date(),
               };
             })
-            .filter((entry) => entry.name !== '.' && entry.name !== '..');
+            .filter((entry) => entry.name && entry.name !== '.' && entry.name !== '..');
         },
 
         exists: async (sandbox: RailwaySandbox, path: string, runCommand: CommandRunner): Promise<boolean> => {

--- a/packages/railway/src/index.ts
+++ b/packages/railway/src/index.ts
@@ -81,13 +81,24 @@ function mapStatus(status: string): SandboxInfo['status'] {
   }
 }
 
+/** Valid POSIX shell environment variable name. Keys cannot be quoted in an
+ * assignment prefix, so anything outside this set is rejected rather than escaped. */
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /** Apply env/cwd/background options by composing a single shell command string. */
 function composeCommand(command: string, options?: RunCommandOptions): string {
   let fullCommand = command;
 
   if (options?.env && Object.keys(options.env).length > 0) {
     const envPrefix = Object.entries(options.env)
-      .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+      .map(([k, v]) => {
+        if (!ENV_KEY_PATTERN.test(k)) {
+          throw new Error(
+            `Invalid environment variable name "${k}". Names must match ${ENV_KEY_PATTERN}.`
+          );
+        }
+        return `${k}="${escapeShellArg(String(v))}"`;
+      })
       .join(' ');
     fullCommand = `${envPrefix} ${fullCommand}`;
   }

--- a/packages/railway/src/index.ts
+++ b/packages/railway/src/index.ts
@@ -1,0 +1,280 @@
+/**
+ * Railway Provider - Factory-based Implementation
+ *
+ * Wraps Railway Sandboxes (https://docs.railway.com/sandboxes) using the
+ * ComputeSDK provider factory. Railway exposes command execution via
+ * `sandbox.exec`; it has no dedicated filesystem or port-exposure API, so the
+ * filesystem block is implemented over the shell and `getUrl` throws.
+ */
+
+import { Sandbox, SandboxNotFoundError } from 'railway';
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+
+import type { CommandResult, RunCommandOptions, SandboxInfo } from '@computesdk/provider';
+import type { CreateSandboxOptions, FileEntry } from 'computesdk';
+
+type RailwaySandbox = Sandbox;
+
+type CommandRunner = (
+  sandbox: RailwaySandbox,
+  command: string,
+  options?: RunCommandOptions
+) => Promise<CommandResult>;
+
+/**
+ * Railway-specific configuration options
+ */
+export interface RailwayConfig {
+  /** Railway API token - falls back to the RAILWAY_API_TOKEN environment variable */
+  token?: string;
+  /** Railway environment ID - falls back to the RAILWAY_ENVIRONMENT_ID environment variable */
+  environmentId?: string;
+  /** Default execution timeout in milliseconds (used for getInfo reporting) */
+  timeout?: number;
+}
+
+/** Options accepted by the Railway SDK's create/connect/list calls. */
+interface RailwayClientOptions {
+  token: string;
+  environmentId?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 300000;
+
+/**
+ * Resolve and validate credentials, falling back to environment variables.
+ * Throws a helpful error when the token is missing.
+ */
+function resolveClientOptions(config: RailwayConfig): RailwayClientOptions {
+  const token =
+    config.token || (typeof process !== 'undefined' ? process.env?.RAILWAY_API_TOKEN : undefined);
+
+  if (!token) {
+    throw new Error(
+      'Missing Railway API token.\n\n' +
+        'Create a token at https://railway.com/account/tokens\n' +
+        "Then pass it: railway({ token: 'xxx' })\n" +
+        'Or set RAILWAY_API_TOKEN in your environment.'
+    );
+  }
+
+  const environmentId =
+    config.environmentId ||
+    (typeof process !== 'undefined' ? process.env?.RAILWAY_ENVIRONMENT_ID : undefined);
+
+  return { token, environmentId };
+}
+
+/** Map Railway's sandbox status onto the ComputeSDK status enum. */
+function mapStatus(status: string): SandboxInfo['status'] {
+  switch (status) {
+    case 'RUNNING':
+    case 'CREATING':
+      return 'running';
+    case 'DESTROYING':
+    case 'DESTROYED':
+      return 'stopped';
+    case 'FAILED':
+      return 'error';
+    default:
+      return 'running';
+  }
+}
+
+/** Apply env/cwd/background options by composing a single shell command string. */
+function composeCommand(command: string, options?: RunCommandOptions): string {
+  let fullCommand = command;
+
+  if (options?.env && Object.keys(options.env).length > 0) {
+    const envPrefix = Object.entries(options.env)
+      .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+      .join(' ');
+    fullCommand = `${envPrefix} ${fullCommand}`;
+  }
+
+  if (options?.cwd) {
+    fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+  }
+
+  if (options?.background) {
+    fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
+  }
+
+  return fullCommand;
+}
+
+export const railway = defineProvider<RailwaySandbox, RailwayConfig>({
+  name: 'railway',
+  methods: {
+    sandbox: {
+      create: async (config: RailwayConfig, options?: CreateSandboxOptions) => {
+        const client = resolveClientOptions(config);
+
+        try {
+          const sandbox = await Sandbox.create({
+            token: client.token,
+            environmentId: client.environmentId,
+            ...(options?.envs ? { env: options.envs } : {}),
+            ...(options?.idleTimeoutMinutes !== undefined
+              ? { idleTimeoutMinutes: options.idleTimeoutMinutes }
+              : {}),
+            ...(options?.networkIsolation !== undefined
+              ? { networkIsolation: options.networkIsolation }
+              : {}),
+          });
+
+          return { sandbox, sandboxId: sandbox.id };
+        } catch (error) {
+          throw new Error(
+            `Failed to create Railway sandbox: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      },
+
+      getById: async (config: RailwayConfig, sandboxId: string) => {
+        const client = resolveClientOptions(config);
+        try {
+          const sandbox = await Sandbox.connect(sandboxId, client);
+          return { sandbox, sandboxId };
+        } catch (error) {
+          if (error instanceof SandboxNotFoundError) return null;
+          return null;
+        }
+      },
+
+      list: async (config: RailwayConfig) => {
+        const client = resolveClientOptions(config);
+        try {
+          const infos = await Sandbox.list(client);
+          const connected = await Promise.allSettled(
+            infos.map(async (info) => {
+              const sandbox = await Sandbox.connect(info.id, client);
+              return { sandbox, sandboxId: info.id };
+            })
+          );
+          return connected
+            .filter(
+              (r): r is PromiseFulfilledResult<{ sandbox: RailwaySandbox; sandboxId: string }> =>
+                r.status === 'fulfilled'
+            )
+            .map((r) => r.value);
+        } catch {
+          return [];
+        }
+      },
+
+      destroy: async (config: RailwayConfig, sandboxId: string) => {
+        const client = resolveClientOptions(config);
+        try {
+          const sandbox = await Sandbox.connect(sandboxId, client);
+          await sandbox.destroy();
+        } catch {
+          /* already destroyed or unreachable */
+        }
+      },
+
+      runCommand: async (
+        sandbox: RailwaySandbox,
+        command: string,
+        options?: RunCommandOptions
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+        const fullCommand = composeCommand(command, options);
+        const timeoutSec = options?.timeout ? Math.ceil(options.timeout / 1000) : undefined;
+
+        try {
+          const result = await sandbox.exec(
+            fullCommand,
+            timeoutSec ? { timeoutSec } : undefined
+          );
+          return {
+            stdout: result.stdout,
+            stderr: result.stderr,
+            // exitCode is null when a signal ended the command; surface as -1
+            exitCode: result.exitCode ?? -1,
+            durationMs: Date.now() - startTime,
+          };
+        } catch (error) {
+          return {
+            stdout: '',
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: 127,
+            durationMs: Date.now() - startTime,
+          };
+        }
+      },
+
+      getInfo: async (sandbox: RailwaySandbox): Promise<SandboxInfo> => ({
+        id: sandbox.id,
+        provider: 'railway',
+        status: mapStatus(sandbox.status),
+        createdAt: new Date(sandbox.createdAt),
+        timeout: DEFAULT_TIMEOUT_MS,
+        metadata: { networkIsolation: sandbox.networkIsolation },
+      }),
+
+      getUrl: async (_sandbox: RailwaySandbox, _options: { port: number; protocol?: string }): Promise<string> => {
+        throw new Error(
+          'Railway sandboxes do not support exposing ports / public URLs. ' +
+            'Use sandbox-to-sandbox networking within a Railway environment instead.'
+        );
+      },
+
+      filesystem: {
+        readFile: async (sandbox: RailwaySandbox, path: string, runCommand: CommandRunner): Promise<string> => {
+          const arg = escapeShellArg(path);
+          const result = await runCommand(sandbox, `test -f "${arg}" && base64 < "${arg}" | tr -d '\\n'`);
+          if (result.exitCode !== 0) throw new Error(`File not found or unreadable: ${path}`);
+          return Buffer.from(result.stdout, 'base64').toString('utf8');
+        },
+
+        writeFile: async (sandbox: RailwaySandbox, path: string, content: string, runCommand: CommandRunner): Promise<void> => {
+          const arg = escapeShellArg(path);
+          const encoded = Buffer.from(content).toString('base64');
+          const result = await runCommand(sandbox, `echo "${encoded}" | base64 -d > "${arg}"`);
+          if (result.exitCode !== 0) throw new Error(`Failed to write file ${path}: ${result.stderr}`);
+        },
+
+        mkdir: async (sandbox: RailwaySandbox, path: string, runCommand: CommandRunner): Promise<void> => {
+          const result = await runCommand(sandbox, `mkdir -p "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
+        },
+
+        readdir: async (sandbox: RailwaySandbox, path: string, runCommand: CommandRunner): Promise<FileEntry[]> => {
+          const result = await runCommand(sandbox, `ls -la "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
+
+          return (result.stdout || '')
+            .split('\n')
+            .filter((line) => line.trim() && !line.startsWith('total'))
+            .map((line) => {
+              const parts = line.trim().split(/\s+/);
+              const name = parts[parts.length - 1];
+              const isDirectory = line.startsWith('d');
+              return {
+                name,
+                type: isDirectory ? ('directory' as const) : ('file' as const),
+                size: parseInt(parts[4]) || 0,
+                modified: new Date(),
+              };
+            })
+            .filter((entry) => entry.name !== '.' && entry.name !== '..');
+        },
+
+        exists: async (sandbox: RailwaySandbox, path: string, runCommand: CommandRunner): Promise<boolean> => {
+          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          return result.exitCode === 0;
+        },
+
+        remove: async (sandbox: RailwaySandbox, path: string, runCommand: CommandRunner): Promise<void> => {
+          const result = await runCommand(sandbox, `rm -rf "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Failed to remove ${path}: ${result.stderr}`);
+        },
+      },
+
+      getInstance: (sandbox: RailwaySandbox): RailwaySandbox => sandbox,
+    },
+  },
+});
+
+export type { Sandbox as RailwaySandbox } from 'railway';

--- a/packages/railway/tsconfig.json
+++ b/packages/railway/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+} 

--- a/packages/railway/tsup.config.ts
+++ b/packages/railway/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+}) 

--- a/packages/railway/vitest.config.ts
+++ b/packages/railway/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+	globals: true,
+	environment: 'node',
+	coverage: {
+	  reporter: ['text', 'json', 'html'],
+	  exclude: [
+		'node_modules/',
+		'dist/',
+		'**/*.d.ts',
+		'**/*.config.*'
+	  ]
+	}
+  },
+  resolve: {
+	alias: {
+	  '@': path.resolve(__dirname, './src')
+	}
+  }
+}) 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1309,6 +1309,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/railway:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+      railway:
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/runloop:
     dependencies:
       '@computesdk/provider':
@@ -2990,6 +3027,11 @@ packages:
 
   '@freestyle-sh/with-type-run-code@0.2.8':
     resolution: {integrity: sha512-xvtZRlWJWS5a+q6iLEY1T1dy8z2PIT3y1q81fm+jxR9rj4V+a71QvueYyOmfZgrq1oigvbDQx1F6R04DMnxTPA==}
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
@@ -5852,6 +5894,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -7073,6 +7119,11 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  railway@3.1.1:
+    resolution: {integrity: sha512-Oy2F5oIey8KXFJwlka618J/pX0Qi+0kGvfH88eaJNb8C5O0Ba9CcVxguanN6MZEI1sXGMfFp2i3GKvNXQDoM2Q==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -9938,6 +9989,10 @@ snapshots:
   '@freestyle-sh/with-type-run-code@0.2.8':
     dependencies:
       freestyle-sandboxes: 0.1.34
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
+    dependencies:
+      graphql: 16.14.2
 
   '@grpc/grpc-js@1.13.4':
     dependencies:
@@ -13707,6 +13762,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.14.2: {}
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -14969,6 +15026,12 @@ snapshots:
     optional: true
 
   queue-microtask@1.2.3: {}
+
+  railway@3.1.1:
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      graphql: 16.14.2
+      tsx: 4.20.3
 
   randombytes@2.1.0:
     dependencies:


### PR DESCRIPTION
## Provider: `@computesdk/railway`

**What is it?** [Railway Sandboxes](https://docs.railway.com/sandboxes) — ephemeral compute environments on the Railway platform for running shell commands.

**Underlying SDK / API:** [`railway`](https://www.npmjs.com/package/railway) `^3.1.1` (official Railway TypeScript SDK, `Sandbox` API).

**Credentials:** `RAILWAY_API_TOKEN` (or `token` config) and `RAILWAY_ENVIRONMENT_ID` (or `environmentId` config). Tokens are created in the Railway dashboard.

### Capabilities

| Capability | Supported? | Notes |
|---|---|---|
| `runCommand` (required) | ✅ | Backed by `sandbox.exec`; `timeout` (ms) mapped to Railway's `timeoutSec`. |
| Filesystem | ✅ | Implemented over the shell (`cat`/`base64`/`mkdir`/`ls`/`rm`) since Railway has no dedicated filesystem API. |
| `getUrl` (port exposure) | ❌ | Railway sandboxes do not expose public per-port URLs. |
| `list` | ✅ | Enumerates sandboxes in the configured environment. |
| Templates | ❌ | Railway templates are a build-time builder (`Sandbox.template()`), not an ID-addressable resource. |
| Snapshots | ❌ | No ID-addressable snapshot resource (`fork()` exists but doesn't map to ComputeSDK snapshots). |

> Unsupported methods are defined but throw a clear "not supported" error — they are not omitted.

### Checklist

- [x] New `packages/railway/` package with `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, `README.md`, and `src/`
- [x] Core sandbox methods implemented: `create`, `getById`, `destroy`, `runCommand`, `getInfo`
- [x] Config validated early with a helpful error; env-var fallback supported
- [x] Shell interpolation uses `escapeShellArg` wrapped in double quotes
- [x] Tests via `runProviderTestSuite` (unit pass; integration gated on credentials)
- [x] `pnpm build` passes
- [x] `pnpm --filter @computesdk/railway run typecheck` passes
- [x] `pnpm --filter @computesdk/railway run lint` passes
- [x] Root `README.md` "Supported Providers" table updated (and install list)
- [x] Changeset added (`patch`)

### Notes for reviewers

- **Verified live:** the full suite (14/14) passes against the real Railway Sandboxes API — create/exec/filesystem/list/destroy.
- **Token types:** auth-scheme selection (bearer vs project-token) is intentionally left to the Railway SDK; the provider just forwards `token`/`environmentId`. Note that command `exec` requires a token authorized for it (project tokens can manage sandboxes but may not exec) — this is a Railway-side concern.
- **No port exposure / templates / snapshots:** these throw clear "not supported" errors, matching Railway's current sandbox surface.
