### PR TITLE
chore(release): isolate isorun publish

### DIFF
--- a/.changeset/clean-bench-tasks.md
+++ b/.changeset/clean-bench-tasks.md
@@ -1,5 +1,0 @@
----
-"@computesdk/bench": patch
----
-
-Add defined task cleanup hooks, worker finish hooks for one-time log uploads, worker artifact upload helpers, a best-effort benchmark reporter for custom coordinators, reusable barrier polling, and system metrics sampling utilities.


### PR DESCRIPTION
Removes the pending `@computesdk/bench` changeset so the next `main` build has **zero changesets**, flipping the changesets action into publish mode. That publishes the only unpublished package — `@computesdk/isorun@0.1.0` (with OIDC provenance) — and nothing else.

Side effect: with no changesets present, the action deletes `changeset-release/main`, auto-closing the existing "Version Packages" PR (#595, bench-only). The bench changeset is restored in a follow-up PR so it re-queues for its own release when ready.

**Do not merge #595** — merge this instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)