### PR TITLE
fix(browseruse): return wss:// CDP connect URLs

### DIFF
--- a/.changeset/browseruse-wss-connect-url.md
+++ b/.changeset/browseruse-wss-connect-url.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/browseruse": patch
+---
+
+Return wss:// CDP connect URLs. The Browser Use API returns an https:// cdpUrl, which makes CDP clients such as Playwright perform an extra /json/version discovery request before opening the websocket. Rewriting the scheme to wss:// lets clients connect to the websocket directly.

--- a/packages/browseruse/src/index.ts
+++ b/packages/browseruse/src/index.ts
@@ -181,7 +181,7 @@ export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseCon
         return {
           session,
           sessionId: session.id,
-          connectUrl: session.cdpUrl,
+          connectUrl: session.cdpUrl.replace(/^https:/, 'wss:'),
           status: mapStatus(session.status),
         };
       },
@@ -194,7 +194,7 @@ export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseCon
           return {
             session,
             sessionId: session.id,
-            connectUrl: session.cdpUrl,
+            connectUrl: session.cdpUrl.replace(/^https:/, 'wss:'),
             status: mapStatus(session.status),
           };
         } catch {
@@ -208,7 +208,7 @@ export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseCon
         return response.items.map((s) => ({
           session: s,
           sessionId: s.id,
-          connectUrl: s.cdpUrl ?? undefined,
+          connectUrl: s.cdpUrl?.replace(/^https:/, 'wss:'),
           status: mapStatus(s.status),
         }));
       },
@@ -227,7 +227,7 @@ export const browseruse = defineBrowserProvider<BrowserUseSession, BrowserUseCon
             `(status: ${session.status}). The session may already be stopped.`
           );
         }
-        return session.cdpUrl;
+        return session.cdpUrl.replace(/^https:/, 'wss:');
       },
     },
 


### PR DESCRIPTION
The Browser Use API returns an https:// `cdpUrl`. CDP clients such as Playwright treat http(s) endpoints as discovery URLs and make an extra `/json/version` request to resolve the websocket endpoint before connecting. The same endpoint accepts websocket connections directly, so this rewrites the scheme to wss:// everywhere the provider hands out a connect URL (`session.create`, `getById`, `list`, `getConnectUrl`), saving a network round trip on every connection.

Includes a patch changeset. Existing tests pass (7/7); `tsup` build and `tsc --noEmit` are clean.