### PR TITLE
feat(bench): add worker lifecycle utilities

### DIFF
--- a/.changeset/clean-bench-tasks.md
+++ b/.changeset/clean-bench-tasks.md
@@ -2,4 +2,4 @@
 "@computesdk/bench": patch
 ---
 
-Add defined task cleanup hooks for tearing down resources after success or failure, plus a worker artifact upload helper for logs and result files.
+Add defined task cleanup hooks, worker artifact upload helpers, a best-effort benchmark reporter for custom coordinators, reusable barrier polling, and system metrics sampling utilities.

--- a/.changeset/clean-bench-tasks.md
+++ b/.changeset/clean-bench-tasks.md
@@ -2,4 +2,4 @@
 "@computesdk/bench": patch
 ---
 
-Add defined task cleanup hooks, worker artifact upload helpers, a best-effort benchmark reporter for custom coordinators, reusable barrier polling, and system metrics sampling utilities.
+Add defined task cleanup hooks, worker finish hooks for one-time log uploads, worker artifact upload helpers, a best-effort benchmark reporter for custom coordinators, reusable barrier polling, and system metrics sampling utilities.

--- a/.changeset/clean-bench-tasks.md
+++ b/.changeset/clean-bench-tasks.md
@@ -2,4 +2,4 @@
 "@computesdk/bench": patch
 ---
 
-Add defined task cleanup hooks for tearing down resources after success or failure.
+Add defined task cleanup hooks for tearing down resources after success or failure, plus a worker artifact upload helper for logs and result files.

--- a/.changeset/clean-bench-tasks.md
+++ b/.changeset/clean-bench-tasks.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/bench": patch
+---
+
+Add defined task cleanup hooks for tearing down resources after success or failure.

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -225,6 +225,25 @@ await reporter?.finish(false);
 
 `BenchmarkReporter` swallows platform telemetry failures for claim, heartbeat, result flushing, artifact upload, and finish calls. Benchmark work can continue even when reporting is temporarily unavailable.
 
+For `defineWorker` / `runWorker`, use `onFinish` to upload worker-level logs once, after final task results are flushed and before the worker attempt is completed or failed:
+
+```ts
+defineWorker({
+  benchmarkSlug: 'scale',
+  runId,
+  participantSlug: 'e2b',
+  task,
+  onFinish: async ({ uploadArtifact }) => {
+    await uploadArtifact({
+      kind: 'log',
+      name: 'coordinator.log',
+      contentType: 'text/plain; charset=utf-8',
+      body: logText,
+    });
+  },
+});
+```
+
 For coordinator health artifacts, sample system metrics:
 
 ```ts

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -138,11 +138,15 @@ If a step returns a JSON object, it is merged into the task result `data` object
 | `cleanup` | `(context) => Promise<void> \| void` | Runs after the task finishes, whether steps succeeded or failed. Use shared `state` to tear down resources created by earlier steps. |
 
 ```ts
-defineTask('sandbox.lifecycle', [
-  defineStep('create', async ({ state }) => {
+type SandboxState = {
+  sandbox?: Awaited<ReturnType<typeof compute.sandbox.create>>;
+};
+
+defineTask<SandboxState>('sandbox.lifecycle', [
+  defineStep<SandboxState>('create', async ({ state }) => {
     state.sandbox = await compute.sandbox.create();
   }),
-  defineStep('exec', async ({ state }) => {
+  defineStep<SandboxState>('exec', async ({ state }) => {
     await state.sandbox.runCommand('node -v');
   }),
 ], {

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -173,6 +173,13 @@ client.getWorker(benchmarkSlug, runId, workerId)
 client.updateWorker(benchmarkSlug, runId, workerId, input)
 client.claimWorker(benchmarkSlug, runId, participantSlug, { processKind, processKey })
 client.sendTaskResults({ benchmarkSlug, runId, workerId, attemptId, sequenceNumber, isFinal, records })
+client.uploadWorkerArtifact(benchmarkSlug, runId, workerId, {
+  attemptId,
+  kind: 'log',
+  name: 'coordinator.log',
+  contentType: 'text/plain; charset=utf-8',
+  body: logText,
+})
 client.heartbeatWorker(benchmarkSlug, runId, workerId, {
   attemptId,
   currentStep: 'pause',

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -131,6 +131,27 @@ Step functions receive:
 
 If a step returns a JSON object, it is merged into the task result `data` object. Defined tasks also include `taskName` in `data`.
 
+`defineTask(name, steps, options)` supports task cleanup:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `cleanup` | `(context) => Promise<void> \| void` | Runs after the task finishes, whether steps succeeded or failed. Use shared `state` to tear down resources created by earlier steps. |
+
+```ts
+defineTask('sandbox.lifecycle', [
+  defineStep('create', async ({ state }) => {
+    state.sandbox = await compute.sandbox.create();
+  }),
+  defineStep('exec', async ({ state }) => {
+    await state.sandbox.runCommand('node -v');
+  }),
+], {
+  cleanup: async ({ state }) => {
+    await state.sandbox?.destroy?.();
+  },
+});
+```
+
 `defineStep(name, options, fn)` supports step-level progress coordination:
 
 | Option | Type | Description |

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -196,6 +196,39 @@ client.failWorker(benchmarkSlug, runId, workerId, attemptId, error)
 client.runWorker(options)
 ```
 
+For custom coordinators that do not fit `defineWorker`, use the best-effort reporter wrapper:
+
+```ts
+const reporter = await BenchmarkReporter.claim({
+  benchmarkSlug: 'scale',
+  runId,
+  participantSlug: 'e2b',
+  processKind: 'container',
+  processKey: instanceId,
+});
+
+reporter?.setProgress({ done, inFlight, errors });
+reporter?.recordResult(record);
+await reporter?.waitForStepReady({ step: 'ready.barrier', timeoutMs: 15 * 60_000 });
+await reporter?.uploadArtifact({
+  kind: 'log',
+  name: 'coordinator.log',
+  contentType: 'text/plain; charset=utf-8',
+  body: logText,
+});
+await reporter?.finish(false);
+```
+
+`BenchmarkReporter` swallows platform telemetry failures for claim, heartbeat, result flushing, artifact upload, and finish calls. Benchmark work can continue even when reporting is temporarily unavailable.
+
+For coordinator health artifacts, sample system metrics:
+
+```ts
+const metrics = createSystemMetricsCollector();
+const samples = [metrics.sample()];
+metrics.stop();
+```
+
 `client.getRunProgress(...)` returns a run summary plus per-participant worker, task, and concurrency progress:
 
 ```ts

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -90,7 +90,13 @@ describe('createBenchmarkClient', () => {
     const seen: Array<{ url: string; body: unknown; method?: string }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      const headers = init?.headers && !Array.isArray(init.headers) && !(init.headers instanceof Headers)
+        ? init.headers as Record<string, string>
+        : {};
+      const contentType = headers['Content-Type'] ?? headers['content-type'];
+      const body = init?.body && contentType === 'application/json'
+        ? JSON.parse(String(init.body))
+        : init?.body;
       seen.push({ url, body, method: init?.method });
 
       if (url.endsWith('/benchmarks/scale/runs') && init?.method === 'POST') {
@@ -124,7 +130,9 @@ describe('createBenchmarkClient', () => {
     const seen: Array<{ url: string; body: unknown; method?: string }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      const body = init?.body && url.startsWith('https://platform.test/')
+        ? JSON.parse(String(init.body))
+        : init?.body;
       seen.push({ url, body, method: init?.method });
 
       if (url.endsWith('/benchmarks/scale') && init?.method === 'PATCH') {
@@ -166,7 +174,7 @@ describe('createBenchmarkClient', () => {
     const seen: Array<{ url: string; body: unknown; method?: string }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
       seen.push({ url, body, method: init?.method });
 
       if (url.endsWith('/participants/e2b/workers/claim')) {
@@ -617,11 +625,14 @@ describe('createBenchmarkClient', () => {
     const seen: Array<{ url: string; body: unknown; method?: string }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
       seen.push({ url, body, method: init?.method });
 
       if (url.endsWith('/workers/worker_1/artifacts') && init?.method === 'POST') {
         return jsonResponse({ artifactId: 'artifact_1', uploadUrl: 'https://upload.test', objectKey: 'benchmarks/bench_1/runs/run_1/artifacts/artifact_1' });
+      }
+      if (url === 'https://upload.test' && init?.method === 'PUT') {
+        return new Response(null, { status: 200 });
       }
       if (url.endsWith('/runs/run_1/artifacts') && init?.method === 'GET') {
         return jsonResponse({ artifacts: [{ artifactId: 'artifact_1', kind: 'coordinator.log' }] });
@@ -666,6 +677,14 @@ describe('createBenchmarkClient', () => {
       kind: 'coordinator.log',
       contentType: 'text/plain',
     })).resolves.toMatchObject({ artifactId: 'artifact_1' });
+    await expect(client.uploadWorkerArtifact('scale', 'run_1', 'worker_1', {
+      attemptId: 'attempt_1',
+      kind: 'log',
+      name: 'coordinator.log',
+      contentType: 'text/plain; charset=utf-8',
+      body: 'hello log\n',
+    })).resolves.toMatchObject({ artifactId: 'artifact_1' });
+    expect((seen[1].body as any).metadata).toMatchObject({ sizeBytes: 10 });
     await expect(client.listRunArtifacts('scale', 'run_1')).resolves.toMatchObject([{ artifactId: 'artifact_1' }]);
     await expect(client.listWorkerArtifacts('scale', 'run_1', 'worker_1')).resolves.toMatchObject([{ artifactId: 'artifact_2' }]);
     await expect(client.getBenchmarkResults('scale', { limit: 5 })).resolves.toMatchObject({
@@ -681,6 +700,8 @@ describe('createBenchmarkClient', () => {
 
     expect(seen.map((entry) => `${entry.method} ${entry.url}`)).toEqual([
       'POST https://platform.test/api/v1/benchmarks/scale/runs/run_1/workers/worker_1/artifacts',
+      'POST https://platform.test/api/v1/benchmarks/scale/runs/run_1/workers/worker_1/artifacts',
+      'PUT https://upload.test',
       'GET https://platform.test/api/v1/benchmarks/scale/runs/run_1/artifacts',
       'GET https://platform.test/api/v1/benchmarks/scale/runs/run_1/workers/worker_1/artifacts',
       'GET https://platform.test/api/v1/benchmarks/scale/results?limit=5',

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -633,10 +633,10 @@ describe('createBenchmarkClient', () => {
         return jsonResponse({
           benchmark: { id: 'bench_1', slug: 'scale', name: 'Scale' },
           generatedAt: new Date().toISOString(),
-          analytics: { status: 'unavailable', query: 'unavailable', error: 'Timeout error.' },
+          analytics: { status: 'complete', query: 'unavailable', error: 'Timeout error.' },
           items: [{
             run: { id: 'run_1' },
-            analytics: { status: 'pending', eventBatches: 1, persisted: 0, queued: 1, failed: 0, imports: { pending: 0, importing: 0, imported: 0, failed: 0, missing: 1 } },
+            analytics: { status: 'complete', eventBatches: 1, persisted: 1, queued: 0, failed: 0, imports: { pending: 0, importing: 0, imported: 1, failed: 0, missing: 0 } },
             participants: [],
           }],
         });
@@ -670,8 +670,8 @@ describe('createBenchmarkClient', () => {
     await expect(client.listWorkerArtifacts('scale', 'run_1', 'worker_1')).resolves.toMatchObject([{ artifactId: 'artifact_2' }]);
     await expect(client.getBenchmarkResults('scale', { limit: 5 })).resolves.toMatchObject({
       benchmark: { slug: 'scale' },
-      analytics: { status: 'unavailable', query: 'unavailable' },
-      items: [{ analytics: { status: 'pending' }, participants: [] }],
+      analytics: { status: 'complete', query: 'unavailable' },
+      items: [{ analytics: { status: 'complete' }, participants: [] }],
     });
     await expect(client.getRunResults('scale', 'run_1')).resolves.toMatchObject({ run: { id: 'run_1' }, participants: [], steps: [] });
     await expect(client.getRunTaskResults('scale', 'run_1', { bucketSize: 10, failureLimit: 2 })).resolves.toMatchObject({ bucketSize: 10, buckets: [], failures: [] });

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -333,6 +333,75 @@ describe('createBenchmarkClient', () => {
     ]);
   });
 
+  it('runs defined task cleanup after a step fails', async () => {
+    const cleaned: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/fail')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    const task = defineTask('sandbox.lifecycle', [
+      defineStep('create', ({ state }) => {
+        state.sandboxId = 'sbx_0';
+      }),
+      defineStep('exec.first-command', () => {
+        throw new TypeError('command failed');
+      }),
+    ], {
+      cleanup: ({ state }) => {
+        cleaned.push(String(state.sandboxId));
+      },
+    });
+
+    const result = await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task,
+    });
+
+    expect(cleaned).toEqual(['sbx_0']);
+    expect(result.records[0]).toMatchObject({ status: 'error', errorCode: 'TypeError' });
+    expect(result.records[0].steps).toMatchObject([
+      { name: 'create', status: 'success' },
+      { name: 'exec.first-command', status: 'error', errorCode: 'TypeError' },
+    ]);
+  });
+
+  it('fails a defined task when cleanup fails after successful steps', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/fail')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    const task = defineTask('cleanup-failure', [
+      defineStep('create', () => ({ sandboxId: 'sbx_0' })),
+    ], {
+      cleanup: () => {
+        throw new Error('destroy failed');
+      },
+    });
+
+    const result = await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task,
+    });
+
+    expect(result.records[0]).toMatchObject({ status: 'error', errorCode: 'Error' });
+    expect(result.records[0].data).toMatchObject({ errorMessage: 'destroy failed' });
+    expect(result.records[0].steps).toMatchObject([{ name: 'create', status: 'success' }]);
+  });
+
   it('rejects duplicate defined task step names', () => {
     expect(() => defineTask('duplicate-steps', [
       defineStep('pause', () => undefined),

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -799,6 +799,37 @@ describe('createBenchmarkClient', () => {
     expect(sample.eventLoopP99Ms).toEqual(expect.any(Number));
   });
 
+  it('runs worker finish hooks before completing the worker', async () => {
+    const seen: Array<{ url: string; body: unknown; method?: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
+      seen.push({ url, body, method: init?.method });
+
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/workers/00000000-0000-4000-8000-000000000002/artifacts')) return jsonResponse({ artifactId: 'artifact_1', uploadUrl: 'https://upload.test' });
+      if (url === 'https://upload.test') return new Response(null, { status: 200 });
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task: () => ({ ok: true }),
+      onFinish: async ({ status, uploadArtifact }) => {
+        expect(status).toBe('success');
+        await uploadArtifact({ kind: 'log', name: 'worker.log', body: 'worker log\n' });
+      },
+    });
+
+    const urls = seen.map((entry) => `${entry.method} ${entry.url}`);
+    expect(urls.indexOf('PUT https://upload.test')).toBeLessThan(urls.findIndex((url) => url.includes('/complete')));
+  });
+
   it('creates workers from a reusable bench definition', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -382,6 +382,38 @@ describe('createBenchmarkClient', () => {
     ]);
   });
 
+  it('preserves the step error when cleanup also fails', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/fail')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    const task = defineTask('cleanup-after-step-failure', [
+      defineStep('create', () => {
+        throw new TypeError('create failed');
+      }),
+    ], {
+      cleanup: () => {
+        throw new Error('destroy failed');
+      },
+    });
+
+    const result = await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task,
+    });
+
+    expect(result.records[0]).toMatchObject({ status: 'error', errorCode: 'TypeError' });
+    expect(result.records[0].data).toMatchObject({ errorMessage: 'create failed' });
+    expect(result.records[0].steps).toMatchObject([{ name: 'create', status: 'error', errorCode: 'TypeError' }]);
+  });
+
   it('fails a defined task when cleanup fails after successful steps', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { BenchmarkApiError, createBenchmarkClient, defineBench, defineStep, defineTask, defineWorker } from '../client';
+import { createSystemMetricsCollector } from '../metrics';
+import { BenchmarkReporter } from '../reporter';
 import type { BenchmarkAssignment } from '../types';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -711,6 +713,58 @@ describe('createBenchmarkClient', () => {
       'GET https://platform.test/api/v1/benchmarks/scale/runs/run_1/results/imports',
       'POST https://platform.test/api/v1/benchmarks/scale/runs/run_1/workers/worker_1/release',
     ]);
+  });
+
+  it('reports custom coordinator progress, barriers, artifacts, and finish best-effort', async () => {
+    const seen: Array<{ url: string; body: unknown; method?: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
+      seen.push({ url, body, method: init?.method });
+
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 5, end: 7, count: 2 }, targetConcurrency: 2 }) });
+      if (url.endsWith('/heartbeat')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      if (url.endsWith('/progress')) return jsonResponse(progressResponse());
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/workers/00000000-0000-4000-8000-000000000002/artifacts')) return jsonResponse({ artifactId: 'artifact_1', uploadUrl: 'https://upload.test' });
+      if (url === 'https://upload.test') return new Response(null, { status: 200 });
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const reporter = await BenchmarkReporter.claim({
+      baseUrl: 'https://platform.test/api/v1',
+      fetch: fetchMock as typeof fetch,
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      batchSize: 1,
+    });
+
+    expect(reporter).not.toBeNull();
+    if (!reporter) return;
+
+    reporter.setProgress({ done: 0, inFlight: 1, errors: 0 });
+    reporter.recordResult({ taskIndex: 5, status: 'success', latencyMs: 1 });
+    await reporter.waitForStepReady({ step: 'pause', timeoutMs: 100, pollIntervalMs: 1 });
+    await expect(reporter.uploadArtifact({ kind: 'log', name: 'coordinator.log', body: 'log\n' })).resolves.toMatchObject({ artifactId: 'artifact_1' });
+    await reporter.finish(false);
+
+    expect(seen.some((entry) => entry.url.endsWith('/heartbeat') && (entry.body as any).currentStep === 'pause')).toBe(true);
+    expect(seen.some((entry) => entry.url.endsWith('/events') && (entry.body as any).records?.[0]?.taskIndex === 5)).toBe(true);
+    expect(seen.some((entry) => entry.url === 'https://upload.test' && entry.method === 'PUT')).toBe(true);
+    expect(seen.at(-1)?.url).toContain('/complete');
+  });
+
+  it('samples system metrics for coordinator artifacts', () => {
+    const collector = createSystemMetricsCollector();
+    const sample = collector.sample();
+    collector.stop();
+
+    expect(sample.ts).toEqual(expect.any(String));
+    expect(sample.uptimeMs).toEqual(expect.any(Number));
+    expect(sample.memRssMb).toBeGreaterThan(0);
+    expect(sample.eventLoopP99Ms).toEqual(expect.any(Number));
   });
 
   it('creates workers from a reusable bench definition', async () => {

--- a/packages/bench/src/__tests__/client.test.ts
+++ b/packages/bench/src/__tests__/client.test.ts
@@ -788,6 +788,42 @@ describe('createBenchmarkClient', () => {
     expect(seen.at(-1)?.url).toContain('/complete');
   });
 
+  it('keeps reporter result batches queued when send fails', async () => {
+    const sentSequences: number[] = [];
+    let sendAttempts = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
+
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 5, end: 7, count: 2 }, targetConcurrency: 2 }) });
+      if (url.endsWith('/events')) {
+        sendAttempts += 1;
+        sentSequences.push((body as any).sequenceNumber);
+        if (sendAttempts === 1) return new Response('temporary failure', { status: 503 });
+        return jsonResponse({ eventBatch: { id: `batch_${sendAttempts}` } }, 202);
+      }
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const reporter = await BenchmarkReporter.claim({
+      baseUrl: 'https://platform.test/api/v1',
+      fetch: fetchMock as typeof fetch,
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      batchSize: 1,
+    });
+
+    expect(reporter).not.toBeNull();
+    if (!reporter) return;
+
+    reporter.recordResult({ taskIndex: 5, status: 'success', latencyMs: 1 });
+    await reporter.finish(false);
+
+    expect(sentSequences).toEqual([0, 0]);
+  });
+
   it('samples system metrics for coordinator artifacts', () => {
     const collector = createSystemMetricsCollector();
     const sample = collector.sample();

--- a/packages/bench/src/__tests__/integration.test.ts
+++ b/packages/bench/src/__tests__/integration.test.ts
@@ -139,11 +139,11 @@ describeIntegration('benchmark orchestrator integration', () => {
 
       const overviewResults = await client.getBenchmarkResults(slug, { limit: 5 });
       expect(overviewResults.benchmark.slug).toBe(slug);
-      expect(['ready', 'partial', 'pending', 'unavailable', 'failed']).toContain(overviewResults.analytics.status);
+      expect(['ready', 'complete', 'partial', 'pending', 'unavailable', 'failed']).toContain(overviewResults.analytics.status);
       expect(['available', 'unavailable']).toContain(overviewResults.analytics.query);
       expect(Array.isArray(overviewResults.items)).toBe(true);
       for (const item of overviewResults.items) {
-        expect(['ready', 'partial', 'pending', 'unavailable', 'failed']).toContain(item.analytics.status);
+        expect(['ready', 'complete', 'partial', 'pending', 'unavailable', 'failed']).toContain(item.analytics.status);
       }
 
       const runResults = await client.getRunResults(slug, run.id);

--- a/packages/bench/src/client.ts
+++ b/packages/bench/src/client.ts
@@ -44,6 +44,7 @@ import type {
   UpdateWorkerInput,
   UpsertBenchmarkInput,
   UpsertParticipantInput,
+  UploadWorkerArtifactInput,
   WorkerConcurrencySample,
   WorkerHeartbeatInput,
 } from './types';
@@ -140,6 +141,15 @@ function validateBatchSize(value: number): void {
 
 function normalizeArtifacts(data: { items?: BenchmarkArtifact[]; artifacts?: BenchmarkArtifact[] }): BenchmarkArtifact[] {
   return data.items ?? data.artifacts ?? [];
+}
+
+function bodySizeBytes(body: UploadWorkerArtifactInput['body']): number | undefined {
+  if (typeof body === 'string') return new TextEncoder().encode(body).byteLength;
+  if (body instanceof Blob) return body.size;
+  if (body instanceof ArrayBuffer) return body.byteLength;
+  if (ArrayBuffer.isView(body)) return body.byteLength;
+  if (body instanceof URLSearchParams) return new TextEncoder().encode(body.toString()).byteLength;
+  return undefined;
 }
 
 function isDefinedTask(task: RunWorkerOptions['task']): task is DefinedTask {
@@ -428,6 +438,36 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
         `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/workers/${encodePath(workerId)}/artifacts`,
         input as unknown as JsonObject,
       );
+    },
+
+    async uploadWorkerArtifact(benchmarkSlug, runId, workerId, input: UploadWorkerArtifactInput) {
+      const sizeBytes = bodySizeBytes(input.body);
+      const artifactInput: CreateWorkerArtifactInput = {
+        attemptId: input.attemptId,
+        kind: input.kind,
+        contentType: input.contentType,
+        name: input.name,
+        metadata: sizeBytes === undefined ? input.metadata : { ...input.metadata, sizeBytes },
+      };
+      const response = await client.createWorkerArtifact(benchmarkSlug, runId, workerId, artifactInput);
+      const uploadUrl = response.uploadUrl ?? response.artifact?.uploadUrl;
+      if (!uploadUrl) {
+        throw new Error('Benchmark artifact upload URL is missing.');
+      }
+      const uploadResponse = await doFetch(uploadUrl, {
+        method: 'PUT',
+        headers: input.contentType ? { 'Content-Type': input.contentType } : undefined,
+        body: input.body,
+      });
+      if (!uploadResponse.ok) {
+        const errorBody = await uploadResponse.text().catch(() => '');
+        throw new BenchmarkApiError(
+          `Benchmark artifact upload failed with ${uploadResponse.status}`,
+          uploadResponse.status,
+          errorBody,
+        );
+      }
+      return response;
     },
 
     async listRunArtifacts(benchmarkSlug, runId) {

--- a/packages/bench/src/client.ts
+++ b/packages/bench/src/client.ts
@@ -655,6 +655,21 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
         await flushChain;
       }
 
+      async function runFinishHook(status: 'success' | 'error'): Promise<void> {
+        await options.onFinish?.({
+          assignment: claimed,
+          records,
+          status,
+          client,
+          uploadArtifact(input) {
+            return client.uploadWorkerArtifact(options.benchmarkSlug, options.runId, claimed.workerId, {
+              ...input,
+              attemptId: claimed.attemptId,
+            });
+          },
+        });
+      }
+
       try {
         await sendHeartbeat().catch(() => {});
 
@@ -738,7 +753,14 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
 
         await flush(true);
 
-        if (records.some((record) => record.status !== 'success')) {
+        const hasErrors = records.some((record) => record.status !== 'success');
+        try {
+          await runFinishHook(hasErrors ? 'error' : 'success');
+        } catch (error) {
+          if (!hasErrors) throw error;
+        }
+
+        if (hasErrors) {
           await client.failWorker(options.benchmarkSlug, options.runId, claimed.workerId, claimed.attemptId, new Error('One or more tasks failed'));
         } else {
           await client.completeWorker(options.benchmarkSlug, options.runId, claimed.workerId, claimed.attemptId);
@@ -747,6 +769,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
         return { assignment: claimed, records };
       } catch (error) {
         await flush(true).catch(() => {});
+        await runFinishHook('error').catch(() => {});
         await client.failWorker(options.benchmarkSlug, options.runId, claimed.workerId, claimed.attemptId, error).catch(() => {});
         throw error;
       } finally {
@@ -817,6 +840,7 @@ export function defineWorker(options: DefineWorkerOptions): BenchmarkWorker {
         batchSize: overrides.batchSize ?? options.batchSize,
         heartbeatIntervalMs: overrides.heartbeatIntervalMs ?? options.heartbeatIntervalMs,
         readyPollIntervalMs: overrides.readyPollIntervalMs ?? options.readyPollIntervalMs,
+        onFinish: options.onFinish,
         task: options.task,
       });
     },
@@ -843,6 +867,7 @@ export function defineBench(options: DefineBenchOptions): BenchDefinition {
         batchSize: workerOptions.batchSize ?? options.batchSize,
         heartbeatIntervalMs: workerOptions.heartbeatIntervalMs ?? options.heartbeatIntervalMs,
         readyPollIntervalMs: workerOptions.readyPollIntervalMs ?? options.readyPollIntervalMs,
+        onFinish: workerOptions.onFinish,
         client: workerOptions.client ?? options.client,
         task: workerOptions.task ?? options.task,
       });

--- a/packages/bench/src/client.ts
+++ b/packages/bench/src/client.ts
@@ -185,13 +185,24 @@ async function runWorkerTask(task: RunWorkerOptions['task'], context: RunWorkerC
       );
       mergeJsonObjects(data, stepData);
     }
-  } finally {
-    await task.options?.cleanup?.({
-      assignment: context.assignment,
-      taskIndex: context.taskIndex,
-      state,
-    });
+  } catch (error) {
+    try {
+      await task.options?.cleanup?.({
+        assignment: context.assignment,
+        taskIndex: context.taskIndex,
+        state,
+      });
+    } catch {
+      // Preserve the task failure as the primary benchmark error.
+    }
+    throw error;
   }
+
+  await task.options?.cleanup?.({
+    assignment: context.assignment,
+    taskIndex: context.taskIndex,
+    state,
+  });
 
   return data;
 }

--- a/packages/bench/src/client.ts
+++ b/packages/bench/src/client.ts
@@ -24,6 +24,7 @@ import type {
   CreateRunInput,
   DefineBenchOptions,
   DefineStepOptions,
+  DefineTaskOptions,
   DefinedStep,
   DefinedTask,
   DefineWorkerOptions,
@@ -161,17 +162,25 @@ async function runWorkerTask(task: RunWorkerOptions['task'], context: RunWorkerC
 
   const state: Record<string, unknown> = {};
   const data: JsonObject = { taskName: task.name };
-  for (const definedStep of task.steps) {
-    const stepData = await context.step(
-      definedStep.name,
-      () => definedStep.fn({
-        assignment: context.assignment,
-        taskIndex: context.taskIndex,
-        state,
-      }),
-      definedStep.options,
-    );
-    mergeJsonObjects(data, stepData);
+  try {
+    for (const definedStep of task.steps) {
+      const stepData = await context.step(
+        definedStep.name,
+        () => definedStep.fn({
+          assignment: context.assignment,
+          taskIndex: context.taskIndex,
+          state,
+        }),
+        definedStep.options,
+      );
+      mergeJsonObjects(data, stepData);
+    }
+  } finally {
+    await task.options?.cleanup?.({
+      assignment: context.assignment,
+      taskIndex: context.taskIndex,
+      state,
+    });
   }
 
   return data;
@@ -724,6 +733,7 @@ export function defineStep<TState extends Record<string, unknown> = Record<strin
 export function defineTask<TState extends Record<string, unknown> = Record<string, unknown>>(
   name: string,
   steps: DefinedStep<TState>[],
+  options?: DefineTaskOptions<TState>,
 ): DefinedTask<TState> {
   if (name.trim() === '') {
     throw new Error('Benchmark task name must be non-empty.');
@@ -738,7 +748,7 @@ export function defineTask<TState extends Record<string, unknown> = Record<strin
     }
     names.add(step.name);
   }
-  return { name, steps };
+  return { name, steps, options };
 }
 
 export function defineWorker(options: DefineWorkerOptions): BenchmarkWorker {

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -76,6 +76,7 @@ export type {
   UpdateRunInput,
   UpdateWorkerInput,
   WorkerConcurrencySample,
+  WorkerFinishContext,
   WorkerHeartbeatInput,
   WorkerTask,
   UpsertBenchmarkInput,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -7,6 +7,8 @@ export {
   defineWorker,
   runBenchmarkWorker,
 } from './client';
+export { BenchmarkReporter, claimBenchmarkReporter } from './reporter';
+export { createSystemMetricsCollector } from './metrics';
 export type {
   BenchDefinition,
   BenchmarkAssignment,
@@ -78,4 +80,17 @@ export type {
   WorkerTask,
   UpsertBenchmarkInput,
   UpsertParticipantInput,
+  UploadWorkerArtifactInput,
 } from './types';
+export type {
+  BenchmarkReporterArtifactInput,
+  BenchmarkReporterBarrierInput,
+  BenchmarkReporterBarrierResult,
+  BenchmarkReporterConfig,
+  BenchmarkReporterHeartbeatInput,
+  BenchmarkReporterProgress,
+} from './reporter';
+export type {
+  BenchmarkSystemMetricsCollector,
+  BenchmarkSystemMetricsSample,
+} from './metrics';

--- a/packages/bench/src/metrics.ts
+++ b/packages/bench/src/metrics.ts
@@ -1,0 +1,93 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+
+export interface BenchmarkSystemMetricsSample {
+  ts: string;
+  uptimeMs: number;
+  cpuUserUs: number;
+  cpuSystemUs: number;
+  memRssMb: number;
+  memHeapUsedMb: number;
+  memHeapTotalMb: number;
+  memExternalMb: number;
+  eventLoopP50Ms: number;
+  eventLoopP99Ms: number;
+  eventLoopMaxMs: number;
+  loadavg1m: number;
+  loadavg5m: number;
+  loadavg15m: number;
+  openFds: number | null;
+  sockstat: Record<string, number> | null;
+}
+
+export interface BenchmarkSystemMetricsCollector {
+  sample(): BenchmarkSystemMetricsSample;
+  stop(): void;
+}
+
+function readSockstat(): Record<string, number> | null {
+  try {
+    const data = fs.readFileSync('/proc/net/sockstat', 'utf-8');
+    const out: Record<string, number> = {};
+    for (const line of data.split('\n')) {
+      const index = line.indexOf(':');
+      if (index < 0) continue;
+      const section = line.slice(0, index).trim().toLowerCase();
+      const parts = line.slice(index + 1).trim().split(/\s+/);
+      for (let i = 0; i + 1 < parts.length; i += 2) {
+        const value = Number.parseInt(parts[i + 1], 10);
+        if (!Number.isNaN(value)) out[`${section}_${parts[i]}`] = value;
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function countOpenFds(): number | null {
+  try {
+    return fs.readdirSync('/proc/self/fd').length;
+  } catch {
+    return null;
+  }
+}
+
+export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector {
+  const startedAt = Date.now();
+  const cpuBaseline = process.cpuUsage();
+  const eventLoop = monitorEventLoopDelay({ resolution: 20 });
+  eventLoop.enable();
+
+  return {
+    sample() {
+      const cpu = process.cpuUsage(cpuBaseline);
+      const memory = process.memoryUsage();
+      const loadavg = os.loadavg();
+      const sample: BenchmarkSystemMetricsSample = {
+        ts: new Date().toISOString(),
+        uptimeMs: Date.now() - startedAt,
+        cpuUserUs: cpu.user,
+        cpuSystemUs: cpu.system,
+        memRssMb: Math.round(memory.rss / 1024 / 1024),
+        memHeapUsedMb: Math.round(memory.heapUsed / 1024 / 1024),
+        memHeapTotalMb: Math.round(memory.heapTotal / 1024 / 1024),
+        memExternalMb: Math.round(memory.external / 1024 / 1024),
+        eventLoopP50Ms: eventLoop.percentile(50) / 1e6,
+        eventLoopP99Ms: eventLoop.percentile(99) / 1e6,
+        eventLoopMaxMs: eventLoop.max / 1e6,
+        loadavg1m: loadavg[0],
+        loadavg5m: loadavg[1],
+        loadavg15m: loadavg[2],
+        openFds: countOpenFds(),
+        sockstat: readSockstat(),
+      };
+      eventLoop.reset();
+      return sample;
+    },
+    stop() {
+      eventLoop.disable();
+    },
+  };
+}

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -175,16 +175,21 @@ export class BenchmarkReporter {
   flush(isFinal = false): Promise<void> {
     this.flushChain = this.flushChain.then(async () => {
       while (this.pending.length >= this.cfg.batchSize || (isFinal && this.pending.length > 0)) {
-        const batch = this.pending.splice(0, this.cfg.batchSize);
-        await this.client.sendTaskResults({
-          benchmarkSlug: this.cfg.benchmarkSlug,
-          runId: this.cfg.runId,
-          workerId: this.assignment.workerId,
-          attemptId: this.assignment.attemptId,
-          sequenceNumber: this.sequenceNumber,
-          isFinal: isFinal && this.pending.length === 0,
-          records: batch,
-        }).catch(() => {});
+        const batch = this.pending.slice(0, this.cfg.batchSize);
+        try {
+          await this.client.sendTaskResults({
+            benchmarkSlug: this.cfg.benchmarkSlug,
+            runId: this.cfg.runId,
+            workerId: this.assignment.workerId,
+            attemptId: this.assignment.attemptId,
+            sequenceNumber: this.sequenceNumber,
+            isFinal: isFinal && batch.length === this.pending.length,
+            records: batch,
+          });
+        } catch {
+          break;
+        }
+        this.pending.splice(0, batch.length);
         this.sequenceNumber += 1;
       }
     });

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -1,0 +1,217 @@
+import { createBenchmarkClient } from './client';
+import type {
+  BenchmarkAssignment,
+  BenchmarkClient,
+  BenchmarkClientConfig,
+  CreateWorkerArtifactResponse,
+  JsonObject,
+  TaskResultRecord,
+  WorkerConcurrencySample,
+} from './types';
+
+const DEFAULT_REPORTER_BATCH_SIZE = 500;
+const DEFAULT_READY_POLL_INTERVAL_MS = 1000;
+
+export interface BenchmarkReporterConfig extends BenchmarkClientConfig {
+  benchmarkSlug: string;
+  runId: string;
+  participantSlug: string;
+  processKind?: string;
+  processKey?: string;
+  batchSize?: number;
+}
+
+export interface BenchmarkReporterProgress {
+  done: number;
+  inFlight: number;
+  errors: number;
+  total?: number;
+}
+
+export interface BenchmarkReporterArtifactInput {
+  kind: string;
+  name?: string;
+  contentType?: string;
+  body: BodyInit;
+  metadata?: JsonObject;
+}
+
+export interface BenchmarkReporterHeartbeatInput {
+  currentStep?: string | null;
+  concurrency?: WorkerConcurrencySample[];
+}
+
+export interface BenchmarkReporterBarrierInput {
+  step: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  active?: number;
+  target?: number;
+  concurrency?: WorkerConcurrencySample[];
+}
+
+export interface BenchmarkReporterBarrierResult {
+  active: number | null;
+  target: number | null;
+  ready: boolean;
+  measuredAt: string;
+}
+
+export class BenchmarkReporter {
+  private readonly client: BenchmarkClient;
+  private readonly assignment: BenchmarkAssignment;
+  private readonly cfg: Required<Pick<BenchmarkReporterConfig, 'benchmarkSlug' | 'runId' | 'participantSlug' | 'batchSize'>>;
+  private pending: TaskResultRecord[] = [];
+  private sequenceNumber = 0;
+  private flushChain: Promise<void> = Promise.resolve();
+  private progress: BenchmarkReporterProgress;
+  private barrier: { step: string; concurrency: WorkerConcurrencySample[] } | null = null;
+
+  private constructor(client: BenchmarkClient, cfg: BenchmarkReporterConfig, assignment: BenchmarkAssignment) {
+    this.client = client;
+    this.assignment = assignment;
+    this.cfg = {
+      benchmarkSlug: cfg.benchmarkSlug,
+      runId: cfg.runId,
+      participantSlug: cfg.participantSlug,
+      batchSize: cfg.batchSize ?? DEFAULT_REPORTER_BATCH_SIZE,
+    };
+    this.progress = { done: 0, inFlight: 0, errors: 0, total: assignment.taskRange.count };
+  }
+
+  static async claim(cfg: BenchmarkReporterConfig): Promise<BenchmarkReporter | null> {
+    const client = createBenchmarkClient(cfg);
+    try {
+      const assignment = await client.claimWorker(cfg.benchmarkSlug, cfg.runId, cfg.participantSlug, {
+        processKind: cfg.processKind,
+        processKey: cfg.processKey,
+      });
+      return assignment ? new BenchmarkReporter(client, cfg, assignment) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  get workerAssignment(): BenchmarkAssignment {
+    return this.assignment;
+  }
+
+  get taskCount(): number {
+    return this.assignment.taskRange.count;
+  }
+
+  get taskIndexStart(): number {
+    return this.assignment.taskRange.start;
+  }
+
+  setProgress(progress: BenchmarkReporterProgress): void {
+    this.progress = { ...progress, total: progress.total ?? this.assignment.taskRange.count };
+  }
+
+  recordResult(record: TaskResultRecord): void {
+    this.pending.push(record);
+    if (this.pending.length >= this.cfg.batchSize) void this.flush(false);
+  }
+
+  async heartbeat(input: BenchmarkReporterHeartbeatInput = {}): Promise<void> {
+    const barrier = this.barrier;
+    const currentStep = barrier?.step ?? input.currentStep;
+    const concurrency = barrier?.concurrency ?? input.concurrency;
+    await this.client.heartbeatWorker(this.cfg.benchmarkSlug, this.cfg.runId, this.assignment.workerId, {
+      attemptId: this.assignment.attemptId,
+      progressDone: this.progress.done,
+      progressInFlight: this.progress.inFlight,
+      progressErrors: this.progress.errors,
+      progressTotal: this.progress.total,
+      ...(currentStep ? { currentStep } : {}),
+      ...(concurrency ? { concurrency } : {}),
+    }).catch(() => {});
+  }
+
+  async waitForStepReady(input: BenchmarkReporterBarrierInput): Promise<BenchmarkReporterBarrierResult> {
+    const startedAt = Date.now();
+    const pollIntervalMs = input.pollIntervalMs ?? DEFAULT_READY_POLL_INTERVAL_MS;
+    const concurrency = input.concurrency ?? [{
+      step: input.step,
+      active: input.active ?? this.assignment.taskRange.count,
+      target: input.target ?? this.assignment.taskRange.count,
+    }];
+    this.barrier = { step: input.step, concurrency };
+    try {
+      while (true) {
+        await this.heartbeat({ currentStep: input.step, concurrency });
+        const progress = await this.client.getRunProgress(this.cfg.benchmarkSlug, this.cfg.runId).catch(() => null);
+        const participant = progress?.participants.find((item) => item.slug === this.cfg.participantSlug);
+        const step = participant?.concurrency.find((item) => item.step === input.step);
+        if (step?.ready) {
+          return {
+            active: step.active,
+            target: step.target,
+            ready: true,
+            measuredAt: progress?.generatedAt ?? new Date().toISOString(),
+          };
+        }
+        if (input.timeoutMs !== undefined && Date.now() - startedAt >= input.timeoutMs) {
+          throw new Error(`Timed out waiting for benchmark step "${input.step}" to become ready.`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      }
+    } finally {
+      this.barrier = null;
+    }
+  }
+
+  uploadArtifact(input: BenchmarkReporterArtifactInput): Promise<CreateWorkerArtifactResponse | null> {
+    return this.client.uploadWorkerArtifact(this.cfg.benchmarkSlug, this.cfg.runId, this.assignment.workerId, {
+      attemptId: this.assignment.attemptId,
+      kind: input.kind,
+      name: input.name,
+      contentType: input.contentType,
+      metadata: input.metadata,
+      body: input.body,
+    }).catch(() => null);
+  }
+
+  flush(isFinal = false): Promise<void> {
+    this.flushChain = this.flushChain.then(async () => {
+      while (this.pending.length >= this.cfg.batchSize || (isFinal && this.pending.length > 0)) {
+        const batch = this.pending.splice(0, this.cfg.batchSize);
+        await this.client.sendTaskResults({
+          benchmarkSlug: this.cfg.benchmarkSlug,
+          runId: this.cfg.runId,
+          workerId: this.assignment.workerId,
+          attemptId: this.assignment.attemptId,
+          sequenceNumber: this.sequenceNumber,
+          isFinal: isFinal && this.pending.length === 0,
+          records: batch,
+        }).catch(() => {});
+        this.sequenceNumber += 1;
+      }
+    });
+    return this.flushChain;
+  }
+
+  async finish(failed = false, error?: unknown): Promise<void> {
+    await this.flush(true).catch(() => {});
+    if (failed) {
+      await this.client.failWorker(
+        this.cfg.benchmarkSlug,
+        this.cfg.runId,
+        this.assignment.workerId,
+        this.assignment.attemptId,
+        error,
+      ).catch(() => {});
+      return;
+    }
+    await this.client.completeWorker(
+      this.cfg.benchmarkSlug,
+      this.cfg.runId,
+      this.assignment.workerId,
+      this.assignment.attemptId,
+    ).catch(() => {});
+  }
+}
+
+export function claimBenchmarkReporter(config: BenchmarkReporterConfig): Promise<BenchmarkReporter | null> {
+  return BenchmarkReporter.claim(config);
+}

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -277,7 +277,7 @@ export interface BenchmarkResultsOverviewInput {
   limit?: number;
 }
 
-export type BenchmarkAnalyticsReadiness = 'ready' | 'partial' | 'pending' | 'unavailable' | 'failed';
+export type BenchmarkAnalyticsReadiness = 'ready' | 'complete' | 'partial' | 'pending' | 'unavailable' | 'failed';
 
 export interface BenchmarkRunAnalyticsSummary {
   status: BenchmarkAnalyticsReadiness;

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -207,6 +207,10 @@ export interface CreateWorkerArtifactInput {
   metadata?: JsonObject;
 }
 
+export interface UploadWorkerArtifactInput extends CreateWorkerArtifactInput {
+  body: BodyInit;
+}
+
 export interface BenchmarkArtifact {
   id?: string;
   artifactId?: string;
@@ -701,6 +705,12 @@ export interface BenchmarkClient {
     runId: string,
     workerId: string,
     input: CreateWorkerArtifactInput,
+  ): Promise<CreateWorkerArtifactResponse>;
+  uploadWorkerArtifact(
+    benchmarkSlug: string,
+    runId: string,
+    workerId: string,
+    input: UploadWorkerArtifactInput,
   ): Promise<CreateWorkerArtifactResponse>;
   listRunArtifacts(benchmarkSlug: string, runId: string): Promise<BenchmarkArtifact[]>;
   listWorkerArtifacts(benchmarkSlug: string, runId: string, workerId: string): Promise<BenchmarkArtifact[]>;

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -526,6 +526,8 @@ export interface StepContext<TState extends Record<string, unknown> = Record<str
   state: TState;
 }
 
+export type CleanupContext<TState extends Record<string, unknown> = Record<string, unknown>> = StepContext<TState>;
+
 export interface DefineStepOptions {
   /** Report this step as active in heartbeat concurrency samples. Defaults to true. */
   reportConcurrency?: boolean;
@@ -545,9 +547,18 @@ export interface DefinedStep<TState extends Record<string, unknown> = Record<str
   fn: (context: StepContext<TState>) => Promise<JsonObject | void> | JsonObject | void;
 }
 
+export interface DefineTaskOptions<TState extends Record<string, unknown> = Record<string, unknown>> {
+  /**
+   * Runs after the task finishes, whether it succeeded or failed.
+   * Use this to tear down resources stored in task state.
+   */
+  cleanup?: (context: CleanupContext<TState>) => Promise<void> | void;
+}
+
 export interface DefinedTask<TState extends Record<string, unknown> = Record<string, unknown>> {
   name: string;
   steps: DefinedStep<TState>[];
+  options?: DefineTaskOptions<TState>;
 }
 
 export type TaskFunction = (context: RunWorkerContext) => Promise<JsonObject | void> | JsonObject | void;

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -524,6 +524,14 @@ export interface RunWorkerContext {
   step<T>(name: string, fn: () => Promise<T> | T, options?: DefineStepOptions): Promise<T>;
 }
 
+export interface WorkerFinishContext {
+  assignment: BenchmarkAssignment;
+  records: TaskResultRecord[];
+  status: 'success' | 'error';
+  client: BenchmarkClient;
+  uploadArtifact(input: Omit<UploadWorkerArtifactInput, 'attemptId'>): Promise<CreateWorkerArtifactResponse>;
+}
+
 export interface StepContext<TState extends Record<string, unknown> = Record<string, unknown>> {
   assignment: BenchmarkAssignment;
   taskIndex: number;
@@ -584,6 +592,8 @@ export interface RunWorkerOptions {
   heartbeatIntervalMs?: number;
   readyPollIntervalMs?: number;
   onResult?: (record: TaskResultRecord) => void;
+  /** Runs once after final result flush and before worker completion/failure is reported. */
+  onFinish?: (context: WorkerFinishContext) => Promise<void> | void;
   task: WorkerTask;
 }
 
@@ -601,6 +611,7 @@ export interface DefineWorkerOptions extends WorkerDefaults {
   processKind?: string;
   processKey?: string;
   client?: BenchmarkClient;
+  onFinish?: RunWorkerOptions['onFinish'];
   task: WorkerTask;
 }
 


### PR DESCRIPTION
## Summary
- add `defineTask(..., { cleanup })` hooks for per-task resource teardown after success or failure
- preserve original task/step errors when cleanup also fails, while still failing otherwise-successful tasks when cleanup fails
- add `onFinish` worker hooks that run once after final result flush and before `completeWorker` / `failWorker`, intended for worker-level logs and artifacts
- add `client.uploadWorkerArtifact(...)` to create an artifact and upload its body to the presigned URL in one call
- add `BenchmarkReporter` / `claimBenchmarkReporter` for custom coordinators that need best-effort claim, heartbeats, result batching, artifact uploads, finish, and barrier polling
- add reusable `waitForStepReady(...)` reporter behavior that keeps re-heartbeating while polling a barrier step
- add `createSystemMetricsCollector()` for coordinator health samples: CPU, memory, event loop delay, load, open FDs, and Linux sockstat
- update analytics readiness typing and integration assertions to accept the platform `complete` status
- document cleanup, worker finish log uploads, custom reporter usage, artifact upload, and metrics sampling
- add a patch changeset for `@computesdk/bench`

## Why
This pulls the reusable pieces from the scale benchmark work into the bench SDK so benchmark coordinators do not need to hand-roll cleanup, log/artifact upload, best-effort reporting, barrier heartbeat loops, or system-health sampling.

## Tests
- `pnpm --filter @computesdk/bench test`
- `pnpm --filter @computesdk/bench typecheck`
- `pnpm --filter @computesdk/bench lint`
- `pnpm --filter @computesdk/bench build`