### PR TITLE
Fix @computesdk/railway publish (republish as 2.0.0)

### DIFF
--- a/.changeset/railway-republish.md
+++ b/.changeset/railway-republish.md
@@ -1,0 +1,10 @@
+---
+"@computesdk/railway": major
+---
+
+Republish @computesdk/railway as a real sandbox provider.
+
+The 1.x line on npm (up to 1.2.2) was a non-functional placeholder. This release
+ships the actual Railway Sandboxes provider (command execution, shell-based
+filesystem, list/get/destroy). The package baseline is realigned to the current
+npm version and bumped to 2.0.0 so the published implementation takes effect.

--- a/packages/railway/package.json
+++ b/packages/railway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@computesdk/railway",
-  "version": "1.0.1",
+  "version": "1.2.2",
   "description": "Railway Sandboxes provider for ComputeSDK - run commands in Railway-hosted sandboxes",
   "author": "ComputeSDK",
   "license": "MIT",


### PR DESCRIPTION
## Problem

`@computesdk/railway` was merged (#577) at version `1.0.0`, but the npm registry already had `@computesdk/railway` published up to **1.2.2** — leftovers from the old non-functional placeholder package. The release therefore tried to publish `1.0.1`, which already exists, so the **real provider never got published** (silent no-op). See https://www.npmjs.com/package/@computesdk/railway.

## Fix

- Realign `packages/railway/package.json` to the current npm baseline (`1.2.2`).
- Add a **major** changeset so the next release publishes the real implementation as **2.0.0** (clean break from the defunct placeholder line).

## Scope / safety

- Only `@computesdk/railway` is bumped. `.changeset/config.json` has empty `fixed`/`linked`, and nothing depends on `@computesdk/railway` (dependency direction is railway → `computesdk`, not the reverse), so **no other package — including `computesdk` core — is affected.**
