### PR TITLE
Configure Cloud Run gateway benchmark deploy flags

### DIFF
--- a/.changeset/cloud-run-gateway-benchmark-flags.md
+++ b/.changeset/cloud-run-gateway-benchmark-flags.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cloud-run": patch
+---
+
+Configure the Cloud Run gateway setup command with benchmark-ready CPU, memory, concurrency, scaling, session affinity, and CPU boost settings.

--- a/packages/cloud-run/README.md
+++ b/packages/cloud-run/README.md
@@ -30,6 +30,7 @@ The setup command uses `gcloud` to:
 
 - Build a small ComputeSDK gateway container.
 - Deploy it to Cloud Run with `--sandbox-launcher` and `--no-cpu-throttling`.
+- Configure the gateway for low-latency sandbox execution with 1 CPU, 2Gi memory, concurrency 1, session affinity, CPU boost, and 100 min/max instances.
 - Allow unauthenticated Cloud Run invocation with `--allow-unauthenticated`.
 - Generate a bearer token for gateway authentication.
 - Print the runtime environment variables.

--- a/packages/cloud-run/src/setup.ts
+++ b/packages/cloud-run/src/setup.ts
@@ -88,6 +88,13 @@ async function setup() {
       '--project', projectId,
       '--sandbox-launcher',
       '--allow-unauthenticated',
+      '--cpu', '1',
+      '--memory', '2Gi',
+      '--concurrency', '1',
+      '--min-instances', '100',
+      '--max-instances', '100',
+      '--session-affinity',
+      '--cpu-boost',
       '--no-cpu-throttling',
       '--set-env-vars', `SANDBOX_SECRET=${secret}`,
     ], { stdio: 'inherit' })


### PR DESCRIPTION
## Summary
- configure the Cloud Run gateway setup command with benchmark-oriented deploy flags
- set CPU 1, memory 2Gi, concurrency 1, min/max instances 100, session affinity, CPU boost, and no CPU throttling
- document the gateway deployment settings and add a patch changeset

## Tests
- pnpm --filter @computesdk/cloud-run build
- pnpm --filter @computesdk/cloud-run typecheck
- pnpm --filter @computesdk/cloud-run test