### PR TITLE
[codex] Bump Tensorlake TypeScript SDK

### DIFF
--- a/packages/tensorlake/package.json
+++ b/packages/tensorlake/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*",
-    "tensorlake": "0.5.33"
+    "tensorlake": "0.5.40"
   },
   "devDependencies": {
     "@computesdk/test-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1539,8 +1539,8 @@ importers:
         specifier: workspace:*
         version: link:../computesdk
       tensorlake:
-        specifier: 0.5.33
-        version: 0.5.33(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 0.5.40
+        version: 0.5.40(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -7649,8 +7649,8 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  tensorlake@0.5.33:
-    resolution: {integrity: sha512-9TX/hKkEL7w6tbZy/yKAJ522Fps9kMkGcoCKibb4XT7OANmwdS3A5GLLsq4ufkVeSxQjaswnmVUoghzFzF1XtQ==}
+  tensorlake@0.5.40:
+    resolution: {integrity: sha512-ljmSDBfwOhzWDhag5lc5YfIEj0mfAt8n0eZG1lyfXv8xUaNtIQXv5WlzVc2vm0c11mU74hbY8v7g31ic3qwOSA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -15709,7 +15709,7 @@ snapshots:
       - bare-abort-controller
     optional: true
 
-  tensorlake@0.5.33(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  tensorlake@0.5.40(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       undici: 8.3.0
       ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)


### PR DESCRIPTION
This is stale

## Summary

- Bump the `@computesdk/tensorlake` provider's `tensorlake` dependency from `0.5.33` to `0.5.40`.
- Update the pnpm lockfile entry for the Tensorlake SDK without unrelated lockfile churn.
- Confirmed `tensorlake@0.5.40` includes the Rust native core via packaged `dist/native/*/tensorlake-node.node` bindings.

## Validation

- `pnpm install --lockfile-only --offline --frozen-lockfile`
- `pnpm --filter @computesdk/tensorlake typecheck`
- Loaded `tensorlake@0.5.40` native binding locally and verified exports: `NativeSandboxClient`, `NativeSandboxProxyClient`, `buildSandboxImage`

## Notes

- `pnpm --filter @computesdk/tensorlake test` was attempted earlier, but the suite creates live Tensorlake sandboxes at `https://sandbox.tensorlake.ai/sandboxes` and failed in this environment before exercising provider behavior.