### PR TITLE
Update Blaxel provider to @blaxel/core 0.2.89

### DIFF
--- a/.changeset/bright-bikes-learn.md
+++ b/.changeset/bright-bikes-learn.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/blaxel": patch
+---
+
+Update @blaxel/core to 0.2.89.

--- a/packages/blaxel/package.json
+++ b/packages/blaxel/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@blaxel/core": "^0.2.75",
+    "@blaxel/core": "^0.2.89",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,8 +270,8 @@ importers:
   packages/blaxel:
     dependencies:
       '@blaxel/core':
-        specifier: ^0.2.75
-        version: 0.2.75(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^0.2.89
+        version: 0.2.89(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2163,8 +2163,8 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
 
-  '@blaxel/core@0.2.75':
-    resolution: {integrity: sha512-EvRVFEqMn8wZ0iJaUhRvqquU4vSfYcUrsmm9mIbCpY36C1wh9C2qBuPZlPRmEf8O+VAfVD6gr1VXYNXofZq5BA==}
+  '@blaxel/core@0.2.89':
+    resolution: {integrity: sha512-2lWvXqpJ+tFqIroHvDahrlKnu0dSlleE4kQihX9xrULVVlMGqIPjOWDFs56YU3FMSd0yviG9P+wjqBWVV1vXGQ==}
     engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.1':
@@ -9270,7 +9270,7 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@blaxel/core@0.2.75(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@blaxel/core@0.2.89(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@hey-api/client-fetch': 0.10.2(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)


### PR DESCRIPTION
Updates the Blaxel provider to test against the current @blaxel/core release instead of the older 0.2.75 lockfile version.

This keeps ComputeSDK’s dev and CI path aligned with what fresh installs already resolve from the provider’s caret dependency.

Local package build, Blaxel provider tests, and packed artifact import checks passed.