### PR TITLE
changeset for adding isorun provider pkg

### DIFF
--- a/.changeset/isorun-provider.md
+++ b/.changeset/isorun-provider.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/isorun': minor
+---
+
+Add the initial Isorun provider package for running untrusted and AI-generated code in isolated Linux VM sandboxes, with sandbox lifecycle support, command execution, filesystem operations, and snapshots.


### PR DESCRIPTION
Adds the missing changeset for `@computesdk/isorun` (merged in #596 without one) so the Version Packages release can publish it to npm.