### PR TITLE
test(bench): require artifact smoke coverage

### DIFF
--- a/packages/bench/src/__tests__/capabilities.test.ts
+++ b/packages/bench/src/__tests__/capabilities.test.ts
@@ -12,7 +12,7 @@ function isOptionalCapabilityMissing(error: unknown): boolean {
   return error instanceof BenchmarkApiError && [404, 405, 501].includes(error.status);
 }
 
-async function probeCapability<T>(name: string, fn: () => Promise<T>): Promise<T | undefined> {
+async function probeOptionalCapability<T>(name: string, fn: () => Promise<T>): Promise<T | undefined> {
   try {
     const result = await fn();
     console.info(`Bench orchestrator capability "${name}" is available.`);
@@ -26,8 +26,12 @@ async function probeCapability<T>(name: string, fn: () => Promise<T>): Promise<T
   }
 }
 
-describeCapabilities('benchmark orchestrator optional capabilities', () => {
-  it('reports artifact and release endpoint availability', async () => {
+function artifactIdOf(artifact: { id?: string; artifactId?: string }): string | undefined {
+  return artifact.artifactId ?? artifact.id;
+}
+
+describeCapabilities('benchmark orchestrator capabilities', () => {
+  it('requires artifact endpoints and reports release availability', async () => {
     const baseUrl = process.env.COMPUTESDK_BENCH_BASE_URL;
     const slug = `sdk-capabilities-${Date.now()}`;
     const participantSlug = 'just-bash';
@@ -61,21 +65,23 @@ describeCapabilities('benchmark orchestrator optional capabilities', () => {
       expect(assignment).not.toBeNull();
       if (!assignment) return;
 
-      const artifact = await probeCapability('worker artifacts create', () => client.createWorkerArtifact(slug, run.id, assignment.workerId, {
+      const artifact = await client.createWorkerArtifact(slug, run.id, assignment.workerId, {
         attemptId: assignment.attemptId,
         kind: 'meta.json',
         contentType: 'application/json',
         metadata: { source: '@computesdk/bench', capabilitySmoke: true },
-      }));
-      if (artifact) expect(artifact.artifactId ?? artifact.artifact?.artifactId ?? artifact.artifact?.id).toEqual(expect.any(String));
+      });
+      const artifactId = artifact.artifactId ?? (artifact.artifact ? artifactIdOf(artifact.artifact) : undefined);
+      expect(artifactId).toEqual(expect.any(String));
+      expect(artifact.objectKey ?? artifact.artifact?.objectKey).toEqual(expect.any(String));
 
-      const runArtifacts = await probeCapability('run artifacts list', () => client.listRunArtifacts(slug, run.id));
-      if (runArtifacts) expect(Array.isArray(runArtifacts)).toBe(true);
+      const runArtifacts = await client.listRunArtifacts(slug, run.id);
+      expect(runArtifacts.some((item) => artifactIdOf(item) === artifactId)).toBe(true);
 
-      const workerArtifacts = await probeCapability('worker artifacts list', () => client.listWorkerArtifacts(slug, run.id, assignment.workerId));
-      if (workerArtifacts) expect(Array.isArray(workerArtifacts)).toBe(true);
+      const workerArtifacts = await client.listWorkerArtifacts(slug, run.id, assignment.workerId);
+      expect(workerArtifacts.some((item) => artifactIdOf(item) === artifactId)).toBe(true);
 
-      const releaseResult = await probeCapability('worker release', () => client.releaseWorker(slug, run.id, assignment.workerId, assignment.attemptId));
+      const releaseResult = await probeOptionalCapability('worker release', () => client.releaseWorker(slug, run.id, assignment.workerId, assignment.attemptId));
       if (releaseResult) {
         expect(releaseResult.worker.id).toBe(assignment.workerId);
       } else {

--- a/packages/bench/src/__tests__/capabilities.test.ts
+++ b/packages/bench/src/__tests__/capabilities.test.ts
@@ -35,6 +35,7 @@ describeCapabilities('benchmark orchestrator capabilities', () => {
     const baseUrl = process.env.COMPUTESDK_BENCH_BASE_URL;
     const slug = `sdk-capabilities-${Date.now()}`;
     const participantSlug = 'just-bash';
+    const artifactName = 'sdk-capability-smoke-meta.json';
     const client = createBenchmarkClient({ baseUrl });
 
     try {
@@ -68,18 +69,30 @@ describeCapabilities('benchmark orchestrator capabilities', () => {
       const artifact = await client.createWorkerArtifact(slug, run.id, assignment.workerId, {
         attemptId: assignment.attemptId,
         kind: 'meta.json',
+        name: artifactName,
         contentType: 'application/json',
         metadata: { source: '@computesdk/bench', capabilitySmoke: true },
       });
       const artifactId = artifact.artifactId ?? (artifact.artifact ? artifactIdOf(artifact.artifact) : undefined);
+      const uploadUrl = artifact.uploadUrl ?? artifact.artifact?.uploadUrl;
       expect(artifactId).toEqual(expect.any(String));
       expect(artifact.objectKey ?? artifact.artifact?.objectKey).toEqual(expect.any(String));
+      expect(uploadUrl).toEqual(expect.any(String));
+
+      const uploadResponse = await fetch(uploadUrl!, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ source: '@computesdk/bench', capabilitySmoke: true, runId: run.id }),
+      });
+      expect(uploadResponse.ok, await uploadResponse.text()).toBe(true);
 
       const runArtifacts = await client.listRunArtifacts(slug, run.id);
       expect(runArtifacts.some((item) => artifactIdOf(item) === artifactId)).toBe(true);
+      expect(runArtifacts.some((item) => artifactIdOf(item) === artifactId && item.name === artifactName)).toBe(true);
 
       const workerArtifacts = await client.listWorkerArtifacts(slug, run.id, assignment.workerId);
       expect(workerArtifacts.some((item) => artifactIdOf(item) === artifactId)).toBe(true);
+      expect(workerArtifacts.some((item) => artifactIdOf(item) === artifactId && item.name === artifactName)).toBe(true);
 
       const releaseResult = await probeOptionalCapability('worker release', () => client.releaseWorker(slug, run.id, assignment.workerId, assignment.attemptId));
       if (releaseResult) {

--- a/packages/bench/src/__tests__/capabilities.test.ts
+++ b/packages/bench/src/__tests__/capabilities.test.ts
@@ -75,9 +75,11 @@ describeCapabilities('benchmark orchestrator capabilities', () => {
       });
       const artifactId = artifact.artifactId ?? (artifact.artifact ? artifactIdOf(artifact.artifact) : undefined);
       const uploadUrl = artifact.uploadUrl ?? artifact.artifact?.uploadUrl;
+      const uploadUrlExpiresAt = artifact.uploadUrlExpiresAt ?? artifact.artifact?.uploadUrlExpiresAt;
       expect(artifactId).toEqual(expect.any(String));
       expect(artifact.objectKey ?? artifact.artifact?.objectKey).toEqual(expect.any(String));
       expect(uploadUrl).toEqual(expect.any(String));
+      expect(uploadUrlExpiresAt).toEqual(expect.any(String));
 
       const uploadResponse = await fetch(uploadUrl!, {
         method: 'PUT',

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -221,6 +221,7 @@ export interface BenchmarkArtifact {
   contentType?: string | null;
   objectKey?: string;
   uploadUrl?: string;
+  uploadUrlExpiresAt?: string;
   metadata?: JsonObject;
   createdAt?: string;
 }
@@ -229,6 +230,7 @@ export interface CreateWorkerArtifactResponse {
   artifact?: BenchmarkArtifact;
   artifactId?: string;
   uploadUrl?: string;
+  uploadUrlExpiresAt?: string;
   objectKey?: string;
 }
 


### PR DESCRIPTION
## Summary
- require the bench capabilities smoke to create a worker artifact
- require the created artifact to appear in run-level and worker-level artifact listings
- keep worker release as an optional probed capability

## Platform dependency
- Exercises artifact endpoints added in computesdk/benchmarks-platform#25

## Tests
- pnpm --filter '@computesdk/bench' run test:capabilities (skipped locally without API key)
- pnpm --filter '@computesdk/bench' run typecheck
- pnpm --filter '@computesdk/bench' run test