### PR TITLE
Add AgentCore provider

### DIFF
--- a/.changeset/add-agentcore-provider.md
+++ b/.changeset/add-agentcore-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/agentcore": patch
+---
+
+Add AWS Bedrock AgentCore Code Interpreter provider. Maps a ComputeSDK sandbox onto an AgentCore Code Interpreter session, with command execution and filesystem support. Authenticates via the standard AWS credential provider chain (environment variables, SSO, named profiles, instance roles), so temporary credentials and profiles work out of the box.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **CreateOS** | `CREATEOS_SANDBOX_API_KEY`, `CREATEOS_SANDBOX_BASE_URL` | VM sandboxes with pause/resume/fork snapshots |
 | **Lelantos** | `LELANTOS_API_KEY` | EU-native Firecracker microVMs, code execution, preview URLs |
 | **Tenki** | `TENKI_API_KEY` or `TENKI_AUTH_TOKEN` | MicroVM sandboxes with native filesystem and preview URLs |
+| **AgentCore** | AWS credential chain (`AWS_REGION`, profile, or SSO) | Managed AWS code-execution sandboxes |
 
 ## Configuration
 
@@ -271,6 +272,7 @@ npm install @computesdk/railway    # Railway provider
 npm install @computesdk/createos-sandbox # CreateOS VM sandbox provider
 npm install @computesdk/lelantos   # Lelantos provider
 npm install @computesdk/tenki      # Tenki provider
+npm install @computesdk/agentcore  # AWS Bedrock AgentCore provider
 npm install @computesdk/just-bash  # Local bash sandbox (no auth needed)
 ```
 
@@ -293,6 +295,7 @@ See individual provider READMEs for details:
 - **[@computesdk/createos-sandbox](./packages/createos-sandbox)** - NodeOps VM sandboxes, with pause/resume/fork snapshots and a native-handle escape hatch
 - **[@computesdk/lelantos](./packages/lelantos)** - EU-native Firecracker microVM sandboxes (E2B-API-compatible), with snapshot/template support
 - **[@computesdk/tenki](./packages/tenki)** - Tenki Cloud microVM sandboxes with native filesystem and public preview URLs
+- **[@computesdk/agentcore](./packages/agentcore)** - Managed AWS Bedrock AgentCore Code Interpreter sandboxes, authenticated via the standard AWS credential chain
 - **[@computesdk/just-bash](./packages/just-bash)** - Local bash sandbox with virtual filesystem (no auth required)
 
 ## Building Custom Providers

--- a/docs/providers/agentcore.md
+++ b/docs/providers/agentcore.md
@@ -1,0 +1,98 @@
+# AWS Bedrock AgentCore
+
+[AWS Bedrock AgentCore Code Interpreter](https://docs.aws.amazon.com/bedrock-agentcore/) provider for ComputeSDK - secure, fully-managed, session-based sandboxes for running code and shell commands, with no infrastructure to provision.
+
+A ComputeSDK sandbox maps onto an AgentCore Code Interpreter session.
+
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/agentcore
+```
+
+There is no API key. The provider uses the standard [AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) — the same resolution as the AWS CLI — so environment variables, SSO sessions, named profiles, and instance roles all work, including temporary credentials.
+
+A region is required, via `region` in config or `AWS_REGION` / `AWS_DEFAULT_REGION`.
+
+### IAM permissions
+
+```
+bedrock-agentcore:StartCodeInterpreterSession
+bedrock-agentcore:InvokeCodeInterpreter
+bedrock-agentcore:StopCodeInterpreterSession
+bedrock-agentcore:GetCodeInterpreterSession
+bedrock-agentcore:ListCodeInterpreterSessions
+```
+
+
+## Usage
+
+```typescript
+import { agentcore } from '@computesdk/agentcore';
+
+const compute = agentcore({ region: 'us-west-2' });
+
+// Create sandbox (an AgentCore Code Interpreter session)
+const sandbox = await compute.sandbox.create();
+
+// Run a command
+const result = await sandbox.runCommand('echo "Hello from AgentCore!"');
+console.log(result.stdout); // "Hello from AgentCore!"
+
+// Run code via the available runtimes (e.g. Python)
+const code = await sandbox.runCommand('python3 -c "print(2 + 2)"');
+console.log(code.stdout); // "4"
+
+// Work with files (files persist for the life of the session)
+await sandbox.filesystem.writeFile('/tmp/hello.py', 'print("Hello World")');
+const content = await sandbox.filesystem.readFile('/tmp/hello.py');
+
+// Clean up
+await sandbox.destroy();
+```
+
+### Named profile
+
+```typescript
+agentcore({ region: 'us-west-2', profile: 'my-profile' });
+```
+
+### Explicit / temporary credentials
+
+```typescript
+agentcore({
+  region: 'us-west-2',
+  credentials: {
+    accessKeyId: '...',
+    secretAccessKey: '...',
+    sessionToken: '...', // temporary credentials supported
+  },
+});
+```
+
+### Configuration Options
+
+```typescript
+interface AgentCoreConfig {
+  /** AWS region. Falls back to AWS_REGION / AWS_DEFAULT_REGION */
+  region?: string;
+  /** Code interpreter to use. Defaults to the managed `aws.codeinterpreter.v1` */
+  codeInterpreterIdentifier?: string;
+  /** Named AWS profile to use for credentials */
+  profile?: string;
+  /** Explicit credentials. Omit to use the default AWS credential chain */
+  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  /** Session timeout in seconds (max 28800 / 8h). Default 900. Overridden by per-create `timeout` (ms) */
+  sessionTimeoutSeconds?: number;
+}
+```
+
+
+## Limitations
+
+- **No preview URLs / ports.** AgentCore Code Interpreter has no inbound network endpoint, so `getUrl()` throws.
+- **No interactive PTY.** Commands are request/response.
+- **Sessions expire.** A session auto-terminates after its idle timeout; create a new sandbox afterward.
+- **Filesystem persists, shell environment does not.** Files survive across `runCommand` calls, but each command runs in a fresh shell — `cd`, `export`, and shell variables do not carry over. Chain them in one command or use the `cwd`/`env` options.
+- **Background commands don't outlive the call.** `{ background: true }` returns immediately, but AgentCore terminates the process tree when the invocation ends, so the job is killed rather than left running.

--- a/packages/agentcore/README.md
+++ b/packages/agentcore/README.md
@@ -87,6 +87,114 @@ agentcore({
 | `credentials` | `AwsCredentialIdentity \| AwsCredentialIdentityProvider` | Explicit credentials. Omit to use the default chain. |
 | `sessionTimeoutSeconds` | `number` | Session idle timeout in seconds (max 28800 / 8h). Default 900. Overridden by the per-`create` `timeout` (ms). |
 
+## API Reference
+
+### Command Execution
+
+```typescript
+// Run a shell command
+const result = await sandbox.runCommand('echo "Hello" && ls -la');
+console.log(result.stdout, result.stderr, result.exitCode);
+
+// Run Python
+const py = await sandbox.runCommand('python3 -c "print(2 + 2)"');
+
+// Run a multi-line script via heredoc
+const script = await sandbox.runCommand(`python3 - <<'PY'
+import json
+print(json.dumps({"ok": True}))
+PY`);
+
+// Pass environment variables and a working directory
+await sandbox.runCommand('printenv TOKEN', { env: { TOKEN: 'abc' }, cwd: '/tmp' });
+
+// Install packages
+await sandbox.runCommand('pip install requests');
+```
+
+`runCommand` never throws for command failures — a non-zero exit is returned in `exitCode`, with `stdout`/`stderr` captured separately.
+
+### Filesystem Operations
+
+```typescript
+await sandbox.filesystem.writeFile('/tmp/hello.py', 'print("Hello World")');
+const content = await sandbox.filesystem.readFile('/tmp/hello.py');
+await sandbox.filesystem.mkdir('/tmp/data');
+const files = await sandbox.filesystem.readdir('/tmp');      // FileEntry[]
+const exists = await sandbox.filesystem.exists('/tmp/hello.py');
+await sandbox.filesystem.remove('/tmp/hello.py');
+```
+
+Filesystem calls operate on text (UTF-8). To move binary data, fetch it inside the
+sandbox (`runCommand('curl -sL URL -o /tmp/file')`) or base64 it over `runCommand`.
+
+### Sandbox Management
+
+```typescript
+const info = await sandbox.getInfo();          // { id, provider, status, createdAt, timeout, metadata }
+const existing = await provider.sandbox.getById(sandbox.sandboxId);  // or null if terminated
+const all = await provider.sandbox.list();     // READY sessions
+await sandbox.destroy();
+```
+
+## Error Handling
+
+`create` translates common AWS failures into actionable messages:
+
+```typescript
+try {
+  const sandbox = await compute.sandbox.create();
+} catch (err) {
+  // e.g. "Missing AWS region for AgentCore. Pass it: agentcore({ region: 'us-west-2' }) ..."
+  // or   "AWS authentication failed for AgentCore. Check your credentials ..."
+  // or   "Access denied ... Ensure your IAM principal allows bedrock-agentcore:*CodeInterpreter* ..."
+  console.error(err.message);
+}
+```
+
+- `runCommand` returns `exitCode: 127` with the error on `stderr` if the invocation itself fails (e.g. the session expired) — it does not throw.
+- Filesystem operations throw on failure (e.g. reading a missing file).
+
+## Examples
+
+### Data processing
+
+```typescript
+const sandbox = await compute.sandbox.create();
+
+await sandbox.filesystem.writeFile('/tmp/data.csv', 'value\n10\n20\n30\n');
+const result = await sandbox.runCommand(`python3 - <<'PY'
+import csv, json
+with open('/tmp/data.csv') as f:
+    values = [int(r['value']) for r in csv.DictReader(f)]
+print(json.dumps({'count': len(values), 'sum': sum(values), 'mean': sum(values)/len(values)}))
+PY`);
+console.log(JSON.parse(result.stdout)); // { count: 3, sum: 60, mean: 20 }
+
+await sandbox.destroy();
+```
+
+### As an AI agent tool
+
+The universal `Sandbox` interface maps cleanly onto agent-framework tools — wrap each
+method in a tool and hand them to your agent (works with any agent SDK):
+
+```typescript
+import { tool } from '@strands-agents/sdk';
+import { z } from 'zod';
+
+const runCommand = tool({
+  name: 'run_command',
+  description: 'Run a shell command in the sandbox.',
+  inputSchema: z.object({ command: z.string() }),
+  callback: async ({ command }) => {
+    const r = await sandbox.runCommand(command);
+    return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode };
+  },
+});
+// ...similarly wrap writeFile / readFile / readdir, then: new Agent({ tools: [...] })
+```
+
 ## Supported runtimes
 
 The managed `aws.codeinterpreter.v1` interpreter ships with Python and a standard Linux shell, so any language runtime available in that environment can be driven via `runCommand`.

--- a/packages/agentcore/README.md
+++ b/packages/agentcore/README.md
@@ -1,0 +1,106 @@
+# @computesdk/agentcore
+
+[AWS Bedrock AgentCore Code Interpreter](https://docs.aws.amazon.com/bedrock-agentcore/) provider for [ComputeSDK](https://www.computesdk.com).
+
+AgentCore Code Interpreter gives you secure, fully-managed, session-based sandboxes for running code and shell commands — no infrastructure to provision. This provider maps a ComputeSDK sandbox onto an AgentCore Code Interpreter session.
+
+## Features
+
+- **Command execution** — run shell commands in an isolated, managed sandbox
+- **Persistent filesystem** — a sandbox is a long-lived session; files written in one call are visible in later calls
+- **Filesystem operations** — read, write, list, and remove files
+- **Standard AWS auth** — uses the default AWS credential provider chain (env vars, SSO, profiles, instance roles), so temporary credentials and named profiles just work
+
+## Installation
+
+```bash
+npm install @computesdk/agentcore
+```
+
+## Authentication
+
+The provider uses the [standard AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) — the same resolution order as the AWS CLI. You don't pass an API key; you authenticate to AWS however you normally would:
+
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+- An SSO session (`aws sso login`)
+- A named profile (`AWS_PROFILE`, or `profile` in config)
+- EC2/ECS/EKS instance roles
+
+A **region** is required, via `region` in config or `AWS_REGION` / `AWS_DEFAULT_REGION`.
+
+### IAM permissions
+
+The principal needs these `bedrock-agentcore` actions on the code interpreter:
+
+- `bedrock-agentcore:StartCodeInterpreterSession`
+- `bedrock-agentcore:InvokeCodeInterpreter`
+- `bedrock-agentcore:StopCodeInterpreterSession`
+- `bedrock-agentcore:GetCodeInterpreterSession` (for `getById`)
+- `bedrock-agentcore:ListCodeInterpreterSessions` (for `list`)
+
+## Usage
+
+```typescript
+import { compute } from 'computesdk';
+import { agentcore } from '@computesdk/agentcore';
+
+// Uses the default AWS credential chain; region from env or config.
+compute.setConfig({ defaultProvider: agentcore({ region: 'us-west-2' }) });
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('echo "Hello from AgentCore" && python3 -c "print(2 + 2)"');
+console.log(result.stdout); // Hello from AgentCore\n4
+
+await sandbox.filesystem.writeFile('/tmp/data.txt', 'persisted across calls');
+console.log(await sandbox.filesystem.readFile('/tmp/data.txt'));
+
+await sandbox.destroy();
+```
+
+### Using a named profile
+
+```typescript
+agentcore({ region: 'us-west-2', profile: 'my-profile' });
+```
+
+### Using explicit / temporary credentials
+
+```typescript
+agentcore({
+  region: 'us-west-2',
+  credentials: {
+    accessKeyId: '...',
+    secretAccessKey: '...',
+    sessionToken: '...', // temporary credentials supported
+  },
+});
+```
+
+## Configuration
+
+| Option | Type | Description |
+|---|---|---|
+| `region` | `string` | AWS region. Falls back to `AWS_REGION` / `AWS_DEFAULT_REGION`. |
+| `codeInterpreterIdentifier` | `string` | Code interpreter to use. Defaults to the managed `aws.codeinterpreter.v1`. |
+| `profile` | `string` | Named AWS profile to use for credentials. |
+| `credentials` | `AwsCredentialIdentity \| AwsCredentialIdentityProvider` | Explicit credentials. Omit to use the default chain. |
+| `sessionTimeoutSeconds` | `number` | Session idle timeout in seconds (max 28800 / 8h). Default 900. Overridden by the per-`create` `timeout` (ms). |
+
+## Supported runtimes
+
+The managed `aws.codeinterpreter.v1` interpreter ships with Python and a standard Linux shell, so any language runtime available in that environment can be driven via `runCommand`.
+
+## Limitations
+
+- **No preview URLs / ports.** AgentCore Code Interpreter has no inbound network endpoint, so `getUrl()` throws. Use it for code execution, not for hosting dev servers.
+- **No interactive PTY.** Commands are request/response; there is no bidirectional terminal.
+- **Sessions expire.** A session auto-terminates after its idle timeout; create a new sandbox afterward.
+- **Filesystem persists, shell environment does not.** Files survive across `runCommand` calls, but each command runs in a fresh shell — `cd`, `export`, and shell variables do not carry over. Chain them in a single command (e.g. `cd /app && npm test`) or use the `cwd`/`env` options.
+- **Background commands don't outlive the call.** `runCommand(..., { background: true })` returns immediately, but AgentCore terminates the process tree when the invocation ends, so the job is killed rather than left running. Use a single command that runs to completion instead.
+- **Large writes are chunked.** To stay under AgentCore's command-size limit, `writeFile` uploads base64 in ~60KB chunks — roughly one round-trip per 60KB, so a 5MB file takes ~40s. Reads are single round-trips and fast.
+- **~10 concurrent operations per session.** AgentCore caps concurrent invocations on a single session; beyond ~10 simultaneous `runCommand`/filesystem calls, extra ones fail with a quota error. Spread heavy parallelism across multiple sandboxes.
+
+## License
+
+MIT

--- a/packages/agentcore/package.json
+++ b/packages/agentcore/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@computesdk/agentcore",
+  "version": "0.1.0",
+  "description": "AWS Bedrock AgentCore Code Interpreter provider for ComputeSDK - secure, session-based code execution sandboxes",
+  "author": "ComputeSDK",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "computesdk": "workspace:*",
+    "@computesdk/provider": "workspace:*",
+    "@aws-sdk/client-bedrock-agentcore": "^3.1076.0"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "keywords": [
+    "computesdk",
+    "agentcore",
+    "bedrock",
+    "aws",
+    "sandbox",
+    "code-execution",
+    "code-interpreter",
+    "cloud",
+    "provider",
+    "agents"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/agentcore"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  }
+}

--- a/packages/agentcore/package.json
+++ b/packages/agentcore/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "computesdk": "workspace:*",
     "@computesdk/provider": "workspace:*",
-    "@aws-sdk/client-bedrock-agentcore": "^3.1076.0"
+    "@aws-sdk/client-bedrock-agentcore": "^3.1076.0",
+    "@aws-sdk/types": "^3.973.15"
   },
   "devDependencies": {
     "@computesdk/test-utils": "workspace:*",

--- a/packages/agentcore/src/__tests__/behavior.test.ts
+++ b/packages/agentcore/src/__tests__/behavior.test.ts
@@ -109,4 +109,19 @@ describeFn('agentcore behavior', () => {
     const final = await sb.filesystem.readFile('/tmp/concurrent.txt');
     expect(candidates).toContain(final); // one writer wins intact; no interleave
   }, 120000);
+
+  it('bounds a runaway command with the timeout option', async () => {
+    const sb = await getSandbox();
+    const result = await sb.runCommand('sleep 30', { timeout: 1000 });
+    expect(result.exitCode).toBe(124); // killed by `timeout`, not run to completion
+  }, 60000);
+
+  it('runs a backgrounded command in the requested cwd', async () => {
+    // Regression: nohup must wrap the whole `cd X && cmd`, not split on &&.
+    const sb = await getSandbox();
+    await sb.filesystem.mkdir('/tmp/bgcwd');
+    await sb.runCommand('echo DATA > out.txt && sleep 1', { cwd: '/tmp/bgcwd', background: true });
+    await new Promise((r) => setTimeout(r, 2500));
+    expect(await sb.filesystem.readFile('/tmp/bgcwd/out.txt')).toBe('DATA\n');
+  }, 60000);
 });

--- a/packages/agentcore/src/__tests__/behavior.test.ts
+++ b/packages/agentcore/src/__tests__/behavior.test.ts
@@ -1,0 +1,112 @@
+/**
+ * AgentCore-specific behavior tests.
+ *
+ * These lock in correctness fixes that the generic provider suite doesn't cover:
+ * byte-exact output with LF line endings (AgentCore runs commands through a PTY),
+ * true stdout/stderr/exit-code separation on failure, shell-safe handling of
+ * paths/values with `$`, spaces, and quotes, directory listing, and env passing.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { agentcore } from '../index';
+import type { ProviderSandbox } from '@computesdk/provider';
+
+const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
+const hasCredentials = Boolean(
+  region &&
+    (process.env.AWS_ACCESS_KEY_ID || process.env.AWS_PROFILE || process.env.AWS_SESSION_TOKEN),
+);
+
+const describeFn = hasCredentials ? describe : describe.skip;
+
+describeFn('agentcore behavior', () => {
+  const provider = agentcore({ region });
+  let sandbox: ProviderSandbox;
+
+  const getSandbox = async () => {
+    if (!sandbox) sandbox = await provider.sandbox.create();
+    return sandbox;
+  };
+
+  afterAll(async () => {
+    if (sandbox) await sandbox.destroy().catch(() => {});
+  });
+
+  it('normalizes CRLF output to LF', async () => {
+    const sb = await getSandbox();
+    const result = await sb.runCommand('printf "a\\nb\\nc\\n"');
+    expect(result.stdout).toBe('a\nb\nc\n');
+    expect(result.stdout).not.toContain('\r');
+  }, 60000);
+
+  it('handles paths containing $ and spaces without expansion', async () => {
+    const sb = await getSandbox();
+    const path = '/tmp/agentcore test/da$h.txt';
+    await sb.filesystem.writeFile(path, 'literal');
+    expect(await sb.filesystem.readFile(path)).toBe('literal');
+    expect(await sb.filesystem.exists(path)).toBe(true);
+  }, 60000);
+
+  it('round-trips file content exactly, including special characters', async () => {
+    const sb = await getSandbox();
+    const content = 'line1\nline2\t"quoted" $VAR `cmd` \'single\'\n';
+    await sb.filesystem.writeFile('/tmp/special.txt', content);
+    expect(await sb.filesystem.readFile('/tmp/special.txt')).toBe(content);
+  }, 60000);
+
+  it('passes environment variables to the command', async () => {
+    const sb = await getSandbox();
+    const result = await sb.runCommand('printenv GREETING', { env: { GREETING: 'hi there$x' } });
+    expect(result.stdout).toBe('hi there$x\n');
+  }, 60000);
+
+  it('reports a non-zero exit code for failing commands', async () => {
+    const sb = await getSandbox();
+    const result = await sb.runCommand('exit 42');
+    expect(result.exitCode).toBe(42);
+  }, 60000);
+
+  it('preserves stdout and separates stderr even when the command fails', async () => {
+    // AgentCore's PTY otherwise merges streams and drops stdout on non-zero exit.
+    const sb = await getSandbox();
+    const result = await sb.runCommand('echo to-out; echo to-err >&2; exit 7');
+    expect(result.stdout).toBe('to-out\n');
+    expect(result.stderr).toBe('to-err\n');
+    expect(result.exitCode).toBe(7);
+  }, 60000);
+
+  it('lists directory entries with spaces and correct types', async () => {
+    const sb = await getSandbox();
+    await sb.filesystem.writeFile('/tmp/listdir/my file.txt', 'a');
+    await sb.filesystem.mkdir('/tmp/listdir/sub');
+    const entries = await sb.filesystem.readdir('/tmp/listdir');
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e.type]));
+    expect(byName['my file.txt']).toBe('file');
+    expect(byName['sub']).toBe('directory');
+  }, 60000);
+
+  it('lists filenames containing control characters byte-exactly', async () => {
+    // The NUL-delimited find output must survive names with tabs (a byte the
+    // raw structuredContent stream would otherwise mangle to '?').
+    const sb = await getSandbox();
+    await sb.runCommand(`mkdir -p /tmp/ctrldir && cd /tmp/ctrldir && : > "$(printf 'a\\tb')"`);
+    const names = (await sb.filesystem.readdir('/tmp/ctrldir')).map((e) => e.name);
+    expect(names).toContain('a\tb');
+  }, 60000);
+
+  it('writes a large file that exceeds the single-command size limit', async () => {
+    // >128KB base64 would hang the PTY in a single command; writeFile chunks it.
+    const sb = await getSandbox();
+    const content = 'A'.repeat(500_000) + '\nΩ end';
+    await sb.filesystem.writeFile('/tmp/large.txt', content);
+    expect(await sb.filesystem.readFile('/tmp/large.txt')).toBe(content);
+  }, 120000);
+
+  it('does not corrupt concurrent writes to the same path', async () => {
+    // Per-call UUID staging must prevent parallel writes from interleaving.
+    const sb = await getSandbox();
+    const candidates = ['A'.repeat(200_000), 'B'.repeat(200_000), 'C'.repeat(200_000)];
+    await Promise.all(candidates.map((c) => sb.filesystem.writeFile('/tmp/concurrent.txt', c)));
+    const final = await sb.filesystem.readFile('/tmp/concurrent.txt');
+    expect(candidates).toContain(final); // one writer wins intact; no interleave
+  }, 120000);
+});

--- a/packages/agentcore/src/__tests__/crud.test.ts
+++ b/packages/agentcore/src/__tests__/crud.test.ts
@@ -1,0 +1,14 @@
+import { runProviderCrudTest } from '@computesdk/test-utils';
+import { agentcore } from '../index';
+
+const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
+const hasCredentials = Boolean(
+  region &&
+    (process.env.AWS_ACCESS_KEY_ID || process.env.AWS_PROFILE || process.env.AWS_SESSION_TOKEN),
+);
+
+runProviderCrudTest({
+  name: 'agentcore',
+  provider: agentcore({ region }),
+  skipIntegration: !hasCredentials,
+});

--- a/packages/agentcore/src/__tests__/index.test.ts
+++ b/packages/agentcore/src/__tests__/index.test.ts
@@ -1,0 +1,19 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { agentcore } from '../index';
+
+// Integration tests run when AWS credentials + region are available.
+// AgentCore resolves credentials via the standard AWS chain (env, SSO, profile).
+const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
+const hasCredentials = Boolean(
+  region &&
+    (process.env.AWS_ACCESS_KEY_ID || process.env.AWS_PROFILE || process.env.AWS_SESSION_TOKEN),
+);
+
+runProviderTestSuite({
+  name: 'agentcore',
+  provider: agentcore({ region }),
+  supportsFilesystem: true,
+  // AgentCore has no inbound ports / preview URLs.
+  supportsGetUrl: false,
+  skipIntegration: !hasCredentials,
+});

--- a/packages/agentcore/src/__tests__/internal.test.ts
+++ b/packages/agentcore/src/__tests__/internal.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the pure helpers — run unconditionally, no AWS credentials
+ * needed. These cover the trickiest logic (shell escaping, command assembly,
+ * marker parsing, error classification, timeout clamping) in isolation.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  sq,
+  buildCommand,
+  wrapForCapture,
+  parseWrappedResult,
+  friendlyError,
+  clampSessionTimeout,
+  MIN_SESSION_TIMEOUT_SECONDS,
+  MAX_SESSION_TIMEOUT_SECONDS,
+} from '../internal';
+
+describe('sq (POSIX single-quote)', () => {
+  it('wraps a plain string in single quotes', () => {
+    expect(sq('hello')).toBe("'hello'");
+  });
+
+  it('neutralizes expansion characters by quoting them literally', () => {
+    expect(sq('$HOME `id` ${x}')).toBe("'$HOME `id` ${x}'");
+  });
+
+  it('escapes embedded single quotes with the close-escape-reopen idiom', () => {
+    expect(sq("it's")).toBe("'it'\\''s'");
+  });
+
+  it('handles an empty string', () => {
+    expect(sq('')).toBe("''");
+  });
+
+  it('handles a string that is only a single quote', () => {
+    expect(sq("'")).toBe("''\\'''");
+  });
+});
+
+describe('clampSessionTimeout', () => {
+  it('passes through in-range values (rounding up)', () => {
+    expect(clampSessionTimeout(900)).toBe(900);
+    expect(clampSessionTimeout(0.4)).toBe(MIN_SESSION_TIMEOUT_SECONDS);
+  });
+
+  it('clamps above the maximum', () => {
+    expect(clampSessionTimeout(99999)).toBe(MAX_SESSION_TIMEOUT_SECONDS);
+  });
+
+  it('clamps below the minimum', () => {
+    expect(clampSessionTimeout(0)).toBe(MIN_SESSION_TIMEOUT_SECONDS);
+    expect(clampSessionTimeout(-5)).toBe(MIN_SESSION_TIMEOUT_SECONDS);
+  });
+
+  it('defaults non-finite input to the maximum', () => {
+    expect(clampSessionTimeout(NaN)).toBe(MAX_SESSION_TIMEOUT_SECONDS);
+    expect(clampSessionTimeout(Infinity)).toBe(MAX_SESSION_TIMEOUT_SECONDS);
+  });
+});
+
+describe('buildCommand', () => {
+  it('returns the command unchanged with no options', () => {
+    expect(buildCommand('echo hi')).toBe('echo hi');
+  });
+
+  it('prefixes env vars (single-quoted) before the command', () => {
+    expect(buildCommand('printenv X', { env: { X: 'a b' } })).toBe("X='a b' printenv X");
+  });
+
+  it('applies env before wrapping in cwd so vars bind to the real command', () => {
+    const out = buildCommand('run', { env: { A: '1' }, cwd: '/tmp' });
+    expect(out).toBe("cd '/tmp' && A='1' run");
+  });
+
+  it('throws on an invalid env var name', () => {
+    expect(() => buildCommand('x', { env: { 'BAD-KEY': '1' } })).toThrow(/Invalid environment variable name/);
+    expect(() => buildCommand('x', { env: { 'A\nB': '1' } })).toThrow(/Invalid environment variable name/);
+  });
+
+  it('wraps background commands with nohup and detaches', () => {
+    expect(buildCommand('server', { background: true })).toBe('nohup server > /dev/null 2>&1 &');
+  });
+});
+
+describe('wrapForCapture + parseWrappedResult round-trip', () => {
+  const tag = 'abc123';
+
+  it('wraps into a subshell with markers and cleanup', () => {
+    const w = wrapForCapture('echo hi', tag);
+    expect(w).toContain('( echo hi )');
+    expect(w).toContain(`CSDKrc${tag}=`);
+    expect(w).toContain(`CSDKsep${tag}`);
+    expect(w).toContain(`rm -f /tmp/.csdk-${tag}.out /tmp/.csdk-${tag}.err`);
+  });
+
+  const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+
+  it('parses stdout, stderr, and exit code from wrapper output', () => {
+    const raw = `CSDKrc${tag}=7\n${b64('out data')}\nCSDKsep${tag}\n${b64('err data')}\n`;
+    expect(parseWrappedResult(raw, tag)).toEqual({ stdout: 'out data', stderr: 'err data', exitCode: 7 });
+  });
+
+  it('is byte-exact for content with newlines and special characters', () => {
+    const stdout = 'line1\nline2\t"q" $x\n';
+    const raw = `CSDKrc${tag}=0\n${b64(stdout)}\nCSDKsep${tag}\n`;
+    expect(parseWrappedResult(raw, tag).stdout).toBe(stdout);
+  });
+
+  it('tolerates CRLF around the markers', () => {
+    const raw = `CSDKrc${tag}=3\r\n${b64('x')}\r\nCSDKsep${tag}\r\n${b64('y')}\r\n`;
+    expect(parseWrappedResult(raw, tag)).toEqual({ stdout: 'x', stderr: 'y', exitCode: 3 });
+  });
+
+  it('does not mis-parse command output that resembles markers (base64 envelope protects it)', () => {
+    const stdout = `CSDKsep${tag}\nCSDKrc${tag}=99\n`; // command literally prints marker-like text
+    const raw = `CSDKrc${tag}=0\n${b64(stdout)}\nCSDKsep${tag}\n`;
+    const parsed = parseWrappedResult(raw, tag);
+    expect(parsed.exitCode).toBe(0);
+    expect(parsed.stdout).toBe(stdout);
+  });
+
+  it('falls back to raw text when markers are absent', () => {
+    expect(parseWrappedResult('unexpected shell error', tag)).toEqual({
+      stdout: 'unexpected shell error',
+      stderr: '',
+      exitCode: 1,
+    });
+    expect(parseWrappedResult('', tag)).toEqual({ stdout: '', stderr: '', exitCode: 0 });
+  });
+});
+
+describe('friendlyError', () => {
+  it('maps a missing-region error', () => {
+    const e = friendlyError('starting a session', new Error('Region is missing'));
+    expect(e.message).toMatch(/Missing AWS region/);
+  });
+
+  it('maps credential errors by name', () => {
+    const err = Object.assign(new Error('whatever'), { name: 'CredentialsProviderError' });
+    expect(friendlyError('x', err).message).toMatch(/authentication failed/i);
+  });
+
+  it('maps expired-token errors', () => {
+    const err = Object.assign(new Error('The security token included in the request is expired'), {
+      name: 'ExpiredTokenException',
+    });
+    expect(friendlyError('x', err).message).toMatch(/authentication failed/i);
+  });
+
+  it('maps access-denied errors by name', () => {
+    const err = Object.assign(new Error('nope'), { name: 'AccessDeniedException' });
+    expect(friendlyError('starting a session', err).message).toMatch(/Access denied/);
+  });
+
+  it('falls back to a generic wrapped message', () => {
+    expect(friendlyError('doing a thing', new Error('boom')).message).toBe('Failed doing a thing: boom');
+  });
+});

--- a/packages/agentcore/src/__tests__/internal.test.ts
+++ b/packages/agentcore/src/__tests__/internal.test.ts
@@ -77,8 +77,20 @@ describe('buildCommand', () => {
     expect(() => buildCommand('x', { env: { 'A\nB': '1' } })).toThrow(/Invalid environment variable name/);
   });
 
-  it('wraps background commands with nohup and detaches', () => {
-    expect(buildCommand('server', { background: true })).toBe('nohup server > /dev/null 2>&1 &');
+  it('wraps background commands in sh -c so nohup covers the whole command', () => {
+    expect(buildCommand('server', { background: true })).toBe("nohup sh -c 'server' > /dev/null 2>&1 &");
+  });
+
+  it('keeps cwd inside the backgrounded unit (nohup must not split on &&)', () => {
+    // Regression: `nohup cd X && cmd &` runs cmd in the wrong dir / not at all.
+    expect(buildCommand('run', { cwd: '/app', background: true })).toBe(
+      "nohup sh -c 'cd '\\''/app'\\'' && run' > /dev/null 2>&1 &",
+    );
+  });
+
+  it('bounds runtime with the timeout coreutil (ms -> seconds, rounded up)', () => {
+    expect(buildCommand('slow', { timeout: 5000 })).toBe("timeout 5 sh -c 'slow'");
+    expect(buildCommand('slow', { timeout: 1500 })).toBe("timeout 2 sh -c 'slow'");
   });
 });
 

--- a/packages/agentcore/src/index.ts
+++ b/packages/agentcore/src/index.ts
@@ -1,0 +1,439 @@
+/**
+ * AWS Bedrock AgentCore Code Interpreter Provider - Factory-based Implementation
+ *
+ * Maps a ComputeSDK "sandbox" onto an AgentCore Code Interpreter *session*:
+ *   create   -> StartCodeInterpreterSession
+ *   destroy  -> StopCodeInterpreterSession
+ *   getById  -> GetCodeInterpreterSession
+ *   list     -> ListCodeInterpreterSessions
+ *   command  -> InvokeCodeInterpreter (name: ToolName.EXECUTE_COMMAND)
+ *
+ * Auth uses the standard AWS credential provider chain (env vars, SSO, profiles,
+ * EC2/ECS roles, ...). Pass `profile` or `credentials` to override; otherwise the
+ * SDK resolves credentials exactly like the AWS CLI, including temporary creds.
+ */
+
+import {
+  BedrockAgentCoreClient,
+  StartCodeInterpreterSessionCommand,
+  StopCodeInterpreterSessionCommand,
+  GetCodeInterpreterSessionCommand,
+  ListCodeInterpreterSessionsCommand,
+  InvokeCodeInterpreterCommand,
+  ToolName,
+  CodeInterpreterSessionStatus,
+} from '@aws-sdk/client-bedrock-agentcore';
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { randomUUID } from 'node:crypto';
+import { defineProvider } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from 'computesdk';
+import { sq, buildCommand, wrapForCapture, parseWrappedResult, friendlyError, clampSessionTimeout } from './internal.js';
+
+/** The built-in managed code interpreter. */
+const DEFAULT_CODE_INTERPRETER = 'aws.codeinterpreter.v1';
+/** AgentCore default session timeout (seconds). */
+const DEFAULT_SESSION_TIMEOUT_SECONDS = 900;
+/**
+ * Max base64 bytes per writeFile command. AgentCore's PTY input line caps around
+ * 128KB and silently hangs beyond it, so stage large writes in bounded chunks.
+ */
+const B64_CHUNK_SIZE = 60000;
+
+export interface AgentCoreConfig {
+  /** AWS region (e.g. 'us-west-2'). Falls back to AWS_REGION / AWS_DEFAULT_REGION. */
+  region?: string;
+  /**
+   * Code interpreter to use. Defaults to the managed `aws.codeinterpreter.v1`.
+   * Pass a custom interpreter id/ARN to use one created via the control plane.
+   */
+  codeInterpreterIdentifier?: string;
+  /** Named profile from your AWS config/credentials files. */
+  profile?: string;
+  /** Explicit credentials. If omitted, the default AWS credential chain is used. */
+  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  /** Session idle timeout in seconds (max 28800 / 8h). Overridden by per-create `timeout`. */
+  sessionTimeoutSeconds?: number;
+}
+
+/** Native sandbox object: the live client plus session coordinates. */
+interface AgentCoreSandbox {
+  client: BedrockAgentCoreClient;
+  codeInterpreterIdentifier: string;
+  sessionId: string;
+  createdAt: Date;
+  sessionTimeoutSeconds: number;
+}
+
+/** Flattened result of a single InvokeCodeInterpreter call. */
+interface InvocationResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function createClient(config: AgentCoreConfig): BedrockAgentCoreClient {
+  // Set each option only when explicitly provided, so the SDK's own resolution
+  // chains stay intact: region resolves from AWS_REGION/AWS_DEFAULT_REGION or the
+  // active profile's config file; credentials from env, SSO, profile, or instance
+  // roles. Second-guessing these here would break valid profile-only setups.
+  return new BedrockAgentCoreClient({
+    ...(config.region ? { region: config.region } : {}),
+    ...(config.profile ? { profile: config.profile } : {}),
+    ...(config.credentials ? { credentials: config.credentials } : {}),
+  });
+}
+
+/** Drain the InvokeCodeInterpreter event stream into a flat result. */
+async function invoke(
+  sandbox: AgentCoreSandbox,
+  name: ToolName,
+  args: Record<string, unknown>,
+): Promise<InvocationResult> {
+  const response = await sandbox.client.send(
+    new InvokeCodeInterpreterCommand({
+      codeInterpreterIdentifier: sandbox.codeInterpreterIdentifier,
+      sessionId: sandbox.sessionId,
+      name,
+      arguments: args,
+    }),
+  );
+
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  let isError = false;
+  let text = '';
+  let hasStructured = false;
+
+  for await (const event of response.stream ?? []) {
+    // The stream is a tagged union: a result, or a mid-stream exception
+    // (throttling, server error, ...). Surface exceptions instead of silently
+    // treating them as an empty successful result.
+    const exception =
+      event.throttlingException ??
+      event.internalServerException ??
+      event.serviceQuotaExceededException ??
+      event.accessDeniedException ??
+      event.resourceNotFoundException ??
+      event.conflictException ??
+      event.validationException;
+    if (exception) throw exception;
+
+    const result = event.result;
+    if (!result) continue;
+    if (result.isError) isError = true;
+
+    // The execute* tools return a structuredContent with clean streams.
+    const structured = result.structuredContent;
+    if (structured) {
+      hasStructured = true;
+      if (typeof structured.stdout === 'string') stdout += structured.stdout;
+      if (typeof structured.stderr === 'string') stderr += structured.stderr;
+      if (typeof structured.exitCode === 'number') exitCode = structured.exitCode;
+    }
+
+    for (const block of result.content ?? []) {
+      if (block.type === 'text' && typeof block.text === 'string') text += block.text;
+    }
+  }
+
+  // Tool-level failures (e.g. invalid arguments) carry no structuredContent,
+  // only a text error block. Surface that as stderr with a non-zero exit code.
+  if (isError && !hasStructured) {
+    if (!stderr) stderr = text;
+    if (exitCode === 0) exitCode = 1;
+  }
+
+  // AgentCore runs commands through a PTY, so line endings come back as CRLF.
+  // stderr is surfaced raw in error messages, so normalize it to LF. stdout is
+  // always consumed as base64 or via the marker wrapper (both CRLF-immune), so
+  // it needs no normalization here.
+  return { stdout, stderr: stderr.replace(/\r\n/g, '\n'), exitCode };
+}
+
+/**
+ * Execute a raw shell command with true, byte-exact stdout/stderr/exit-code
+ * separation via the capture wrapper. Used by both runCommand and the
+ * filesystem operations that need faithful output.
+ */
+async function execCaptured(
+  sandbox: AgentCoreSandbox,
+  inner: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const tag = randomUUID().replace(/-/g, '');
+  const raw = await invoke(sandbox, ToolName.EXECUTE_COMMAND, { command: wrapForCapture(inner, tag) });
+  return parseWrappedResult(raw.stdout, tag);
+}
+
+/** Run a shell command for its side effect, throwing `failure` on a non-zero exit. */
+async function runOrThrow(sandbox: AgentCoreSandbox, command: string, failure: string): Promise<void> {
+  const result = await invoke(sandbox, ToolName.EXECUTE_COMMAND, { command });
+  if (result.exitCode !== 0) throw new Error(result.stderr || failure);
+}
+
+const _provider = defineProvider<AgentCoreSandbox, AgentCoreConfig>({
+  name: 'agentcore',
+  methods: {
+    sandbox: {
+      create: async (config: AgentCoreConfig, options?: CreateSandboxOptions) => {
+        const client = createClient(config);
+        const codeInterpreterIdentifier = config.codeInterpreterIdentifier || DEFAULT_CODE_INTERPRETER;
+        // Per-create `timeout` (ms) wins over config; clamp into AgentCore's
+        // accepted range so an out-of-bounds value doesn't fail with a raw
+        // ValidationException.
+        const sessionTimeoutSeconds = clampSessionTimeout(
+          options?.timeout
+            ? options.timeout / 1000
+            : config.sessionTimeoutSeconds ?? DEFAULT_SESSION_TIMEOUT_SECONDS,
+        );
+
+        try {
+          const response = await client.send(
+            new StartCodeInterpreterSessionCommand({
+              codeInterpreterIdentifier,
+              name: options?.name,
+              sessionTimeoutSeconds,
+            }),
+          );
+          if (!response.sessionId) {
+            throw new Error('AgentCore StartCodeInterpreterSession returned no sessionId');
+          }
+
+          const sandbox: AgentCoreSandbox = {
+            client,
+            codeInterpreterIdentifier,
+            sessionId: response.sessionId,
+            createdAt: response.createdAt ? new Date(response.createdAt) : new Date(),
+            sessionTimeoutSeconds,
+          };
+          // Encode both identifier and session into the portable sandboxId.
+          return { sandbox, sandboxId: `${codeInterpreterIdentifier}::${response.sessionId}` };
+        } catch (error) {
+          throw friendlyError('starting an AgentCore session', error);
+        }
+      },
+
+      getById: async (config: AgentCoreConfig, sandboxId: string) => {
+        const { codeInterpreterIdentifier, sessionId } = parseSandboxId(sandboxId, config);
+        const client = createClient(config);
+        try {
+          const response = await client.send(
+            new GetCodeInterpreterSessionCommand({ codeInterpreterIdentifier, sessionId }),
+          );
+          // A terminated/expired session is not a usable sandbox.
+          if (response.status && response.status !== CodeInterpreterSessionStatus.READY) return null;
+          const sandbox: AgentCoreSandbox = {
+            client,
+            codeInterpreterIdentifier,
+            sessionId,
+            createdAt: response.createdAt ? new Date(response.createdAt) : new Date(),
+            sessionTimeoutSeconds: response.sessionTimeoutSeconds ?? DEFAULT_SESSION_TIMEOUT_SECONDS,
+          };
+          return { sandbox, sandboxId };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config: AgentCoreConfig) => {
+        const client = createClient(config);
+        const codeInterpreterIdentifier = config.codeInterpreterIdentifier || DEFAULT_CODE_INTERPRETER;
+        const results: Array<{ sandbox: AgentCoreSandbox; sandboxId: string }> = [];
+        try {
+          // Page through all READY sessions.
+          let nextToken: string | undefined;
+          do {
+            const response = await client.send(
+              new ListCodeInterpreterSessionsCommand({
+                codeInterpreterIdentifier,
+                status: CodeInterpreterSessionStatus.READY,
+                nextToken,
+              }),
+            );
+            for (const item of response.items ?? []) {
+              if (!item.sessionId) continue;
+              const sandbox: AgentCoreSandbox = {
+                client,
+                codeInterpreterIdentifier: item.codeInterpreterIdentifier || codeInterpreterIdentifier,
+                sessionId: item.sessionId,
+                createdAt: item.createdAt ? new Date(item.createdAt) : new Date(),
+                // The list summary doesn't carry the timeout; getInfo on a listed
+                // sandbox reports the default. Use getById for the true value.
+                sessionTimeoutSeconds: DEFAULT_SESSION_TIMEOUT_SECONDS,
+              };
+              results.push({ sandbox, sandboxId: `${sandbox.codeInterpreterIdentifier}::${sandbox.sessionId}` });
+            }
+            nextToken = response.nextToken;
+          } while (nextToken);
+          return results;
+        } catch {
+          return [];
+        }
+      },
+
+      destroy: async (config: AgentCoreConfig, sandboxId: string) => {
+        const { codeInterpreterIdentifier, sessionId } = parseSandboxId(sandboxId, config);
+        const client = createClient(config);
+        try {
+          await client.send(
+            new StopCodeInterpreterSessionCommand({ codeInterpreterIdentifier, sessionId }),
+          );
+        } catch {
+          // Already stopped or expired.
+        }
+      },
+
+      runCommand: async (
+        sandbox: AgentCoreSandbox,
+        command: string,
+        options?: RunCommandOptions,
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+        try {
+          const parsed = await execCaptured(sandbox, buildCommand(command, options));
+          return { ...parsed, durationMs: Date.now() - startTime };
+        } catch (error) {
+          return {
+            stdout: '',
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: 127,
+            durationMs: Date.now() - startTime,
+          };
+        }
+      },
+
+      // Reports cached creation-time metadata. status is always 'running' (like
+      // the e2b/leap0 siblings); use getById for authoritative liveness, which
+      // returns null once a session has terminated.
+      getInfo: async (sandbox: AgentCoreSandbox): Promise<SandboxInfo> => ({
+        id: `${sandbox.codeInterpreterIdentifier}::${sandbox.sessionId}`,
+        provider: 'agentcore',
+        status: 'running',
+        createdAt: sandbox.createdAt,
+        timeout: sandbox.sessionTimeoutSeconds * 1000,
+        metadata: {
+          codeInterpreterIdentifier: sandbox.codeInterpreterIdentifier,
+          sessionId: sandbox.sessionId,
+        },
+      }),
+
+      getUrl: async (): Promise<string> => {
+        throw new Error(
+          `AgentCore Code Interpreter does not expose inbound ports or preview URLs. ` +
+            `It is a code-execution sandbox without a public network endpoint.`,
+        );
+      },
+
+      // Filesystem is implemented over the shell channel: AgentCore's native
+      // file tools sandbox paths to a relative workdir and reject absolute paths,
+      // whereas the shell has full filesystem access (matches other providers).
+      filesystem: {
+        readFile: async (sandbox: AgentCoreSandbox, path: string): Promise<string> => {
+          const cmd = `if [ -f ${sq(path)} ]; then base64 ${sq(path)} | tr -d '\\n'; else exit 1; fi`;
+          const result = await invoke(sandbox, ToolName.EXECUTE_COMMAND, { command: cmd });
+          if (result.exitCode !== 0) throw new Error(result.stderr || `File not found: ${path}`);
+          return Buffer.from(result.stdout, 'base64').toString('utf8');
+        },
+
+        writeFile: async (sandbox: AgentCoreSandbox, path: string, content: string): Promise<void> => {
+          const b64 = Buffer.from(content, 'utf8').toString('base64');
+          // Stage under a per-call unique name in /tmp. A deterministic
+          // `${path}.csdk-b64` would let two concurrent writeFile calls to the
+          // same path interleave their appends and decode into corrupt output
+          // (or one call would `rm` the other's staging file), so tag it with a
+          // UUID — the same collision-avoidance technique as wrapForCapture.
+          const staged = `/tmp/.csdk-b64-${randomUUID().replace(/-/g, '')}`;
+
+          // AgentCore runs commands through a PTY whose input line has a hard
+          // ~128KB limit; a command longer than that hangs silently. So stage the
+          // base64 in bounded chunks (append), then decode. Small files still take
+          // a single round-trip.
+          const fail = `Failed to write: ${path}`;
+          try {
+            await runOrThrow(sandbox, `mkdir -p "$(dirname ${sq(path)})"`, fail);
+            // `|| i === 0` runs one iteration for empty content, creating an empty file.
+            for (let i = 0; i < b64.length || i === 0; i += B64_CHUNK_SIZE) {
+              const chunk = b64.slice(i, i + B64_CHUNK_SIZE);
+              const redirect = i === 0 ? '>' : '>>';
+              await runOrThrow(sandbox, `printf '%s' ${sq(chunk)} ${redirect} ${sq(staged)}`, fail);
+            }
+            await runOrThrow(sandbox, `base64 -d ${sq(staged)} > ${sq(path)}`, fail);
+          } finally {
+            // Always remove the staging file, even if a chunk append failed midway.
+            await invoke(sandbox, ToolName.EXECUTE_COMMAND, { command: `rm -f ${sq(staged)}` }).catch(() => {});
+          }
+        },
+
+        mkdir: async (sandbox: AgentCoreSandbox, path: string): Promise<void> => {
+          await runOrThrow(sandbox, `mkdir -p ${sq(path)}`, `Failed to mkdir: ${path}`);
+        },
+
+        readdir: async (sandbox: AgentCoreSandbox, path: string): Promise<FileEntry[]> => {
+          // `find -printf` emits `type<TAB>size<TAB>epoch<TAB>name` per entry,
+          // NUL-terminated. NUL is the one byte a filename can't contain, so this
+          // stays unambiguous even for names with spaces, tabs, or newlines.
+          // execCaptured routes the bytes through base64, so they arrive exact.
+          const cmd =
+            `if [ -d ${sq(path)} ]; then ` +
+            `find ${sq(path)} -maxdepth 1 -mindepth 1 -printf '%y\\t%s\\t%T@\\t%f\\0'; ` +
+            `else exit 1; fi`;
+          const result = await execCaptured(sandbox, cmd);
+          if (result.exitCode !== 0) throw new Error(result.stderr || `Not a directory: ${path}`);
+          const entries: FileEntry[] = [];
+          for (const record of result.stdout.split('\0')) {
+            if (!record) continue;
+            // Only the first three tabs are delimiters; the name may contain tabs.
+            const firstTab = record.indexOf('\t');
+            const secondTab = record.indexOf('\t', firstTab + 1);
+            const thirdTab = record.indexOf('\t', secondTab + 1);
+            if (firstTab < 0 || secondTab < 0 || thirdTab < 0) continue;
+            const type = record.slice(0, firstTab);
+            const size = record.slice(firstTab + 1, secondTab);
+            const epoch = record.slice(secondTab + 1, thirdTab);
+            const name = record.slice(thirdTab + 1);
+            if (!name) continue;
+            entries.push({
+              name,
+              type: type === 'd' ? 'directory' : 'file',
+              size: Number(size) || 0,
+              modified: new Date(Number(epoch) * 1000),
+            });
+          }
+          return entries;
+        },
+
+        exists: async (sandbox: AgentCoreSandbox, path: string): Promise<boolean> => {
+          const result = await invoke(sandbox, ToolName.EXECUTE_COMMAND, { command: `test -e ${sq(path)}` });
+          return result.exitCode === 0;
+        },
+
+        remove: async (sandbox: AgentCoreSandbox, path: string): Promise<void> => {
+          await runOrThrow(sandbox, `rm -rf ${sq(path)}`, `Failed to remove: ${path}`);
+        },
+      },
+
+      getInstance: (sandbox: AgentCoreSandbox): AgentCoreSandbox => sandbox,
+    },
+  },
+});
+
+/** Split a `<identifier>::<sessionId>` sandboxId, tolerating bare session ids. */
+function parseSandboxId(
+  sandboxId: string,
+  config: AgentCoreConfig,
+): { codeInterpreterIdentifier: string; sessionId: string } {
+  const sep = sandboxId.indexOf('::');
+  if (sep === -1) {
+    return {
+      codeInterpreterIdentifier: config.codeInterpreterIdentifier || DEFAULT_CODE_INTERPRETER,
+      sessionId: sandboxId,
+    };
+  }
+  return {
+    codeInterpreterIdentifier: sandboxId.slice(0, sep),
+    sessionId: sandboxId.slice(sep + 2),
+  };
+}
+
+export const agentcore = (config: AgentCoreConfig = {}) => _provider(config);
+export type { AgentCoreSandbox };

--- a/packages/agentcore/src/internal.ts
+++ b/packages/agentcore/src/internal.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure, side-effect-free helpers for the AgentCore provider.
+ *
+ * Kept in a separate module so they can be unit-tested without AWS credentials —
+ * these functions hold the trickiest logic (shell escaping, command wrapping,
+ * marker parsing, error classification) and benefit from direct coverage.
+ */
+
+import type { RunCommandOptions } from 'computesdk';
+
+/** AgentCore session timeout bounds (seconds), per the StartCodeInterpreterSession API. */
+export const MIN_SESSION_TIMEOUT_SECONDS = 1;
+export const MAX_SESSION_TIMEOUT_SECONDS = 28800; // 8 hours
+
+/**
+ * POSIX single-quote a string for safe shell interpolation. Single quotes
+ * disable all expansion ($, backticks, etc.); an embedded `'` is closed,
+ * escaped, and reopened. Safe for any path or value, unlike double quotes.
+ *
+ * We intentionally use this instead of `escapeShellArg` from `@computesdk/provider`:
+ * that helper targets double-quote contexts and does not neutralize spaces or
+ * shell metacharacters, whereas single-quoting is safe for arbitrary user paths.
+ */
+export function sq(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Clamp a requested session timeout into the API's accepted range so `create`
+ * fails friendly (or just works) instead of surfacing a raw ValidationException.
+ */
+export function clampSessionTimeout(seconds: number): number {
+  if (!Number.isFinite(seconds)) return MAX_SESSION_TIMEOUT_SECONDS;
+  return Math.min(MAX_SESSION_TIMEOUT_SECONDS, Math.max(MIN_SESSION_TIMEOUT_SECONDS, Math.ceil(seconds)));
+}
+
+/**
+ * Build the shell command from the user command plus env/cwd/background options.
+ * Throws on an invalid environment variable name.
+ */
+export function buildCommand(command: string, options?: RunCommandOptions): string {
+  let full = command;
+  // Apply env first so the variables bind to the actual command, then wrap in
+  // cwd. (Prefixing env onto a `cd ... && cmd` would only export it to `cd`.)
+  if (options?.env && Object.keys(options.env).length > 0) {
+    const envPrefix = Object.entries(options.env)
+      .map(([k, v]) => {
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) {
+          throw new Error(`Invalid environment variable name: ${k}`);
+        }
+        return `${k}=${sq(String(v))}`;
+      })
+      .join(' ');
+    full = `${envPrefix} ${full}`;
+  }
+  if (options?.cwd) full = `cd ${sq(options.cwd)} && ${full}`;
+  // Background: detach so the call returns immediately with exit code 0. Note that
+  // AgentCore tears down the process tree when the invocation returns, so a
+  // backgrounded job does not survive past this call (see README limitations).
+  if (options?.background) full = `nohup ${full} > /dev/null 2>&1 &`;
+  return full;
+}
+
+/**
+ * Wrap a command so its stdout, stderr, and exit code can be recovered faithfully.
+ *
+ * AgentCore runs commands through a PTY, which (a) merges stderr into stdout and
+ * (b) reports the *tool's* success, not the command's exit code — a failing
+ * command otherwise loses its stdout entirely. So we redirect the command's
+ * streams to temp files inside a subshell, then emit the exit code plus base64 of
+ * each stream. base64 also side-steps PTY CRLF mangling, so output is byte-exact.
+ * The `tag` (a UUID) namespaces the markers and temp files so concurrent calls on
+ * one session can't collide. (The k8s provider uses the same exit-code marker technique.)
+ */
+export function wrapForCapture(inner: string, tag: string): string {
+  const out = `/tmp/.csdk-${tag}.out`;
+  const err = `/tmp/.csdk-${tag}.err`;
+  // Subshell so the command's own `exit N` can't terminate the wrapper.
+  return (
+    `( ${inner} ) >${out} 2>${err}; __rc=$?; ` +
+    `printf 'CSDKrc${tag}=%s\\n' "$__rc"; base64 ${out}; echo CSDKsep${tag}; base64 ${err}; rm -f ${out} ${err}`
+  );
+}
+
+/**
+ * Parse the wrapper's output — `CSDKrc<tag>=<code>` then `<base64 stdout>`,
+ * a `CSDKsep<tag>` separator, then `<base64 stderr>` — into a clean result.
+ * If the markers are absent (unexpected shell failure), fall back to returning
+ * the raw text as stdout. Tolerates the PTY's CRLF around markers; base64
+ * payloads are whitespace-stripped.
+ */
+export function parseWrappedResult(
+  raw: string,
+  tag: string,
+): { stdout: string; stderr: string; exitCode: number } {
+  const rc = raw.match(new RegExp(`CSDKrc${tag}=(\\d+)`));
+  if (!rc) {
+    return { stdout: raw, stderr: '', exitCode: raw.trim() ? 1 : 0 };
+  }
+  const exitCode = Number(rc[1]);
+  const [outB64, errB64] = raw.slice(rc.index! + rc[0].length).split(new RegExp(`CSDKsep${tag}`));
+  const decode = (b64?: string) => Buffer.from((b64 ?? '').replace(/\s/g, ''), 'base64').toString('utf8');
+  return { stdout: decode(outB64), stderr: decode(errB64), exitCode };
+}
+
+/** Wrap opaque AWS SDK errors with actionable ComputeSDK guidance. */
+export function friendlyError(action: string, error: unknown): Error {
+  const name = (error as { name?: string })?.name ?? '';
+  const message = error instanceof Error ? error.message : String(error);
+  const matches = (pattern: RegExp) => pattern.test(name) || pattern.test(message);
+
+  if (matches(/Region is missing/i)) {
+    return new Error(
+      `Missing AWS region for AgentCore.\n\n` +
+        `Pass it: agentcore({ region: 'us-west-2' })\n` +
+        `Or set AWS_REGION / AWS_DEFAULT_REGION, or a region in your AWS profile.`,
+    );
+  }
+  if (matches(/Credentials|security token|UnrecognizedClient|ExpiredToken|could not load credentials/i)) {
+    return new Error(
+      `AWS authentication failed for AgentCore. Check your credentials ` +
+        `(env vars, SSO session, or profile) and that they are not expired.\n${message}`,
+    );
+  }
+  if (matches(/AccessDenied|not authorized/i)) {
+    return new Error(
+      `Access denied ${action}. Ensure your IAM principal allows the ` +
+        `bedrock-agentcore:*CodeInterpreter* and InvokeCodeInterpreter actions.\n${message}`,
+    );
+  }
+  return new Error(`Failed ${action}: ${message}`);
+}

--- a/packages/agentcore/src/internal.ts
+++ b/packages/agentcore/src/internal.ts
@@ -54,10 +54,13 @@ export function buildCommand(command: string, options?: RunCommandOptions): stri
     full = `${envPrefix} ${full}`;
   }
   if (options?.cwd) full = `cd ${sq(options.cwd)} && ${full}`;
-  // Background: detach so the call returns immediately with exit code 0. Note that
-  // AgentCore tears down the process tree when the invocation returns, so a
-  // backgrounded job does not survive past this call (see README limitations).
-  if (options?.background) full = `nohup ${full} > /dev/null 2>&1 &`;
+  // Bound the command's runtime with the `timeout` coreutil (exit 124 on timeout).
+  if (options?.timeout) full = `timeout ${Math.ceil(options.timeout / 1000)} sh -c ${sq(full)}`;
+  // Background: detach so the call returns immediately with exit code 0. Wrap the
+  // whole composed command in `sh -c` so nohup/& apply to all of it, not just the
+  // first `&&` clause. Note AgentCore tears down the process tree when the
+  // invocation returns, so a backgrounded job does not survive (see README).
+  if (options?.background) full = `nohup sh -c ${sq(full)} > /dev/null 2>&1 &`;
   return full;
 }
 

--- a/packages/agentcore/tsconfig.json
+++ b/packages/agentcore/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/agentcore/tsup.config.ts
+++ b/packages/agentcore/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/agentcore/vitest.config.ts
+++ b/packages/agentcore/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/packages/test-utils/src/provider-crud-test.ts
+++ b/packages/test-utils/src/provider-crud-test.ts
@@ -41,6 +41,7 @@ const CRUD_ENABLED_PROVIDERS = [
   'avm',
   'northflank', // Service-per-sandbox lifecycle is fully stable and listed
   'isorun',   // Isolated Linux VM, full create/getById/list/destroy lifecycle
+  'agentcore', // AgentCore Code Interpreter sessions support full CRUD lifecycle
   // Add more providers here as they become stable for CRUD testing
   // 'e2b',      // Add when CRUD implementation is stable
   // 'vercel',   // Skip - ephemeral sandboxes don't support listing operations

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@aws-sdk/client-bedrock-agentcore':
         specifier: ^3.1076.0
         version: 3.1078.0
+      '@aws-sdk/types':
+        specifier: ^3.973.15
+        version: 3.973.15
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2346,10 +2349,6 @@ packages:
 
   '@aws-sdk/types@3.973.15':
     resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.8':
-    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -4805,10 +4804,6 @@ packages:
 
   '@smithy/smithy-client@4.13.1':
     resolution: {integrity: sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.14.1':
-    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.15.1':
@@ -8931,20 +8926,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-locate-window': 3.804.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8954,7 +8949,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-locate-window': 3.804.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8962,7 +8957,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -8971,7 +8966,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -9005,7 +9000,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/region-config-resolver': 3.972.13
       '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.24
@@ -9029,7 +9024,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/url-parser': 4.3.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -9059,7 +9054,7 @@ snapshots:
 
   '@aws-sdk/core@3.974.8':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/xml-builder': 3.972.22
       '@smithy/core': 3.24.1
       '@smithy/node-config-provider': 4.4.1
@@ -9067,7 +9062,7 @@ snapshots:
       '@smithy/protocol-http': 5.4.1
       '@smithy/signature-v4': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.3.1
       '@smithy/util-retry': 4.4.1
@@ -9076,15 +9071,15 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.7':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.34':
     dependencies:
       '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/property-provider': 4.3.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.52':
@@ -9098,13 +9093,13 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.36':
     dependencies:
       '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/fetch-http-handler': 5.4.1
       '@smithy/node-http-handler': 4.7.1
       '@smithy/property-provider': 4.3.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-stream': 4.6.1
       tslib: 2.8.1
 
@@ -9128,11 +9123,11 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.38
       '@aws-sdk/credential-provider-web-identity': 3.972.38
       '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/credential-provider-imds': 4.3.1
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9157,11 +9152,11 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/property-provider': 4.3.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9183,11 +9178,11 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.34
       '@aws-sdk/credential-provider-sso': 3.972.38
       '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/credential-provider-imds': 4.3.1
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9209,10 +9204,10 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
       '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.52':
@@ -9228,10 +9223,10 @@ snapshots:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/token-providers': 3.1041.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9250,10 +9245,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9273,7 +9268,7 @@ snapshots:
       '@smithy/middleware-endpoint': 4.5.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       buffer: 5.6.0
       events: 3.3.0
       stream-browserify: 3.0.0
@@ -9281,19 +9276,19 @@ snapshots:
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/node-config-provider': 4.4.1
       '@smithy/protocol-http': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-expect-continue@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/protocol-http': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.16':
@@ -9303,11 +9298,11 @@ snapshots:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/crc64-nvme': 3.972.7
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/node-config-provider': 4.4.1
       '@smithy/protocol-http': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-middleware': 4.3.1
       '@smithy/util-stream': 4.6.1
       '@smithy/util-utf8': 4.2.2
@@ -9315,42 +9310,42 @@ snapshots:
 
   '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/protocol-http': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-location-constraint@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.15
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.15
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws/lambda-invoke-store': 0.2.2
       '@smithy/protocol-http': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.37':
     dependencies:
       '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.24.1
       '@smithy/node-config-provider': 4.4.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/signature-v4': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.3.1
       '@smithy/util-stream': 4.6.1
@@ -9359,18 +9354,18 @@ snapshots:
 
   '@aws-sdk/middleware-ssec@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.15
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-endpoints': 3.996.8
       '@smithy/core': 3.24.1
       '@smithy/protocol-http': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-retry': 4.4.1
       tslib: 2.8.1
 
@@ -9396,7 +9391,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/region-config-resolver': 3.972.13
       '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.24
@@ -9414,7 +9409,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/url-parser': 4.3.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -9431,30 +9426,30 @@ snapshots:
 
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/config-resolver': 4.5.1
       '@smithy/node-config-provider': 4.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/s3-request-presigner@3.1045.0':
     dependencies:
       '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@aws-sdk/util-format-url': 3.972.10
       '@smithy/middleware-endpoint': 4.5.1
       '@smithy/protocol-http': 5.4.1
       '@smithy/smithy-client': 4.13.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.25':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.37
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/protocol-http': 5.4.1
       '@smithy/signature-v4': 5.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.38':
@@ -9468,10 +9463,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9490,28 +9485,23 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.973.8':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.8':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.15
+      '@smithy/types': 4.15.1
       '@smithy/url-parser': 4.3.1
       '@smithy/util-endpoints': 3.5.1
       tslib: 2.8.1
 
   '@aws-sdk/util-format-url@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/querystring-builder': 4.3.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.804.0':
@@ -9520,24 +9510,24 @@ snapshots:
 
   '@aws-sdk/util-user-agent-browser@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.15
+      '@smithy/types': 4.15.1
       bowser: 2.11.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.973.24':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/node-config-provider': 4.4.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.22':
     dependencies:
       '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
@@ -11853,7 +11843,7 @@ snapshots:
   '@smithy/core@3.24.1':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/core@3.29.0':
@@ -11864,7 +11854,7 @@ snapshots:
   '@smithy/credential-provider-imds@4.3.1':
     dependencies:
       '@smithy/core': 3.24.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.4.5':
@@ -11891,7 +11881,7 @@ snapshots:
   '@smithy/fetch-http-handler@5.4.1':
     dependencies:
       '@smithy/core': 3.24.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.6.2':
@@ -11966,7 +11956,7 @@ snapshots:
   '@smithy/node-http-handler@4.7.1':
     dependencies:
       '@smithy/core': 3.24.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.2':
@@ -11998,7 +11988,7 @@ snapshots:
   '@smithy/signature-v4@5.4.1':
     dependencies:
       '@smithy/core': 3.24.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.1':
@@ -12010,11 +12000,7 @@ snapshots:
   '@smithy/smithy-client@4.13.1':
     dependencies:
       '@smithy/core': 3.24.1
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.1':
-    dependencies:
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/types@4.15.1':
@@ -12119,7 +12105,7 @@ snapshots:
       '@aws-sdk/client-s3': 3.1045.0
       '@aws-sdk/lib-storage': 3.1045.0(@aws-sdk/client-s3@3.1045.0)
       '@aws-sdk/s3-request-presigner': 3.1045.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.15
       '@smithy/signature-v4': 5.4.1
       dotenv: 17.4.2
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,43 @@ importers:
         specifier: ^4.43.0
         version: 4.104.0(@cloudflare/workers-types@4.20250826.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
+  packages/agentcore:
+    dependencies:
+      '@aws-sdk/client-bedrock-agentcore':
+        specifier: ^3.1076.0
+        version: 3.1078.0
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/agentuity:
     dependencies:
       '@computesdk/provider':
@@ -2145,8 +2182,16 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-bedrock-agentcore@3.1078.0':
+    resolution: {integrity: sha512-2UUyqmkCShdCO7PTbcq+kijYdG2e28vMSlnxoPH09/zMQra0/9TtvUlxxDMe9WnElwoZ/ulpXpC9rsVtDAo7SQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1045.0':
     resolution: {integrity: sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.26':
+    resolution: {integrity: sha512-wRj7Pthvjk3anees97pUWlxlTa0DUjeGrEQU5fKDZVdWZV0ekaprbof0df2uaE9g8u67t035v2j+ne2AW2UMkA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.8':
@@ -2161,32 +2206,64 @@ packages:
     resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.52':
+    resolution: {integrity: sha512-sxuaHZGHqOgKB8OdL3doXa1NJjqmO60FPfyTnYVKGjX9taRsIEGS9pd+2yALmo06hijZ8L94uSK0kfXZsRmVyA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.36':
     resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.54':
+    resolution: {integrity: sha512-e6yz52nq3SpR1oPLcvfsDM7H7k2gIYk/NSn/rwsFqzGXEwr3g0mRMlPbLaKCPCGNZJMU/gZg6/64B3eSam+gBw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.38':
     resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.59':
+    resolution: {integrity: sha512-9Um/UpruN76AdpiLnvwChVkJJwJ9Vx9ykk/2AeLxxSCM/YYRD8Kkq2towUk9fZQLV7dd9ATlsi87U7hKs0z/iQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.38':
     resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.58':
+    resolution: {integrity: sha512-H3q96qF8/DJsPsXMVtMRqSWOc85K5O4zos32untdw+vE5vw0f3a6qJo1YqbND4BsEIKd4iZmzzVUq9kV4LjbHg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.39':
     resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.61':
+    resolution: {integrity: sha512-2U2KHMRCt1dlZoLU3KZR5g5EL4b0h2HHw96SkaUBK7qvEXPZj5rGRO/3ZTeJmh37dIYQuCnA2273rZOQvmsiHw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.34':
     resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.52':
+    resolution: {integrity: sha512-Aff9Ebs42lz+Ep1wkS+Nlwh5S0eahakpyskPsuKGjiBJ6ExOjNtxbfKJTKovQtQNgJ7oG1BH6esJwGrbs7qgSA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.38':
     resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.58':
+    resolution: {integrity: sha512-syloC58mXOacUqM2toPNfwd7X3jT+tWj0F/cN7qdW1FQyI0q41J0tPf6DIZ56BF0x82iS9j3ALP45MoBz79YuQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.58':
+    resolution: {integrity: sha512-pTBImKzcGK+pcMKjL0fAJbnYzzYd1c0UDc7BSIOGNQhF9Nuk66vWlIXfYTYyzNSs+w8Q/vfbbNDDU8zdrouwLg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/lib-storage@3.1045.0':
@@ -2235,6 +2312,10 @@ packages:
     resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.26':
+    resolution: {integrity: sha512-Lwe3F6K7bs+jEubp1LbrvzeMBYb5fMazJ1IxV9TtKWPF8CSh67Fmwyq9fLz3NL/k55Dfpuph5Dimw76JFgr+SA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.6':
     resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
     engines: {node: '>=20.0.0'}
@@ -2251,16 +2332,20 @@ packages:
     resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1041.0':
     resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.936.0':
-    resolution: {integrity: sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==}
-    engines: {node: '>=18.0.0'}
+  '@aws-sdk/token-providers@3.1078.0':
+    resolution: {integrity: sha512-/uyXLBGu3Lw1GbBA2X66hcOMnKtMcqAIF+3/eHfxBQmUeXF2sdqozDPrTfEr/TnSd0D6deZar+eVyhEqqWu29w==}
+    engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.6':
-    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
@@ -2297,6 +2382,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.22':
     resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.2':
@@ -4598,8 +4687,16 @@ packages:
     engines: {node: '>=18.0.0'}
     deprecated: Deprecated due to bug in browser bundling instructions https://github.com/smithy-lang/smithy-typescript/issues/2025
 
+  '@smithy/core@3.29.0':
+    resolution: {integrity: sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.1':
     resolution: {integrity: sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.5':
+    resolution: {integrity: sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-serde-browser@4.3.1':
@@ -4616,6 +4713,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.4.1':
     resolution: {integrity: sha512-r7bN6spQ+caZC8AnyvSxkRUb57zt2jhhRw3Z+2Ez8hjq6coIikDBFUUI/+CQ1xx9K6eX1Gx6wUKo4ylU66TIqw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.2':
+    resolution: {integrity: sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.3.1':
@@ -4674,6 +4775,10 @@ packages:
     resolution: {integrity: sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.2':
+    resolution: {integrity: sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.3.1':
     resolution: {integrity: sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA==}
     engines: {node: '>=18.0.0'}
@@ -4694,20 +4799,20 @@ packages:
     resolution: {integrity: sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.13.1':
-    resolution: {integrity: sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==}
+  '@smithy/signature-v4@5.6.1':
+    resolution: {integrity: sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.13.1':
-    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+  '@smithy/smithy-client@4.13.1':
+    resolution: {integrity: sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.9.0':
-    resolution: {integrity: sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==}
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.3.1':
@@ -8826,20 +8931,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.804.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8849,7 +8954,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.804.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8866,8 +8971,19 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-agentcore@3.1078.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-node': 3.972.61
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1045.0':
@@ -8930,6 +9046,17 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/core@3.974.26':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.2.2
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.1
+      bowser: 2.11.0
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.8':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -8960,6 +9087,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.36':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -8971,6 +9106,16 @@ snapshots:
       '@smithy/smithy-client': 4.13.1
       '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.6.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.38':
@@ -8992,6 +9137,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-env': 3.972.52
+      '@aws-sdk/credential-provider-http': 3.972.54
+      '@aws-sdk/credential-provider-login': 3.972.58
+      '@aws-sdk/credential-provider-process': 3.972.52
+      '@aws-sdk/credential-provider-sso': 3.972.58
+      '@aws-sdk/credential-provider-web-identity': 3.972.58
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -9004,6 +9165,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.39':
     dependencies:
@@ -9022,6 +9192,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.61':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.52
+      '@aws-sdk/credential-provider-http': 3.972.54
+      '@aws-sdk/credential-provider-ini': 3.972.59
+      '@aws-sdk/credential-provider-process': 3.972.52
+      '@aws-sdk/credential-provider-sso': 3.972.58
+      '@aws-sdk/credential-provider-web-identity': 3.972.58
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -9029,6 +9213,14 @@ snapshots:
       '@smithy/property-provider': 4.3.1
       '@smithy/shared-ini-file-loader': 4.5.1
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.38':
@@ -9044,6 +9236,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/token-providers': 3.1078.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -9055,6 +9257,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/lib-storage@3.1045.0(@aws-sdk/client-s3@3.1045.0)':
     dependencies:
@@ -9163,6 +9374,17 @@ snapshots:
       '@smithy/util-retry': 4.4.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.26':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.6':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -9235,6 +9457,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1041.0':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -9247,14 +9476,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.936.0':
+  '@aws-sdk/token-providers@3.1078.0':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.973.6':
+  '@aws-sdk/types@3.973.15':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.8':
@@ -9306,6 +9539,11 @@ snapshots:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.2': {}
@@ -11618,10 +11856,21 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/core@3.29.0':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.1':
     dependencies:
       '@smithy/core': 3.24.1
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.5':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.3.1':
@@ -11643,6 +11892,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.24.1
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.3.1':
@@ -11714,6 +11969,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.2':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.3.1':
     dependencies:
       '@smithy/core': 3.24.1
@@ -11740,21 +12001,23 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.6.1':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.13.1':
     dependencies:
       '@smithy/core': 3.24.1
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/types@4.13.1':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/types@4.14.1':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/types@4.9.0':
+  '@smithy/types@4.15.1':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
## Provider: `@computesdk/agentcore`

Adds a sandbox provider for AWS Bedrock AgentCore Code Interpreter. A ComputeSDK
sandbox maps to an AgentCore Code Interpreter session; commands and filesystem
operations run through `InvokeCodeInterpreter`.

**Underlying SDK:** `@aws-sdk/client-bedrock-agentcore`

**Credentials:** standard AWS credential chain (env vars, SSO, profiles, instance
roles). No API key. A region is required via `region` config or `AWS_REGION`.

### Capabilities

| Capability | Supported? | Notes |
|---|---|---|
| `runCommand` (required) | Yes | |
| Filesystem | Yes | read/write/mkdir/readdir/exists/remove over the shell |
| `getUrl` (port exposure) | No | AgentCore has no inbound endpoint; throws a clear error |
| `list` | Yes | paginated, READY sessions |
| Templates | No | no template concept in Code Interpreter |
| Snapshots | No | no snapshot concept in Code Interpreter |

### Notes for reviewers

- Shell interpolation uses a local POSIX single-quote helper (`sq()`) rather than
  `escapeShellArg`. The shared helper targets double-quote contexts and does not
  neutralize spaces or `$`; single-quoting is safe for arbitrary user paths.
- AgentCore runs commands through a PTY, which merges stderr into stdout and hides
  the command exit code. `runCommand` recovers all three faithfully by wrapping the
  command (temp files + base64 + markers). Same technique as the k8s provider.
- `writeFile` chunks base64 to stay under the PTY command-size limit.
- Adds `agentcore` to the CRUD test whitelist in `packages/test-utils`.
- Verified against live AWS (eu-north-1) with temporary credentials: full suite
  passes; integration tests skip cleanly without credentials (CI mock mode).
