### PR TITLE
Update Runloop client to 1.24

### DIFF
--- a/.changeset/runloop-client-1-24.md
+++ b/.changeset/runloop-client-1-24.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/runloop": patch
+---
+
+Require the Runloop API client 1.24 release line.

--- a/packages/runloop/package.json
+++ b/packages/runloop/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@runloop/api-client": "^1.23.0",
+    "@runloop/api-client": "^1.24.0",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1348,8 +1348,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@runloop/api-client':
-        specifier: ^1.23.0
-        version: 1.23.0
+        specifier: ^1.24.0
+        version: 1.24.0
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -3821,8 +3821,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@runloop/api-client@1.23.0':
-    resolution: {integrity: sha512-cAuQYNHbgLeXMocQv3EOSkALl3i3JD3zVdSM7SpeMohScA5AxRvbEAtFUwRILuo6Hkg/nm/E831gBcH9Ghsi/g==}
+  '@runloop/api-client@1.24.0':
+    resolution: {integrity: sha512-A/G9l2MlBz/u0Wr2RvCEJvh0+4Pn/8p15BTq9wQt3vEgEGLEk844+9bIKsfWbDvU/4JdRvIUND79Vu5qvKQzUQ==}
 
   '@secure-exec/browser@0.1.1-rc.3':
     resolution: {integrity: sha512-syjym68632Yzba6Uu9tfnd2KGHTHoiOMTg3hnYRxs4t2RrTfzKm3fWOBVmOZHaZT7ECMCItXerDfYmH05tbHDg==}
@@ -10941,7 +10941,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.45.1':
     optional: true
 
-  '@runloop/api-client@1.23.0':
+  '@runloop/api-client@1.24.0':
     dependencies:
       '@types/node': 18.19.123
       '@types/node-fetch': 2.6.13


### PR DESCRIPTION
## Summary

- Update `@computesdk/runloop` to require `@runloop/api-client` `^1.24.0`.
- Regenerate the pnpm lockfile for `@runloop/api-client@1.24.0`.
- Add a changeset for the Runloop package dependency update.

## Notes

Merging this should produce the next `@computesdk/runloop` patch release from the changeset. It does not require a core `computesdk` package release.

## Validation

- `pnpm --filter @computesdk/runloop run typecheck`
- `pnpm --filter @computesdk/runloop run test`