### PR TITLE
fix(bench): coalesce worker readiness and heartbeats

### DIFF
--- a/.changeset/bench-runtime-artifacts.md
+++ b/.changeset/bench-runtime-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/bench": patch
+---
+
+Release benchmark worker heartbeat coalescing fixes and artifact upload response typing.

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -355,7 +355,10 @@ describe('createBenchmarkClient', () => {
       }
       if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
       if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
-      if (url.endsWith('/heartbeat')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      if (url.endsWith('/heartbeat')) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      }
       throw new Error(`unexpected request: ${url}`);
     });
 
@@ -375,6 +378,64 @@ describe('createBenchmarkClient', () => {
     expect(order).toEqual(['progress', 'step']);
     expect(seen.some((entry) => entry.url.endsWith('/heartbeat') && (entry.body as any).currentStep === 'pause')).toBe(true);
     expect(seen.some((entry) => entry.url.endsWith('/heartbeat') && (entry.body as any).concurrency?.[0]?.target === 1)).toBe(true);
+  });
+
+  it('deduplicates readiness polling across concurrent tasks for the same step', async () => {
+    const order: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 4, count: 5 }, targetConcurrency: 5 }) });
+      if (url.endsWith('/progress')) {
+        order.push('progress');
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return jsonResponse(progressResponse());
+      }
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      if (url.endsWith('/heartbeat')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task: defineTask('dedupe-readiness', [
+        defineStep('pause', { readiness: 'poll', readyPollIntervalMs: 1 }, () => undefined),
+      ]),
+    });
+
+    expect(order).toEqual(['progress']);
+  });
+
+  it('caps heartbeat concurrency samples to the platform limit', async () => {
+    const seen: Array<{ url: string; body: unknown }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      seen.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 }, targetConcurrency: 1 }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      if (url.endsWith('/heartbeat')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task: async ({ taskIndex, step }) => {
+        await Promise.all(Array.from({ length: 25 }, (_, index) => (
+          step(`step-${index}`, () => new Promise((resolve) => setTimeout(resolve, 5)))
+        )));
+      },
+    });
+
+    const heartbeat = seen.find((entry) => entry.url.endsWith('/heartbeat') && (entry.body as any).concurrency?.length === 20);
+    expect((heartbeat?.body as any).concurrency).toHaveLength(20);
+    expect((heartbeat?.body as any).currentStep).toBe('step-0');
   });
 
   it('only polls progress for explicitly polled steps', async () => {

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -434,6 +434,7 @@ describe('createBenchmarkClient', () => {
     });
 
     const heartbeat = seen.find((entry) => entry.url.endsWith('/heartbeat') && (entry.body as any).concurrency?.length === 20);
+    expect(heartbeat).toBeDefined();
     expect((heartbeat?.body as any).concurrency).toHaveLength(20);
     expect((heartbeat?.body as any).currentStep).toBe('step-0');
   });

--- a/packages/bench/src/client.ts
+++ b/packages/bench/src/client.ts
@@ -492,6 +492,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       const taskIndices = Array.from({ length: claimed.taskRange.count }, (_, index) => claimed.taskRange.start + index);
       const activeByStep = new Map<string, number>();
       const targetByStep = new Map<string, number>();
+      const readyWaitByStep = new Map<string, Promise<void>>();
       let doneCount = 0;
       let errorCount = 0;
       let inFlightCount = 0;
@@ -504,11 +505,13 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
             step,
             active,
             target: targetByStep.get(step) ?? workerConcurrency,
-          }));
+          }))
+          .sort((a, b) => b.active - a.active)
+          .slice(0, MAX_HEARTBEAT_CONCURRENCY_SAMPLES);
       }
 
       function currentStep(): string | null {
-        const sample = concurrencySamples().sort((a, b) => b.active - a.active)[0];
+        const sample = concurrencySamples()[0];
         return sample?.step ?? null;
       }
 
@@ -543,7 +546,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
         });
       }
 
-      async function waitForStepReady(stepName: string, stepOptions: DefineStepOptions): Promise<void> {
+      async function pollStepReady(stepName: string, stepOptions: DefineStepOptions): Promise<void> {
         const startedAt = Date.now();
         const pollInterval = stepOptions.readyPollIntervalMs ?? options.readyPollIntervalMs ?? DEFAULT_READY_POLL_INTERVAL_MS;
 
@@ -561,8 +564,19 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
         }
       }
 
+      async function waitForStepReady(stepName: string, stepOptions: DefineStepOptions): Promise<void> {
+        const existing = readyWaitByStep.get(stepName);
+        if (existing) return existing;
+
+        const wait = pollStepReady(stepName, stepOptions).finally(() => {
+          if (readyWaitByStep.get(stepName) === wait) readyWaitByStep.delete(stepName);
+        });
+        readyWaitByStep.set(stepName, wait);
+        return wait;
+      }
+
       const heartbeat = setInterval(() => {
-        void sendHeartbeat().catch(() => {});
+        requestHeartbeat();
       }, options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS);
       heartbeat.unref?.();
 

--- a/packages/bench/src/client.ts
+++ b/packages/bench/src/client.ts
@@ -510,13 +510,9 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
           .slice(0, MAX_HEARTBEAT_CONCURRENCY_SAMPLES);
       }
 
-      function currentStep(): string | null {
-        const sample = concurrencySamples()[0];
-        return sample?.step ?? null;
-      }
-
       async function sendHeartbeat(): Promise<void> {
-        const step = currentStep();
+        const concurrency = concurrencySamples();
+        const step = concurrency[0]?.step ?? null;
         await client.heartbeatWorker(options.benchmarkSlug, options.runId, claimed.workerId, {
           attemptId: claimed.attemptId,
           progressDone: doneCount,
@@ -524,7 +520,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
           progressErrors: errorCount,
           progressTotal: taskIndices.length,
           ...(step ? { currentStep: step } : {}),
-          concurrency: concurrencySamples(),
+          concurrency,
         });
       }
 


### PR DESCRIPTION
## Summary
- dedupe readiness polling per worker step so concurrent tasks share one progress poll
- cap heartbeat concurrency samples at the platform limit and keep currentStep derived from the sorted sample
- route interval heartbeats through the existing coalescing helper

## Tests
- pnpm --filter '@computesdk/bench' run test
- pnpm --filter '@computesdk/bench' run typecheck