### PR TITLE
feat: add @computesdk/isorun provider

### DIFF
--- a/packages/isorun/CHANGELOG.md
+++ b/packages/isorun/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @computesdk/isorun
+
+## 0.1.0
+
+- Initial release. Wraps the `isorun` SDK to expose the ComputeSDK provider interface — isolated Linux VM sandboxes for running untrusted and AI-generated code. Supports `create`, `getById`, `list`, `destroy`, `runCommand`, `getInfo`, `getUrl`, and full filesystem operations.

--- a/packages/isorun/README.md
+++ b/packages/isorun/README.md
@@ -40,7 +40,7 @@ await sandbox.destroy()
 // Execute commands
 const cmd = await sandbox.runCommand('echo hello', { env: { FOO: 'bar' }, cwd: '/tmp' })
 
-// Filesystem (native API, not shell hacks)
+// Filesystem
 await sandbox.filesystem.writeFile('/app/data.json', JSON.stringify({ key: 'value' }))
 const data = await sandbox.filesystem.readFile('/app/data.json')
 const entries = await sandbox.filesystem.readdir('/app')

--- a/packages/isorun/README.md
+++ b/packages/isorun/README.md
@@ -1,0 +1,65 @@
+# @computesdk/isorun
+
+[Isorun](https://isorun.ai) provider for [ComputeSDK](https://computesdk.com). Isolated Linux VM sandboxes for running untrusted and AI-generated code, billed by the second.
+
+## Install
+
+```bash
+npm install @computesdk/isorun
+```
+
+## Usage
+
+```typescript
+import { isorun } from '@computesdk/isorun'
+
+const compute = isorun({
+  apiKey: process.env.ISORUN_API_KEY,
+})
+
+const sandbox = await compute.sandbox.create({ runtime: 'node' })
+
+const result = await sandbox.runCommand('node -v')
+console.log(result.stdout) // v22.x.x
+
+await sandbox.filesystem.writeFile('/tmp/hello.txt', 'world')
+const content = await sandbox.filesystem.readFile('/tmp/hello.txt')
+
+await sandbox.destroy()
+```
+
+## Configuration
+
+| Option | Env var | Default | Description |
+|---|---|---|---|
+| `apiKey` | `ISORUN_API_KEY` | required | API key from [app.isorun.ai](https://app.isorun.ai) |
+
+## Sandbox API
+
+```typescript
+// Execute commands
+const cmd = await sandbox.runCommand('echo hello', { env: { FOO: 'bar' }, cwd: '/tmp' })
+
+// Filesystem (native API, not shell hacks)
+await sandbox.filesystem.writeFile('/app/data.json', JSON.stringify({ key: 'value' }))
+const data = await sandbox.filesystem.readFile('/app/data.json')
+const entries = await sandbox.filesystem.readdir('/app')
+const exists = await sandbox.filesystem.exists('/app/data.json')
+await sandbox.filesystem.mkdir('/app/output')
+await sandbox.filesystem.remove('/app/output')
+
+// Lifecycle
+const info = await sandbox.getInfo()
+const all = await compute.sandbox.list()
+await sandbox.destroy()
+```
+
+## Beyond the standard interface
+
+The `isorun` SDK exposes a few capabilities that don't have slots in the standard ComputeSDK interface — fork (`sandbox.fork(n)`), hibernate/resume (`sandbox.hibernate()` / `sandbox.resume()`), and timeout reset (`sandbox.setTimeout(seconds)`). Reach the underlying instance via:
+
+```typescript
+const native = compute.sandbox.getInstance(sandbox) // returns the raw Sandbox
+await native.fork(4)
+await native.hibernate()
+```

--- a/packages/isorun/package.json
+++ b/packages/isorun/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@computesdk/isorun",
+  "version": "0.1.0",
+  "description": "Isorun provider for ComputeSDK — isolated Linux VM sandboxes for running untrusted and AI-generated code",
+  "author": "Isorun <hello@isorun.ai>",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "isorun",
+    "sandbox",
+    "isolation",
+    "code-interpreter",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider",
+    "ai-agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/isorun"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "dependencies": {
+    "isorun": "^1.0.0",
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/isorun/package.json
+++ b/packages/isorun/package.json
@@ -4,6 +4,9 @@
   "description": "Isorun provider for ComputeSDK — isolated Linux VM sandboxes for running untrusted and AI-generated code",
   "author": "Isorun <hello@isorun.ai>",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/isorun/src/__tests__/crud.test.ts
+++ b/packages/isorun/src/__tests__/crud.test.ts
@@ -1,0 +1,8 @@
+import { runProviderCrudTest } from '@computesdk/test-utils'
+import { isorun } from '../index'
+
+runProviderCrudTest({
+  name: 'isorun',
+  provider: isorun({}),
+  skipIntegration: !process.env.ISORUN_API_KEY,
+})

--- a/packages/isorun/src/__tests__/index.test.ts
+++ b/packages/isorun/src/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+import { runProviderTestSuite } from '@computesdk/test-utils'
+import { isorun } from '../index'
+
+runProviderTestSuite({
+  name: 'isorun',
+  provider: isorun({}),
+  supportsFilesystem: true,
+  supportsGetUrl: true,
+  ports: [3000, 8080],
+  skipIntegration: !process.env.ISORUN_API_KEY,
+})

--- a/packages/isorun/src/index.ts
+++ b/packages/isorun/src/index.ts
@@ -96,7 +96,15 @@ export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSna
 
         if (options?.env && Object.keys(options.env).length > 0) {
           const prefix = Object.entries(options.env)
-            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+            .map(([k, v]) => {
+              // Env var names are POSIX identifiers; reject anything else so a
+              // malicious key (e.g. `x; rm -rf /`, `$(...)`) can't break out of
+              // the assignment and inject a command. Values are escaped below.
+              if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) {
+                throw new Error(`Invalid environment variable name: ${JSON.stringify(k)}`)
+              }
+              return `${k}="${escapeShellArg(String(v))}"`
+            })
             .join(' ')
           fullCommand = `${prefix} ${fullCommand}`
         }

--- a/packages/isorun/src/index.ts
+++ b/packages/isorun/src/index.ts
@@ -50,9 +50,9 @@ type FsRunCommand = (sandbox: Sandbox, command: string, options?: RunCommandOpti
 
 export interface IsorunSnapshot {
   id: string
-  runId?: string
-  sizeBytes: number
-  createdAt: string
+  provider: string
+  createdAt: Date
+  metadata?: Record<string, unknown>
 }
 
 export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSnapshot>({
@@ -138,8 +138,10 @@ export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSna
 
       getUrl: async (sandbox: Sandbox, options: { port: number; protocol?: string }) => {
         const url = sandbox.url(options.port)
-        if (options.protocol && options.protocol !== 'http' && options.protocol !== 'https') {
-          return url.replace(/^https?:\/\//, `${options.protocol}://`)
+        if (options.protocol) {
+          const u = new URL(url)
+          u.protocol = `${options.protocol}:`
+          return u.toString()
         }
         return url
       },
@@ -199,9 +201,9 @@ export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSna
         const snap = await sandbox.snapshot()
         return {
           id: snap.id,
-          runId: snap.runId,
-          sizeBytes: snap.sizeBytes,
-          createdAt: snap.createdAt,
+          provider: 'isorun',
+          createdAt: new Date(snap.createdAt),
+          metadata: { runId: snap.runId, sizeBytes: snap.sizeBytes },
         }
       },
 
@@ -209,9 +211,9 @@ export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSna
         const entries = await getClient(config).listSnapshots()
         return entries.map(e => ({
           id: e.id,
-          runId: e.runId,
-          sizeBytes: e.sizeBytes,
-          createdAt: e.createdAt,
+          provider: 'isorun',
+          createdAt: new Date(e.createdAt),
+          metadata: { runId: e.runId, sizeBytes: e.sizeBytes },
         }))
       },
 

--- a/packages/isorun/src/index.ts
+++ b/packages/isorun/src/index.ts
@@ -1,0 +1,217 @@
+/**
+ * @computesdk/isorun — Isorun provider for ComputeSDK.
+ *
+ * Thin wrapper around `isorun` that maps the ComputeSDK provider
+ * interface to Isorun's sandbox API.
+ *
+ * @see https://isorun.ai
+ */
+
+import { Isorun, Sandbox } from 'isorun'
+import { defineProvider, escapeShellArg } from '@computesdk/provider'
+
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+  SandboxInfo,
+} from '@computesdk/provider'
+
+export interface IsorunConfig {
+  /** API key. Falls back to `ISORUN_API_KEY` env var. The runner endpoint is derived from the key. */
+  apiKey?: string
+}
+
+type ConfigWithClient = IsorunConfig & { __client?: Isorun }
+
+function getClient(config: ConfigWithClient): Isorun {
+  if (!config.__client) {
+    const apiKey = config.apiKey ?? process.env.ISORUN_API_KEY
+    if (!apiKey) {
+      throw new Error(`Missing Isorun API key. Provide 'apiKey' in config or set ISORUN_API_KEY.`)
+    }
+    config.__client = new Isorun({ apiKey })
+  }
+  return config.__client
+}
+
+type Runtime = 'node' | 'python'
+
+function defaultImage(runtime?: Runtime): string {
+  return runtime === 'python' ? 'python:3.12-slim' : 'node:22'
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000
+
+const sandboxTimeouts = new WeakMap<Sandbox, number>()
+
+type FsRunCommand = (sandbox: Sandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
+
+export interface IsorunSnapshot {
+  id: string
+  runId?: string
+  sizeBytes: number
+  createdAt: string
+}
+
+export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSnapshot>({
+  name: 'isorun',
+  methods: {
+    sandbox: {
+      create: async (config: ConfigWithClient, options?: CreateSandboxOptions) => {
+        const client = getClient(config)
+        const runtime = options?.runtime ?? 'node'
+        const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT_MS
+        const sandbox = await client.create({
+          image: options?.image || defaultImage(runtime),
+          vcpus: options?.vcpus,
+          memMiB: options?.memMiB,
+          diskMiB: options?.diskMiB,
+          timeoutSec: Math.max(1, Math.ceil(timeoutMs / 1000)),
+        })
+        sandboxTimeouts.set(sandbox, timeoutMs)
+        return { sandbox, sandboxId: sandbox.id }
+      },
+
+      getById: async (config: ConfigWithClient, sandboxId: string) => {
+        const sandbox = await getClient(config).get(sandboxId)
+        if (!sandbox) return null
+        return { sandbox, sandboxId }
+      },
+
+      list: async (config: ConfigWithClient) => {
+        const sandboxes = await getClient(config).list()
+        return sandboxes.map(sandbox => ({ sandbox, sandboxId: sandbox.id }))
+      },
+
+      destroy: async (config: ConfigWithClient, sandboxId: string) => {
+        const sandbox = await getClient(config).get(sandboxId)
+        if (sandbox) await sandbox.destroy()
+      },
+
+      runCommand: async (sandbox: Sandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
+        const startTime = Date.now()
+        let fullCommand = command
+
+        if (options?.env && Object.keys(options.env).length > 0) {
+          const prefix = Object.entries(options.env)
+            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+            .join(' ')
+          fullCommand = `${prefix} ${fullCommand}`
+        }
+        if (options?.cwd) {
+          fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`
+        }
+        if (options?.background) {
+          fullCommand = `nohup sh -c "${escapeShellArg(fullCommand)}" >/dev/null 2>&1 &`
+        }
+
+        const result = await sandbox.exec(fullCommand, Math.max(1, Math.ceil((options?.timeout ?? DEFAULT_TIMEOUT_MS) / 1000)))
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          durationMs: Date.now() - startTime,
+        }
+      },
+
+      getInfo: async (sandbox: Sandbox): Promise<SandboxInfo> => {
+        const i = await sandbox.info()
+        return {
+          id: sandbox.id,
+          provider: 'isorun',
+          status: i.status === 'running' ? 'running' : i.status === 'error' ? 'error' : 'stopped',
+          createdAt: new Date(i.createdAt),
+          timeout: sandboxTimeouts.get(sandbox) ?? DEFAULT_TIMEOUT_MS,
+          metadata: { createMs: i.createMs, image: i.image },
+        }
+      },
+
+      getUrl: async (sandbox: Sandbox, options: { port: number; protocol?: string }) => {
+        const url = sandbox.url(options.port)
+        if (options.protocol && options.protocol !== 'http' && options.protocol !== 'https') {
+          return url.replace(/^https?:\/\//, `${options.protocol}://`)
+        }
+        return url
+      },
+
+      getInstance: (sandbox: Sandbox) => sandbox,
+
+      filesystem: {
+        readFile: async (sandbox: Sandbox, path: string): Promise<string> => {
+          return sandbox.readFile(path)
+        },
+
+        writeFile: async (sandbox: Sandbox, path: string, content: string): Promise<void> => {
+          await sandbox.writeFile(path, content)
+        },
+
+        mkdir: async (sandbox: Sandbox, path: string, runCommand: FsRunCommand): Promise<void> => {
+          const r = await runCommand(sandbox, `mkdir -p "${escapeShellArg(path)}"`)
+          if (r.exitCode !== 0) throw new Error(r.stderr || `Failed to create directory: ${path}`)
+        },
+
+        readdir: async (sandbox: Sandbox, path: string, runCommand: FsRunCommand): Promise<FileEntry[]> => {
+          // ls -la, not find -printf: BusyBox images (Alpine) lack -printf
+          const r = await runCommand(sandbox, `ls -la "${escapeShellArg(path)}"`)
+          if (r.exitCode !== 0) throw new Error(r.stderr || `Cannot read directory: ${path}`)
+          const entries: FileEntry[] = []
+          for (const line of r.stdout.split('\n')) {
+            if (!line.trim() || line.startsWith('total ')) continue
+            const parts = line.split(/\s+/)
+            if (parts.length < 9) continue
+            const name = parts.slice(8).join(' ')
+            if (name === '.' || name === '..') continue
+            entries.push({
+              name,
+              type: parts[0].startsWith('d') ? 'directory' : 'file',
+              size: Number.parseInt(parts[4], 10) || 0,
+            })
+          }
+          return entries
+        },
+
+        exists: async (sandbox: Sandbox, path: string, runCommand: FsRunCommand): Promise<boolean> => {
+          const r = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`)
+          return r.exitCode === 0
+        },
+
+        remove: async (sandbox: Sandbox, path: string, runCommand: FsRunCommand): Promise<void> => {
+          const r = await runCommand(sandbox, `rm -rf "${escapeShellArg(path)}"`)
+          if (r.exitCode !== 0) throw new Error(r.stderr || `Failed to remove: ${path}`)
+        },
+      },
+    },
+
+    snapshot: {
+      create: async (config: ConfigWithClient, sandboxId: string): Promise<IsorunSnapshot> => {
+        const sandbox = await getClient(config).get(sandboxId)
+        if (!sandbox) throw new Error(`Sandbox not found: ${sandboxId}`)
+        const snap = await sandbox.snapshot()
+        return {
+          id: snap.id,
+          runId: snap.runId,
+          sizeBytes: snap.sizeBytes,
+          createdAt: snap.createdAt,
+        }
+      },
+
+      list: async (config: ConfigWithClient): Promise<IsorunSnapshot[]> => {
+        const entries = await getClient(config).listSnapshots()
+        return entries.map(e => ({
+          id: e.id,
+          runId: e.runId,
+          sizeBytes: e.sizeBytes,
+          createdAt: e.createdAt,
+        }))
+      },
+
+      delete: async (config: ConfigWithClient, snapshotId: string): Promise<void> => {
+        try {
+          await getClient(config).deleteSnapshot(snapshotId)
+        } catch { /* idempotent: snapshot may already be gone */ }
+      },
+    },
+  },
+})

--- a/packages/isorun/tsconfig.json
+++ b/packages/isorun/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/isorun/tsup.config.ts
+++ b/packages/isorun/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/isorun/vitest.config.ts
+++ b/packages/isorun/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/packages/test-utils/src/provider-crud-test.ts
+++ b/packages/test-utils/src/provider-crud-test.ts
@@ -40,6 +40,7 @@ const CRUD_ENABLED_PROVIDERS = [
   'namespace',
   'avm',
   'northflank', // Service-per-sandbox lifecycle is fully stable and listed
+  'isorun',   // Isolated Linux VM, full create/getById/list/destroy lifecycle
   // Add more providers here as they become stable for CRUD testing
   // 'e2b',      // Add when CRUD implementation is stable
   // 'vercel',   // Skip - ephemeral sandboxes don't support listing operations

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -65,6 +65,7 @@
     "@computesdk/just-bash": "workspace:*",
     "@computesdk/hopx": "workspace:*",
     "@computesdk/declaw": "workspace:*",
+    "@computesdk/isorun": "workspace:*",
     "@computesdk/modal": "workspace:*",
     "@computesdk/runloop": "workspace:*",
     "@computesdk/vercel": "workspace:*",
@@ -110,6 +111,9 @@
       "optional": true
     },
     "@computesdk/declaw": {
+      "optional": true
+    },
+    "@computesdk/isorun": {
       "optional": true
     },
     "@computesdk/beam": {

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -19,6 +19,7 @@ const SHARED_PROVIDER_NAMES = [
   'namespace',
   'hopx',
   'declaw',
+  'isorun',
   'sprites',
   'agentuity',
   'freestyle',
@@ -51,6 +52,7 @@ const SHARED_PROVIDER_AUTH: Record<SharedProviderName, readonly (readonly string
   namespace: [['NSC_TOKEN'], ['NSC_TOKEN_FILE']],
   hopx: [['HOPX_API_KEY']],
   declaw: [['DECLAW_API_KEY']],
+  isorun: [['ISORUN_API_KEY']],
   sprites: [['SPRITES_TOKEN']],
   agentuity: [['AGENTUITY_SDK_KEY']],
   freestyle: [['FREESTYLE_API_KEY']],
@@ -82,6 +84,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string>> = {
   namespace: { token: 'NSC_TOKEN', tokenFile: 'NSC_TOKEN_FILE' },
   hopx: { apiKey: 'HOPX_API_KEY' },
   declaw: { apiKey: 'DECLAW_API_KEY' },
+  isorun: { apiKey: 'ISORUN_API_KEY' },
   sprites: { token: 'SPRITES_TOKEN' },
   agentuity: { sdkKey: 'AGENTUITY_SDK_KEY' },
   freestyle: { apiKey: 'FREESTYLE_API_KEY' },
@@ -338,6 +341,8 @@ export async function loadProvider(providerName: ProviderName): Promise<any> {
         return await import('@computesdk/hopx');
       case 'declaw':
         return await import('@computesdk/declaw');
+      case 'isorun':
+        return await import('@computesdk/isorun');
       case 'sprites':
         return await import('@computesdk/sprites');
       case 'agentuity':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,7 +267,7 @@ importers:
     dependencies:
       '@blaxel/core':
         specifier: ^0.2.89
-        version: 0.2.89(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 0.2.91(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -795,7 +795,7 @@ importers:
         version: link:../computesdk
       e2b:
         specifier: ^2.26.0
-        version: 2.26.0
+        version: 2.30.1
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -943,6 +943,43 @@ importers:
       playwright-core:
         specifier: ^1.40.0
         version: 1.58.2
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
+  packages/isorun:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+      isorun:
+        specifier: ^1.0.0
+        version: 1.0.0(@modelcontextprotocol/sdk@1.26.0(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -1315,7 +1352,7 @@ importers:
         version: link:../computesdk
       railway:
         specifier: ^3.1.1
-        version: 3.1.1
+        version: 3.3.1
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -1741,6 +1778,9 @@ importers:
       '@computesdk/hopx':
         specifier: workspace:*
         version: link:../hopx
+      '@computesdk/isorun':
+        specifier: workspace:*
+        version: link:../isorun
       '@computesdk/just-bash':
         specifier: workspace:*
         version: link:../just-bash
@@ -2159,8 +2199,8 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
 
-  '@blaxel/core@0.2.89':
-    resolution: {integrity: sha512-2lWvXqpJ+tFqIroHvDahrlKnu0dSlleE4kQihX9xrULVVlMGqIPjOWDFs56YU3FMSd0yviG9P+wjqBWVV1vXGQ==}
+  '@blaxel/core@0.2.91':
+    resolution: {integrity: sha512-xtwuH9hpb5x+jmEF8rTUgJdQdEdn1lkr9OlTqjcGwkDRsaviqJzN5UfhN3zR2iG7yaUYfRwOLcMOEJVofWaOqg==}
     engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.1':
@@ -2378,6 +2418,28 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@currentspace/http3-darwin-arm64@0.8.5':
+    resolution: {integrity: sha512-8ocdwlTfqZp0awQUlv5kB9C3Q7C1iZagtNpv+TzQpQph1ZWu1K5iS209IjR2EIAGs6V1WIczjc8slZCUB97RuQ==}
+    engines: {node: '>=24.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@currentspace/http3-linux-arm64-gnu@0.8.5':
+    resolution: {integrity: sha512-cNbSWE2EwY/yfpnj7qtgXpIC9AkFh28ACc7xygnKE0ayIvRweoLsP+GMtgwGVUWAxDB1vf6X8PMXxZYKmWqI0A==}
+    engines: {node: '>=24.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@currentspace/http3-linux-x64-gnu@0.8.5':
+    resolution: {integrity: sha512-pENtrt3EVG3O5ktGci2hoNJmIIOokuUVDYzhs/6teMcNFSUqWTHIm7VGfJajj67iUgRzWeRYjVv3/Y0lcinNqA==}
+    engines: {node: '>=24.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@currentspace/http3@0.8.5':
+    resolution: {integrity: sha512-Quxr3ul3raPslOi0xS3NGMx/TkjDiChafqJ1Td3qeyQXT5tqLpFSQDqA54Ewg0YemEMB5JInFWc9dsVCKW16dw==}
+    engines: {node: '>=24.0.0'}
 
   '@daytonaio/api-client@0.143.0':
     resolution: {integrity: sha512-LcrvExGcwyngt1JnVoxuBMD19fL9F+vwGnp18Hav5HJEbICM0pbrJc2FJ242sQJquNIF5mq+5jgznWg6wshZJA==}
@@ -3219,6 +3281,26 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@isorun/http-transport-linux-arm64-gnu@0.8.8':
+    resolution: {integrity: sha512-tTFnCj24lftvF5q+14W8tIA4RosT2a8F1teqpo9A0DBeTrsqE9UIeJUdiStGtfTJfdEM3QAjAninMpQ95tZMOA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@isorun/http-transport-linux-arm64-musl@0.8.8':
+    resolution: {integrity: sha512-mCAe5LHr2h6zBf6gyNJwnFVIumeR9kHQvgAYGuWm3I9xd2eWUMN+90905i2tXnhShqVHOT3DnJbiWJmt8lKvsg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@isorun/http-transport-linux-x64-gnu@0.8.8':
+    resolution: {integrity: sha512-13IyNfK47jXXix/AQB7lIvhYb0obDykdJR4cSey4vl+iptEVNqJLHr+DK13+VNmNeBKVzWemQJtF0Ui+RheAoQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@isorun/http-transport-linux-x64-musl@0.8.8':
+    resolution: {integrity: sha512-TJM8TaHr36YnNMl5JEzzeB4YQBYSHZNqCY2Ivd5KMo2FzPCdHJjjZ0Z6AQlldqst5X0C9khgfWEr+0CRNzmZsg==}
+    cpu: [x64]
+    os: [linux]
+
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -3936,7 +4018,6 @@ packages:
   '@smithy/core@3.24.1':
     resolution: {integrity: sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==}
     engines: {node: '>=18.0.0'}
-    deprecated: Deprecated due to bug in browser bundling instructions https://github.com/smithy-lang/smithy-typescript/issues/2025
 
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
@@ -5419,8 +5500,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  e2b@2.26.0:
-    resolution: {integrity: sha512-yMAWaIFMW8jNCWOPU+Kix+tbyZQ2yd4zYumOcJcEkMwkCjtLCJmDLto4zRa2GtLyL+61v+NF3ykT72X3UEdFpw==}
+  e2b@2.30.1:
+    resolution: {integrity: sha512-PPUlZAQbXtmxbcHWjbpw+ImbfQScgosmMJ/1XMu7gZrv/r+gANVdpDt0SPZ7GVMotX0So1HdokJm72Uh1tCTOw==}
     engines: {node: '>=20.18.1'}
 
   eastasianwidth@0.2.0:
@@ -6213,6 +6294,28 @@ packages:
     peerDependencies:
       ws: '*'
 
+  isorun@1.0.0:
+    resolution: {integrity: sha512-+6NQ8dOxgvDzltSeAtPJKYx4bH9NPywArCGi/GaTHpf/va8HAORHsSVis8okxTIOgw4GGBCFJL2NBKysMcaggA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@anthropic-ai/sdk': ^0.98.0
+      '@langchain/core': ^1.0.0
+      '@modelcontextprotocol/sdk': ^1.0.0
+      '@openai/agents': ^0.11.0
+      zod: '>=3.23 <5'
+    peerDependenciesMeta:
+      '@anthropic-ai/sdk':
+        optional: true
+      '@langchain/core':
+        optional: true
+      '@modelcontextprotocol/sdk':
+        optional: true
+      '@openai/agents':
+        optional: true
+      zod:
+        optional: true
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -6239,9 +6342,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -7116,8 +7216,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  railway@3.1.1:
-    resolution: {integrity: sha512-Oy2F5oIey8KXFJwlka618J/pX0Qi+0kGvfH88eaJNb8C5O0Ba9CcVxguanN6MZEI1sXGMfFp2i3GKvNXQDoM2Q==}
+  railway@3.3.1:
+    resolution: {integrity: sha512-1GiaejHe9HPM1mt7dMgh3RSqJdZasXzjtbynn0Nb7oRxF2vT+Y57mOt8W/sVkM2H4WpVa4Ks2WDsE8krVyvrGw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7638,8 +7738,8 @@ packages:
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   tar@7.5.9:
@@ -7900,8 +8000,8 @@ packages:
     resolution: {integrity: sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.26.0:
-    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   undici@8.3.0:
@@ -9266,7 +9366,7 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@blaxel/core@0.2.89(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@blaxel/core@0.2.91(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@hey-api/client-fetch': 0.10.2(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
@@ -9278,7 +9378,7 @@ snapshots:
       jwt-decode: 4.0.0
       toml: 3.0.0
       uuid: 11.1.0
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yaml: 2.8.2
       zod: 3.25.76
     transitivePeerDependencies:
@@ -9581,6 +9681,21 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4':
     optional: true
+
+  '@currentspace/http3-darwin-arm64@0.8.5':
+    optional: true
+
+  '@currentspace/http3-linux-arm64-gnu@0.8.5':
+    optional: true
+
+  '@currentspace/http3-linux-x64-gnu@0.8.5':
+    optional: true
+
+  '@currentspace/http3@0.8.5':
+    optionalDependencies:
+      '@currentspace/http3-darwin-arm64': 0.8.5
+      '@currentspace/http3-linux-arm64-gnu': 0.8.5
+      '@currentspace/http3-linux-x64-gnu': 0.8.5
 
   '@daytonaio/api-client@0.143.0':
     dependencies:
@@ -10176,6 +10291,18 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@isorun/http-transport-linux-arm64-gnu@0.8.8':
+    optional: true
+
+  '@isorun/http-transport-linux-arm64-musl@0.8.8':
+    optional: true
+
+  '@isorun/http-transport-linux-x64-gnu@0.8.8':
+    optional: true
+
+  '@isorun/http-transport-linux-x64-musl@0.8.8':
+    optional: true
+
   '@istanbuljs/schema@0.1.3': {}
 
   '@jest/schemas@29.6.3':
@@ -10276,7 +10403,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.11.10
-      jose: 6.1.3
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
@@ -10284,6 +10411,29 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/sdk@1.26.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.10)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.11.10
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -10311,7 +10461,7 @@ snapshots:
       lodash-es: 4.18.1
       node-fetch: 2.6.7
       pump: 3.0.3
-      tar: 7.5.15
+      tar: 7.5.16
       utf-8-validate: 6.0.6
       whatwg-url: 14.2.0
       ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -10950,8 +11100,8 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
-      tar: 7.5.15
-      undici: 7.26.0
+      tar: 7.5.9
+      undici: 7.28.0
       uuidv7: 1.1.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13101,7 +13251,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  e2b@2.26.0:
+  e2b@2.30.1:
     dependencies:
       '@bufbuild/protobuf': 2.7.0
       '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.7.0)
@@ -13112,8 +13262,8 @@ snapshots:
       glob: 11.1.0
       openapi-fetch: 0.14.1
       platform: 1.3.6
-      tar: 7.5.15
-      undici: 7.26.0
+      tar: 7.5.16
+      undici: 7.28.0
 
   eastasianwidth@0.2.0: {}
 
@@ -14071,6 +14221,18 @@ snapshots:
     dependencies:
       ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
+  isorun@1.0.0(@modelcontextprotocol/sdk@1.26.0(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@currentspace/http3': 0.8.5
+      undici: 8.3.0
+    optionalDependencies:
+      '@isorun/http-transport-linux-arm64-gnu': 0.8.8
+      '@isorun/http-transport-linux-arm64-musl': 0.8.8
+      '@isorun/http-transport-linux-x64-gnu': 0.8.8
+      '@isorun/http-transport-linux-x64-musl': 0.8.8
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.4.3)
+      zod: 4.4.3
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -14103,8 +14265,6 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   jiti@2.6.1: {}
-
-  jose@6.1.3: {}
 
   jose@6.2.3: {}
 
@@ -15004,7 +15164,7 @@ snapshots:
 
   pyodide@0.28.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15023,7 +15183,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  railway@3.1.1:
+  railway@3.3.1:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
       graphql: 16.14.2
@@ -15686,7 +15846,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.15:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -15969,7 +16129,7 @@ snapshots:
 
   undici@7.19.0: {}
 
-  undici@7.26.0: {}
+  undici@7.28.0: {}
 
   undici@8.3.0: {}
 


### PR DESCRIPTION
## Summary

- add a first-party `@computesdk/isorun` provider package for [Isorun](https://isorun.ai/)-backed sandboxes (isolated Linux VMs from any container image, billed by the second)
- implement sandbox lifecycle, command execution, filesystem, port exposure (`getUrl`), and info support
- add package docs, tests, build config, and register the provider in the workbench CLI

## Validation
```
npx tsc --noEmit                     # typecheck, clean
npx tsup                             # build, ok
npx vitest run                       # 16 pass / 1 skip (integration needs ISORUN_API_KEY)
ISORUN_API_KEY=... npx vitest run    # 21 pass (full integration)
```

Live integration against the Isorun runner: create sandbox, run commands, filesystem ops, getUrl port exposure, destroy.