### PR TITLE
Use sync-tar state for Cloud Run gateway

### DIFF
--- a/.changeset/cloud-run-sync-tar-gateway.md
+++ b/.changeset/cloud-run-sync-tar-gateway.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cloud-run": patch
+---
+
+Use Cloud Run `sandbox do --sync-tar` with Cloud Storage state in the remote gateway for horizontally scalable filesystem-backed execution.

--- a/packages/cloud-run/README.md
+++ b/packages/cloud-run/README.md
@@ -31,16 +31,18 @@ The setup command uses `gcloud` to:
 - Build a small ComputeSDK gateway container.
 - Deploy it to Cloud Run with `--sandbox-launcher` and `--no-cpu-throttling`.
 - Allow unauthenticated Cloud Run invocation with `--allow-unauthenticated`.
+- Create or reuse a Cloud Storage bucket for per-sandbox filesystem state.
 - Generate a bearer token for gateway authentication.
 - Print the runtime environment variables.
 
-The gateway creates a persistent sandbox session for each ComputeSDK sandbox. Filesystem state is preserved for the lifetime of that session and removed when the sandbox is destroyed.
+The gateway runs each command with `sandbox do --sync-tar`. Filesystem state is preserved between commands through a per-sandbox tar archive in Cloud Storage, and removed when the sandbox is destroyed. Running processes are not preserved between commands.
 
 Add the printed values to your app environment:
 
 ```bash
 CLOUD_RUN_SANDBOX_URL=https://computesdk-sandbox-...run.app
 CLOUD_RUN_SANDBOX_SECRET=...
+CLOUD_RUN_SANDBOX_STATE_BUCKET=your-gcp-project-computesdk-sandbox-state
 ```
 
 Prerequisites:
@@ -49,6 +51,7 @@ Prerequisites:
 - `gcloud` is installed, up to date, and authenticated.
 - Cloud Build and Cloud Run APIs are enabled for the project.
 - Your organization policy allows public Cloud Run invokers, or callers must provide `CLOUD_RUN_AUTH_TOKEN`.
+- The deployed Cloud Run service account can read, write, and delete objects in the state bucket.
 
 ### Public Gateway Access
 
@@ -117,6 +120,7 @@ await sandbox.destroy()
 | `sandboxSecret` | `CLOUD_RUN_SANDBOX_SECRET` | | Bearer token for deployed gateway service |
 | `gatewayAuthToken` | `CLOUD_RUN_AUTH_TOKEN` | | Optional Google identity token when Cloud Run IAM auth is enabled |
 | `sandboxBinary` | `CLOUD_RUN_SANDBOX_BINARY` | `/usr/local/gcp/bin/sandbox` | Path to the Cloud Run sandbox CLI |
+| Gateway state bucket | `CLOUD_RUN_SANDBOX_STATE_BUCKET` | | Cloud Storage bucket used by the gateway for synced filesystem state |
 | `mode` | | CLI default | Sandbox CLI mode, `local` or `container` |
 | `allowEgress` | | `false` | Allow sandbox network egress |
 | `rootfs` | | `/` | Root filesystem exposed to sandboxes |
@@ -133,7 +137,7 @@ await sandbox.destroy()
 
 ## Notes
 
-Filesystem writes are preserved for the lifetime of a ComputeSDK sandbox session. They are not durable after `destroy()` unless your Cloud Run sandbox CLI supports host-backed persistence such as `--persist-dir`.
+Filesystem writes are preserved through `sandbox do --sync-tar` and Cloud Storage state. Process state is not preserved: background commands, daemons, and open ports do not survive between `runCommand()` calls.
 
 `getUrl()` is not supported because the current Cloud Run sandbox CLI does not expose per-sandbox ports.
 

--- a/packages/cloud-run/README.md
+++ b/packages/cloud-run/README.md
@@ -22,6 +22,10 @@ Set your GCP project and region, then run the setup command:
 ```bash
 export CLOUD_RUN_PROJECT_ID="your-gcp-project"
 export CLOUD_RUN_REGION="us-central1"
+# Optional defaults: one large gateway instance
+export CLOUD_RUN_MAX_INSTANCES="1"
+export CLOUD_RUN_CPU="8"
+export CLOUD_RUN_MEMORY="32Gi"
 
 npx @computesdk/cloud-run
 ```
@@ -31,6 +35,7 @@ The setup command uses `gcloud` to:
 - Build a small ComputeSDK gateway container.
 - Deploy it to Cloud Run with `--sandbox-launcher` and `--no-cpu-throttling`.
 - Allow unauthenticated Cloud Run invocation with `--allow-unauthenticated`.
+- Set `--max-instances=1`, `--cpu=8`, and `--memory=32Gi` by default.
 - Create or reuse a Cloud Storage bucket for per-sandbox filesystem state.
 - Generate a bearer token for gateway authentication.
 - Print the runtime environment variables.

--- a/packages/cloud-run/src/__tests__/smoke.test.ts
+++ b/packages/cloud-run/src/__tests__/smoke.test.ts
@@ -6,7 +6,7 @@ const sandboxSecret = process.env.CLOUD_RUN_SANDBOX_SECRET
 const hasGatewayCredentials = !!(sandboxUrl && sandboxSecret)
 
 describe.runIf(hasGatewayCredentials)('cloudRun credentialed smoke test', () => {
-  it('creates a remote sandbox, runs node, and destroys it', async () => {
+  it('creates a remote sandbox, runs node, syncs files, and destroys it', async () => {
     const compute = cloudRun({
       sandboxUrl,
       sandboxSecret,
@@ -20,6 +20,9 @@ describe.runIf(hasGatewayCredentials)('cloudRun credentialed smoke test', () => 
       expect(nodeVersion.exitCode).toBe(0)
       expect(nodeVersion.stderr).toBe('')
       expect(nodeVersion.stdout.trim()).toMatch(/^v\d+\.\d+\.\d+$/)
+
+      await sandbox.filesystem.writeFile('/tmp/computesdk-smoke/hello.txt', 'hello from sync tar')
+      await expect(sandbox.filesystem.readFile('/tmp/computesdk-smoke/hello.txt')).resolves.toBe('hello from sync tar')
     } finally {
       await sandbox.destroy()
     }

--- a/packages/cloud-run/src/gateway.ts
+++ b/packages/cloud-run/src/gateway.ts
@@ -8,12 +8,21 @@
 import { spawn } from 'node:child_process'
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
 const SANDBOX_BINARY = process.env.CLOUD_RUN_SANDBOX_BINARY ?? '/usr/local/gcp/bin/sandbox'
 const SANDBOX_SECRET = process.env.SANDBOX_SECRET ?? process.env.CLOUD_RUN_SANDBOX_SECRET
+const STATE_BUCKET = process.env.CLOUD_RUN_SANDBOX_STATE_BUCKET
+const LOCAL_STATE_ROOT = process.env.CLOUD_RUN_SANDBOX_STATE_ROOT ?? join(tmpdir(), 'computesdk-cloud-run-state')
 const DEFAULT_TIMEOUT_MS = 300_000
 
 type Json = Record<string, any>
+type TokenState = { accessToken: string; expiresAt: number }
+
+let tokenState: TokenState | undefined
 
 function send(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, { 'Content-Type': 'application/json' })
@@ -66,6 +75,69 @@ async function runSandbox(args: string[], timeout = DEFAULT_TIMEOUT_MS): Promise
   })
 }
 
+function stateObjectName(sandboxId: string): string {
+  return `sandboxes/${sandboxId}.tar`
+}
+
+function statePath(sandboxId: string): string {
+  return join(LOCAL_STATE_ROOT, `${sandboxId}.tar`)
+}
+
+async function getAccessToken(): Promise<string> {
+  if (tokenState && tokenState.expiresAt > Date.now() + 60_000) return tokenState.accessToken
+  const response = await fetch('http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token', {
+    headers: { 'Metadata-Flavor': 'Google' },
+  })
+  if (!response.ok) throw new Error(`Failed to get metadata access token: ${response.status}`)
+  const data = await response.json() as { access_token: string; expires_in: number }
+  tokenState = { accessToken: data.access_token, expiresAt: Date.now() + data.expires_in * 1000 }
+  return tokenState.accessToken
+}
+
+async function gcsRequest(path: string, init: RequestInit = {}): Promise<Response> {
+  const accessToken = await getAccessToken()
+  return fetch(`https://storage.googleapis.com${path}`, {
+    ...init,
+    headers: {
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+}
+
+async function prepareState(sandboxId: string): Promise<string> {
+  await mkdir(LOCAL_STATE_ROOT, { recursive: true })
+  const path = statePath(sandboxId)
+  if (!STATE_BUCKET) return path
+
+  const objectName = encodeURIComponent(stateObjectName(sandboxId))
+  const response = await gcsRequest(`/storage/v1/b/${STATE_BUCKET}/o/${objectName}?alt=media`)
+  if (response.status === 404) return path
+  if (!response.ok) throw new Error(`Failed to download Cloud Run sandbox state: ${response.status}`)
+  await writeFile(path, Buffer.from(await response.arrayBuffer()))
+  return path
+}
+
+async function persistState(sandboxId: string, path: string): Promise<void> {
+  if (!STATE_BUCKET || !existsSync(path)) return
+  const objectName = encodeURIComponent(stateObjectName(sandboxId))
+  const content = await readFile(path)
+  const response = await gcsRequest(`/upload/storage/v1/b/${STATE_BUCKET}/o?uploadType=media&name=${objectName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-tar' },
+    body: content,
+  })
+  if (!response.ok) throw new Error(`Failed to upload Cloud Run sandbox state: ${response.status}`)
+}
+
+async function removeState(sandboxId: string): Promise<void> {
+  await rm(statePath(sandboxId), { force: true })
+  if (!STATE_BUCKET) return
+  const objectName = encodeURIComponent(stateObjectName(sandboxId))
+  const response = await gcsRequest(`/storage/v1/b/${STATE_BUCKET}/o/${objectName}`, { method: 'DELETE' })
+  if (!response.ok && response.status !== 404) throw new Error(`Failed to delete Cloud Run sandbox state: ${response.status}`)
+}
+
 function pushExecArgs(args: string[], body: Json): void {
   if (body.cwd) args.push('--workdir', String(body.cwd))
   for (const [key, value] of Object.entries(body.env ?? {})) {
@@ -75,35 +147,27 @@ function pushExecArgs(args: string[], body: Json): void {
 }
 
 async function execCommand(sandboxId: string, command: string, body: Json = {}) {
-  const args = ['exec', sandboxId]
+  const stateTar = await prepareState(sandboxId)
+  const args = ['do', '--sandbox-name', sandboxId, '--sync-tar', stateTar, '--write']
   pushExecArgs(args, body)
   args.push('--', '/bin/sh', '-c', command)
-  return runSandbox(args, body.timeout)
+  const result = await runSandbox(args, body.timeout)
+  await persistState(sandboxId, stateTar)
+  return result
 }
 
 async function handle(pathname: string, body: Json): Promise<unknown> {
   const sandboxId = validateSandboxId(body.sandboxId || `cloud-run-${randomUUID()}`)
 
   if (pathname === '/v1/sandbox/create') {
-    const args = ['run', sandboxId, '--detach', '--write']
-    if (body.workdir) args.push('--workdir', String(body.workdir))
-    for (const [key, value] of Object.entries(body.env ?? {})) {
-      validateEnvName(key)
-      args.push('-e', `${key}=${String(value)}`)
-    }
-    const result = await runSandbox(args, body.timeout)
-    if (result.exitCode !== 0) throw new Error(result.stderr || `Failed to create Cloud Run sandbox ${sandboxId}`)
-    return { sandboxId, status: 'running' }
+    await prepareState(sandboxId)
+    return { sandboxId, status: 'running', mode: 'sync-tar' }
   }
 
   if (!body.sandboxId) throw new Error('Missing sandboxId')
 
   if (pathname === '/v1/sandbox/destroy') {
-    const child = spawn(SANDBOX_BINARY, ['delete', sandboxId, '--force', '--stdin=false', '--stdout=false', '--stderr=false'], {
-      stdio: 'ignore',
-      detached: true,
-    })
-    child.unref()
+    await removeState(sandboxId)
     return { success: true }
   }
 

--- a/packages/cloud-run/src/setup.ts
+++ b/packages/cloud-run/src/setup.ts
@@ -41,6 +41,9 @@ async function setup() {
   const region = process.env.CLOUD_RUN_REGION ?? process.env.GOOGLE_CLOUD_LOCATION ?? process.env.REGION
   const serviceName = process.env.CLOUD_RUN_SERVICE_NAME ?? 'computesdk-sandbox'
   const stateBucket = process.env.CLOUD_RUN_SANDBOX_STATE_BUCKET ?? `${projectId}-${serviceName}-state`
+  const maxInstances = process.env.CLOUD_RUN_MAX_INSTANCES ?? '1'
+  const cpu = process.env.CLOUD_RUN_CPU ?? '8'
+  const memory = process.env.CLOUD_RUN_MEMORY ?? '32Gi'
 
   console.log('\n  ComputeSDK Cloud Run Setup\n')
 
@@ -105,6 +108,9 @@ async function setup() {
       '--sandbox-launcher',
       '--allow-unauthenticated',
       '--no-cpu-throttling',
+      '--cpu', cpu,
+      '--memory', memory,
+      '--max-instances', maxInstances,
       '--set-env-vars', `SANDBOX_SECRET=${secret},CLOUD_RUN_SANDBOX_STATE_BUCKET=${stateBucket}`,
     ], { stdio: 'inherit' })
 

--- a/packages/cloud-run/src/setup.ts
+++ b/packages/cloud-run/src/setup.ts
@@ -40,6 +40,7 @@ async function setup() {
   const projectId = process.env.CLOUD_RUN_PROJECT_ID ?? process.env.GOOGLE_CLOUD_PROJECT ?? process.env.PROJECT_ID
   const region = process.env.CLOUD_RUN_REGION ?? process.env.GOOGLE_CLOUD_LOCATION ?? process.env.REGION
   const serviceName = process.env.CLOUD_RUN_SERVICE_NAME ?? 'computesdk-sandbox'
+  const stateBucket = process.env.CLOUD_RUN_SANDBOX_STATE_BUCKET ?? `${projectId}-${serviceName}-state`
 
   console.log('\n  ComputeSDK Cloud Run Setup\n')
 
@@ -80,6 +81,21 @@ async function setup() {
     console.log(`  Building gateway image ${image}...`)
     run('gcloud', ['builds', 'submit', '--tag', image, '--project', projectId], { cwd: tmpDir, stdio: 'inherit' })
 
+    console.log(`  Ensuring state bucket gs://${stateBucket}...`)
+    try {
+      run('gcloud', ['storage', 'buckets', 'describe', `gs://${stateBucket}`, '--project', projectId])
+    } catch {
+      run('gcloud', ['storage', 'buckets', 'create', `gs://${stateBucket}`, '--project', projectId, '--location', region, '--uniform-bucket-level-access'], { stdio: 'inherit' })
+    }
+
+    const projectNumber = run('gcloud', ['projects', 'describe', projectId, '--format', 'value(projectNumber)']).trim()
+    const serviceAccount = `${projectNumber}-compute@developer.gserviceaccount.com`
+    try {
+      run('gcloud', ['storage', 'buckets', 'add-iam-policy-binding', `gs://${stateBucket}`, '--member', `serviceAccount:${serviceAccount}`, '--role', 'roles/storage.objectAdmin', '--project', projectId], { stdio: 'inherit' })
+    } catch (error) {
+      console.warn(`  Warning: failed to grant ${serviceAccount} access to gs://${stateBucket}. Ensure it has roles/storage.objectAdmin before using the gateway.`)
+    }
+
     console.log(`  Deploying ${serviceName} with --sandbox-launcher...`)
     run('gcloud', [
       'beta', 'run', 'deploy', serviceName,
@@ -89,7 +105,7 @@ async function setup() {
       '--sandbox-launcher',
       '--allow-unauthenticated',
       '--no-cpu-throttling',
-      '--set-env-vars', `SANDBOX_SECRET=${secret}`,
+      '--set-env-vars', `SANDBOX_SECRET=${secret},CLOUD_RUN_SANDBOX_STATE_BUCKET=${stateBucket}`,
     ], { stdio: 'inherit' })
 
     const serviceUrl = run('gcloud', [
@@ -102,6 +118,7 @@ async function setup() {
     console.log('\n  Setup complete! Add these to your .env:\n')
     console.log(`  CLOUD_RUN_SANDBOX_URL=${serviceUrl}`)
     console.log(`  CLOUD_RUN_SANDBOX_SECRET=${secret}`)
+    console.log(`  CLOUD_RUN_SANDBOX_STATE_BUCKET=${stateBucket}`)
     console.log('')
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- switch the Cloud Run remote gateway from persistent run/exec sessions to sandbox do --sync-tar
- add Cloud Storage-backed per-sandbox state in setup and gateway runtime
- update docs and credentialed smoke test to verify filesystem sync

## Verification
- pnpm --filter @computesdk/cloud-run typecheck
- pnpm --filter @computesdk/cloud-run build
- pnpm --filter @computesdk/cloud-run test
- deployed temporary computesdk-sandbox-sync-test in main-498812/us-east4 with local build
- live smoke passed against temporary gateway without CLOUD_RUN_AUTH_TOKEN
- deleted temporary service and state bucket after verification