### PR TITLE
Fix Cloud Run sandbox do execution

### DIFF
--- a/.changeset/cloud-run-sandbox-do.md
+++ b/.changeset/cloud-run-sandbox-do.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cloud-run": patch
+---
+
+Use `sandbox do` for Cloud Run command execution instead of detached `run` sessions and `exec`.

--- a/packages/cloud-run/README.md
+++ b/packages/cloud-run/README.md
@@ -34,7 +34,7 @@ The setup command uses `gcloud` to:
 - Generate a bearer token for gateway authentication.
 - Print the runtime environment variables.
 
-The gateway creates a persistent sandbox session for each ComputeSDK sandbox. Filesystem state is preserved for the lifetime of that session and removed when the sandbox is destroyed.
+The gateway executes each ComputeSDK command with `sandbox do`. The ComputeSDK sandbox object is a logical handle used to carry configuration such as environment variables and working directory between calls.
 
 Add the printed values to your app environment:
 
@@ -128,12 +128,11 @@ await sandbox.destroy()
 | `mounts` | | `[]` | Bind mounts passed to `--mount` |
 | `env` | | `{}` | Environment variables for new sandbox sessions |
 | `globalArgs` | | `[]` | Extra CLI global args |
-| `runArgs` | | `[]` | Extra args for `sandbox run` |
-| `execArgs` | | `[]` | Extra args for `sandbox exec` |
+| `runArgs` | | `[]` | Extra args for `sandbox do` |
 
 ## Notes
 
-Filesystem writes are preserved for the lifetime of a ComputeSDK sandbox session. They are not durable after `destroy()` unless your Cloud Run sandbox CLI supports host-backed persistence such as `--persist-dir`.
+Commands are executed with `sandbox do` rather than a detached persistent session. Filesystem writes are only preserved when your Cloud Run sandbox CLI configuration supports host-backed persistence such as `--persist-dir`.
 
 `getUrl()` is not supported because the current Cloud Run sandbox CLI does not expose per-sandbox ports.
 

--- a/packages/cloud-run/src/gateway.ts
+++ b/packages/cloud-run/src/gateway.ts
@@ -75,7 +75,7 @@ function pushExecArgs(args: string[], body: Json): void {
 }
 
 async function execCommand(sandboxId: string, command: string, body: Json = {}) {
-  const args = ['do', sandboxId, '--write']
+  const args = ['do', '--write']
   pushExecArgs(args, body)
   args.push('--', '/bin/sh', '-c', command)
   return runSandbox(args, body.timeout)

--- a/packages/cloud-run/src/gateway.ts
+++ b/packages/cloud-run/src/gateway.ts
@@ -75,7 +75,7 @@ function pushExecArgs(args: string[], body: Json): void {
 }
 
 async function execCommand(sandboxId: string, command: string, body: Json = {}) {
-  const args = ['exec', sandboxId]
+  const args = ['do', sandboxId, '--write']
   pushExecArgs(args, body)
   args.push('--', '/bin/sh', '-c', command)
   return runSandbox(args, body.timeout)
@@ -99,25 +99,12 @@ async function handle(pathname: string, body: Json): Promise<unknown> {
   }
 
   if (pathname === '/v1/sandbox/create') {
-    const args = ['run', sandboxId, '--detach', '--write']
-    if (body.workdir) args.push('--workdir', String(body.workdir))
-    for (const [key, value] of Object.entries(body.env ?? {})) {
-      validateEnvName(key)
-      args.push('-e', `${key}=${String(value)}`)
-    }
-    const result = await runSandbox(args, body.timeout)
-    if (result.exitCode !== 0) throw new Error(result.stderr || `Failed to create Cloud Run sandbox ${sandboxId}`)
     return { sandboxId, status: 'running' }
   }
 
   if (!body.sandboxId) throw new Error('Missing sandboxId')
 
   if (pathname === '/v1/sandbox/destroy') {
-    const child = spawn(SANDBOX_BINARY, ['delete', sandboxId, '--force', '--stdin=false', '--stdout=false', '--stderr=false'], {
-      stdio: 'ignore',
-      detached: true,
-    })
-    child.unref()
     return { success: true }
   }
 

--- a/packages/cloud-run/src/gateway.ts
+++ b/packages/cloud-run/src/gateway.ts
@@ -86,15 +86,14 @@ async function handle(pathname: string, body: Json): Promise<unknown> {
 
   if (pathname === '/v1/sandbox/do') {
     if (!body.command) throw new Error('Missing required field: command')
-    const args = ['do']
-    if (body.workdir) args.push('--workdir', String(body.workdir))
+    const args = ['do', '--write']
+    if (body.cwd) args.push('--workdir', String(body.cwd))
     for (const [key, value] of Object.entries(body.env ?? {})) {
       validateEnvName(key)
       args.push('-e', `${key}=${String(value)}`)
     }
     args.push('--', '/bin/sh', '-c', String(body.command))
     const result = await runSandbox(args, body.timeout)
-    if (result.exitCode !== 0) throw new Error(result.stderr || `Failed sandbox do: exit code ${result.exitCode}`)
     return { sandboxId: `do-${randomUUID()}`, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr }
   }
 

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -214,38 +214,6 @@ function withShellOptions(command: string, options?: RunCommandOptions): string 
 
 async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> {
   const start = Date.now()
-
-  if (sandbox.config.persistDir === undefined && sandbox.config.overlayDir === undefined) {
-    if (sandbox.remote) {
-      try {
-        const result = await gatewayRequest(sandbox.config, '/v1/sandbox/do', {
-          command: withShellOptions(command, options),
-          cwd: options?.cwd,
-          env: options?.env,
-          timeout: options?.timeout,
-        })
-        return {
-          stdout: result.stdout || '',
-          stderr: result.stderr || '',
-          exitCode: result.exitCode ?? 0,
-          durationMs: Date.now() - start,
-        }
-      } catch (error) {
-        return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - start }
-      }
-    }
-
-    const args = [...buildBaseArgs(sandbox.config), 'do']
-    pushExecArgs(args, sandbox.config, options?.env, options?.cwd)
-    args.push('--', '/bin/sh', '-c', withShellOptions(command, options))
-    const result = await runSandboxCli(sandbox.config, args, {
-      timeout: options?.timeout,
-      onStdout: options?.onStdout,
-      onStderr: options?.onStderr,
-    })
-    return { ...result, durationMs: Date.now() - start }
-  }
-
   if (sandbox.remote) {
     try {
       const result = await gatewayRequest(sandbox.config, '/v1/sandbox/exec', {

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -266,7 +266,7 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
     }
   }
 
-  const args = [...buildBaseArgs(sandbox.config), 'do', sandbox.id]
+  const args = [...buildBaseArgs(sandbox.config), 'do']
   pushRunArgs(args, sandbox.config, options?.env, options?.cwd)
   args.push(...(sandbox.config.runArgs ?? []))
   args.push('--', '/bin/sh', '-c', withShellOptions(command, options))

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -59,10 +59,8 @@ export interface CloudRunConfig {
   env?: Record<string, string>
   /** Extra args passed before the sandbox subcommand, e.g. global debug flags. */
   globalArgs?: string[]
-  /** Extra args passed to `sandbox run` and `sandbox do`. */
+  /** Extra args passed to `sandbox do`. */
   runArgs?: string[]
-  /** Extra args passed to `sandbox exec`. */
-  execArgs?: string[]
 }
 
 export interface CloudRunSandbox {
@@ -154,15 +152,6 @@ function pushRunArgs(args: string[], config: CloudRunConfig, env?: Record<string
     validateEnvName(key)
     args.push('-e', `${key}=${value}`)
   }
-}
-
-function pushExecArgs(args: string[], config: CloudRunConfig, env?: Record<string, string>, workdir?: string): void {
-  if (workdir) args.push('--workdir', workdir)
-  for (const [key, value] of Object.entries(env ?? {})) {
-    validateEnvName(key)
-    args.push('-e', `${key}=${value}`)
-  }
-  args.push(...(config.execArgs ?? []))
 }
 
 function buildBaseArgs(config: CloudRunConfig): string[] {
@@ -262,8 +251,8 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
       const result = await gatewayRequest(sandbox.config, '/v1/sandbox/exec', {
         sandboxId: sandbox.id,
         command: withShellOptions(command, options),
-        cwd: options?.cwd,
-        env: options?.env,
+        cwd: options?.cwd ?? sandbox.config.workdir,
+        env: { ...sandbox.config.env, ...options?.env },
         timeout: options?.timeout,
       })
       return {
@@ -277,8 +266,9 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
     }
   }
 
-  const args = [...buildBaseArgs(sandbox.config), 'exec', sandbox.id]
-  pushExecArgs(args, sandbox.config, options?.env, options?.cwd)
+  const args = [...buildBaseArgs(sandbox.config), 'do', sandbox.id]
+  pushRunArgs(args, sandbox.config, options?.env, options?.cwd)
+  args.push(...(sandbox.config.runArgs ?? []))
   args.push('--', '/bin/sh', '-c', withShellOptions(command, options))
   const result = await runSandboxCli(sandbox.config, args, {
     timeout: options?.timeout,
@@ -295,29 +285,25 @@ export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
   methods: {
     sandbox: {
       create: async (config: CloudRunConfig = {}, options?: CreateSandboxOptions) => {
+        const sandboxConfig = {
+          ...config,
+          env: { ...config.env, ...options?.envs },
+          workdir: options?.directory ?? config.workdir,
+        }
         if (isRemote(config)) {
           const sandboxId = options?.name ?? `cloud-run-${randomUUID()}`
           const response = await gatewayRequest(config, '/v1/sandbox/create', {
             sandboxId,
-            env: { ...config.env, ...options?.envs },
-            workdir: options?.directory ?? config.workdir,
             timeout: options?.timeout,
           })
-          const sandbox = { id: response.sandboxId ?? sandboxId, createdAt: new Date(), config, remote: true }
+          const sandbox = { id: response.sandboxId ?? sandboxId, createdAt: new Date(), config: sandboxConfig, remote: true }
           activeSandboxes.set(sandbox.id, sandbox)
           return { sandbox, sandboxId: sandbox.id }
         }
 
-        await assertSandboxBinary(config)
+        await assertSandboxBinary(sandboxConfig)
         const sandboxId = options?.name ?? `cloud-run-${randomUUID()}`
-        const args = [...buildBaseArgs(config), 'run', sandboxId, '--detach']
-        pushRunArgs(args, config, options?.envs, options?.directory)
-        args.push(...(config.runArgs ?? []))
-        const result = await runSandboxCli(config, args, { timeout: options?.timeout })
-        if (result.exitCode !== 0) {
-          throw new Error(result.stderr || `Failed to create Cloud Run sandbox ${sandboxId}`)
-        }
-        const sandbox = { id: sandboxId, createdAt: new Date(), config, remote: false }
+        const sandbox = { id: sandboxId, createdAt: new Date(), config: sandboxConfig, remote: false }
         activeSandboxes.set(sandboxId, sandbox)
         return { sandbox, sandboxId }
       },
@@ -346,10 +332,6 @@ export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
           return
         }
 
-        const result = await runSandboxCli(config, [...buildBaseArgs(config), 'delete', sandboxId, '--force', '--stdin=false', '--stdout=false', '--stderr=false'], { timeout: 30_000 })
-        if (result.exitCode !== 0 && result.exitCode !== 124 && !/not found|does not exist/i.test(result.stderr)) {
-          throw new Error(result.stderr || `Failed to delete Cloud Run sandbox ${sandboxId}`)
-        }
         activeSandboxes.delete(sandboxId)
       },
 

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -260,11 +260,7 @@ export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
         }
         if (isRemote(config)) {
           const sandboxId = options?.name ?? `cloud-run-${randomUUID()}`
-          const response = await gatewayRequest(config, '/v1/sandbox/create', {
-            sandboxId,
-            timeout: options?.timeout,
-          })
-          const sandbox = { id: response.sandboxId ?? sandboxId, createdAt: new Date(), config: sandboxConfig, remote: true }
+          const sandbox = { id: sandboxId, createdAt: new Date(), config: sandboxConfig, remote: true }
           activeSandboxes.set(sandbox.id, sandbox)
           return { sandbox, sandboxId: sandbox.id }
         }


### PR DESCRIPTION
## Summary
- build on top of PR #621 after it merged to main
- switch Cloud Run command execution from detached run/exec sessions to sandbox do
- make create/destroy logical bookkeeping for Cloud Run sandbox handles
- fix sandbox do command shape, cwd handling, and non-zero exit result propagation
- update Cloud Run docs and add a patch changeset

## Tests
- pnpm --filter @computesdk/cloud-run build
- pnpm --filter @computesdk/cloud-run typecheck
- pnpm --filter @computesdk/cloud-run test
- deployed gateway to Cloud Run us-east4 from the rebased branch
- verified /v1/sandbox/exec returns node -v via sandbox do
- verified /v1/sandbox/do returns node -v via sandbox do
- CLOUD_RUN_SANDBOX_URL + CLOUD_RUN_SANDBOX_SECRET pnpm --filter @computesdk/cloud-run test