### PR TITLE
Preserve false browser provider options

### DIFF
--- a/.changeset/browser-provider-false-options.md
+++ b/.changeset/browser-provider-false-options.md
@@ -1,0 +1,11 @@
+---
+"@computesdk/anchorbrowser": patch
+"@computesdk/browserbase": patch
+"@computesdk/browseruse": patch
+"@computesdk/hyperbrowser": patch
+"@computesdk/kernel": patch
+"@computesdk/notte": patch
+"@computesdk/steel": patch
+---
+
+Preserve explicit `stealth: false` and `proxies: false` browser session options where provider APIs support them, and warn once when a provider cannot honor the option.

--- a/packages/anchorbrowser/src/__tests__/options.test.ts
+++ b/packages/anchorbrowser/src/__tests__/options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ data: { id: 'session-id', cdp_url: 'wss://anchor.example' } })),
+}));
+
+vi.mock('anchorbrowser', () => ({
+  default: class Anchorbrowser {
+    sessions = {
+      create: sdk.create,
+    };
+  },
+}));
+
+import { anchorbrowser } from '../index';
+
+describe('anchorbrowser option mapping', () => {
+  it('preserves explicit false stealth and proxy values', async () => {
+    const provider = anchorbrowser({ apiKey: 'test' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.create).toHaveBeenCalledWith({
+      browser: {
+        viewport: { width: 1920, height: 1080 },
+        extra_stealth: { active: false },
+      },
+      session: {
+        proxy: { active: false, type: 'anchor_proxy' },
+      },
+    });
+  });
+});

--- a/packages/anchorbrowser/src/index.ts
+++ b/packages/anchorbrowser/src/index.ts
@@ -159,8 +159,8 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions): SessionCreate
     session.tags = Object.entries(options.userMetadata).map(([k, v]) => `${k}:${v}`);
   }
 
-  if (options.proxies === true) {
-    session.proxy = { active: true, type: 'anchor_proxy' };
+  if (typeof options.proxies === 'boolean') {
+    session.proxy = { active: options.proxies, type: 'anchor_proxy' };
   } else if (Array.isArray(options.proxies) && options.proxies.length > 0) {
     session.proxy = buildProxyParams(options.proxies[0]!);
   }

--- a/packages/browserbase/src/__tests__/options.test.ts
+++ b/packages/browserbase/src/__tests__/options.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ id: 'session-id', connectUrl: 'wss://browserbase.example', status: 'RUNNING' })),
+}));
+
+vi.mock('@browserbasehq/sdk', () => ({
+  default: class Browserbase {
+    sessions = {
+      create: sdk.create,
+    };
+  },
+}));
+
+import { browserbase } from '../index';
+
+describe('browserbase option mapping', () => {
+  it('preserves explicit false stealth and proxy values', async () => {
+    const provider = browserbase({ apiKey: 'test', projectId: 'project-id' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.create).toHaveBeenCalledWith({
+      projectId: 'project-id',
+      proxies: false,
+      browserSettings: {
+        viewport: { width: 1920, height: 1080 },
+        advancedStealth: false,
+      },
+    });
+  });
+});

--- a/packages/browserbase/src/index.ts
+++ b/packages/browserbase/src/index.ts
@@ -76,8 +76,8 @@ function mapSessionOptions(config: BrowserbaseConfig, options?: CreateBrowserSes
   if (options.userMetadata) params.userMetadata = options.userMetadata;
 
   // Proxy configuration
-  if (options.proxies === true) {
-    params.proxies = true;
+  if (typeof options.proxies === 'boolean') {
+    params.proxies = options.proxies;
   } else if (Array.isArray(options.proxies)) {
     params.proxies = options.proxies.map((p: any) => {
       if (p.type === 'custom' && p.server) {

--- a/packages/browseruse/src/__tests__/options.test.ts
+++ b/packages/browseruse/src/__tests__/options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ id: 'session-id', cdpUrl: 'https://browseruse.example', status: 'active' })),
+}));
+
+vi.mock('browser-use-sdk/v3', () => ({
+  BrowserUse: class BrowserUse {
+    browsers = {
+      create: sdk.create,
+    };
+  },
+}));
+
+import { browseruse } from '../index';
+
+describe('browseruse option mapping', () => {
+  it('preserves explicit proxy false and warns for unsupported stealth', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = browseruse({ apiKey: 'test' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.create).toHaveBeenCalledWith({
+      browserScreenWidth: 1920,
+      browserScreenHeight: 1080,
+      proxyCountryCode: null,
+    });
+    expect(warn).toHaveBeenCalledWith("[@computesdk/browseruse] 'stealth' is ignored: Browser Use does not expose a per-session stealth toggle.");
+
+    warn.mockRestore();
+  });
+});

--- a/packages/browseruse/src/index.ts
+++ b/packages/browseruse/src/index.ts
@@ -60,6 +60,13 @@ function createClient(config: BrowserUseConfig): BrowserUse {
   return new BrowserUse({ apiKey, baseUrl, timeout, maxRetries });
 }
 
+const warnedUnsupported = new Set<string>();
+function warnOnce(field: string, reason: string) {
+  if (warnedUnsupported.has(field)) return;
+  warnedUnsupported.add(field);
+  console.warn(`[@computesdk/browseruse] '${field}' is ignored: ${reason}`);
+}
+
 /**
  * Apply a single ProxyConfig entry to the create-browser request.
  * Browser Use supports residential proxies via country code, or custom HTTP/SOCKS5
@@ -117,8 +124,12 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions): Partial<Creat
   // Browser Use accepts session timeout in minutes (default 60, max 240)
   if (options.timeout !== undefined) params.timeout = Math.max(1, Math.ceil(options.timeout / 60));
 
-  // Stealth is enabled by default on Browser Use and not configurable per request.
-  // We accept the option for parity with other providers but it is a no-op.
+  // Browser Use does not expose a per-session stealth toggle. Its browser
+  // sessions are stealth-oriented by default, so `stealth: false` cannot be
+  // honored by this adapter.
+  if (options.stealth !== undefined) {
+    warnOnce('stealth', 'Browser Use does not expose a per-session stealth toggle.');
+  }
 
   if (options.proxies === false) {
     // Explicit opt-out: disable proxy.

--- a/packages/hyperbrowser/src/__tests__/options.test.ts
+++ b/packages/hyperbrowser/src/__tests__/options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ id: 'session-id', wsEndpoint: 'wss://hyperbrowser.example', status: 'active' })),
+}));
+
+vi.mock('@hyperbrowser/sdk', () => ({
+  Hyperbrowser: class Hyperbrowser {
+    sessions = {
+      create: sdk.create,
+    };
+  },
+}));
+
+import { hyperbrowser } from '../index';
+
+describe('hyperbrowser option mapping', () => {
+  it('preserves explicit false stealth and proxy values', async () => {
+    const provider = hyperbrowser({ apiKey: 'test' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.create).toHaveBeenCalledWith({
+      useStealth: false,
+      useProxy: false,
+      screen: { width: 1920, height: 1080 },
+    });
+  });
+});

--- a/packages/hyperbrowser/src/index.ts
+++ b/packages/hyperbrowser/src/index.ts
@@ -106,8 +106,8 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions): CreateSession
   // Hyperbrowser only accepts a session timeout in minutes
   if (options.timeout !== undefined) params.timeoutMinutes = Math.max(1, Math.ceil(options.timeout / 60));
 
-  if (options.proxies === true) {
-    params.useProxy = true;
+  if (typeof options.proxies === 'boolean') {
+    params.useProxy = options.proxies;
   } else if (Array.isArray(options.proxies) && options.proxies.length > 0) {
     applyProxy(params, options.proxies[0]!);
   }

--- a/packages/kernel/src/__tests__/options.test.ts
+++ b/packages/kernel/src/__tests__/options.test.ts
@@ -28,9 +28,7 @@ describe('kernel option mapping', () => {
     expect(sdk.create).toHaveBeenCalledWith({
       stealth: false,
       viewport: { width: 1920, height: 1080 },
-    });
-    expect(warn).toHaveBeenCalledWith("[@computesdk/kernel] 'proxies' is ignored: Kernel create-browser supports only a provider proxy_id, which BrowserSessionCreateOptions cannot express.");
-
+    expect(warn).toHaveBeenCalledWith("[@computesdk/kernel] 'proxies' is ignored: Kernel create-browser supports only a provider proxy_id, which CreateBrowserSessionOptions cannot express.");
     warn.mockRestore();
   });
 });

--- a/packages/kernel/src/__tests__/options.test.ts
+++ b/packages/kernel/src/__tests__/options.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ session_id: 'session-id', cdp_ws_url: 'wss://kernel.example' })),
+}));
+
+vi.mock('@onkernel/sdk', () => ({
+  default: class Kernel {
+    browsers = {
+      create: sdk.create,
+    };
+  },
+}));
+
+import { kernel } from '../index';
+
+describe('kernel option mapping', () => {
+  it('preserves explicit stealth false and warns for unsupported proxies', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = kernel({ apiKey: 'test' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.create).toHaveBeenCalledWith({
+      stealth: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+    expect(warn).toHaveBeenCalledWith("[@computesdk/kernel] 'proxies' is ignored: Kernel create-browser supports only a provider proxy_id, which BrowserSessionCreateOptions cannot express.");
+
+    warn.mockRestore();
+  });
+});

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -20,6 +20,13 @@ import type {
 
 import type { BrowserCreateResponse } from '@onkernel/sdk/resources/browsers';
 
+const warnedUnsupported = new Set<string>();
+function warnOnce(field: string, reason: string) {
+  if (warnedUnsupported.has(field)) return;
+  warnedUnsupported.add(field);
+  console.warn(`[@computesdk/kernel] '${field}' is ignored: ${reason}`);
+}
+
 /**
  * Kernel-specific configuration options
  */
@@ -62,6 +69,9 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions) {
 
   if (options.stealth !== undefined) params.stealth = options.stealth;
   if (options.timeout !== undefined) params.timeout_seconds = options.timeout;
+  if (options.proxies !== undefined) {
+    warnOnce('proxies', 'Kernel create-browser supports only a provider proxy_id, which BrowserSessionCreateOptions cannot express.');
+  }
 
   // Viewport
   if (options.viewport) {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -70,7 +70,7 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions) {
   if (options.stealth !== undefined) params.stealth = options.stealth;
   if (options.timeout !== undefined) params.timeout_seconds = options.timeout;
   if (options.proxies !== undefined) {
-    warnOnce('proxies', 'Kernel create-browser supports only a provider proxy_id, which BrowserSessionCreateOptions cannot express.');
+    warnOnce('proxies', 'Kernel create-browser supports only a provider proxy_id, which CreateBrowserSessionOptions cannot express.');
   }
 
   // Viewport

--- a/packages/notte/src/__tests__/options.test.ts
+++ b/packages/notte/src/__tests__/options.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  sessionStart: vi.fn(async () => ({ data: { session_id: 'session-id', cdp_url: 'wss://notte.example', status: 'active' } })),
+}));
+
+vi.mock('notte-sdk', () => ({
+  createClient: vi.fn(() => ({})),
+  sessionStart: sdk.sessionStart,
+  sessionStatus: vi.fn(),
+  sessionStop: vi.fn(),
+  listSessions: vi.fn(),
+  profileCreate: vi.fn(),
+  profileGet: vi.fn(),
+  profileList: vi.fn(),
+  profileDelete: vi.fn(),
+}));
+
+import { notte } from '../index';
+
+describe('notte option mapping', () => {
+  it('preserves explicit proxy false and warns for unsupported stealth', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = notte({ apiKey: 'test' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.sessionStart).toHaveBeenCalledWith({
+      client: {},
+      body: {
+        viewport_width: 1920,
+        viewport_height: 1080,
+        proxies: false,
+      },
+      throwOnError: true,
+    });
+    expect(warn).toHaveBeenCalledWith("[@computesdk/notte] 'stealth' is ignored: Notte does not expose a per-session stealth toggle.");
+
+    warn.mockRestore();
+  });
+});

--- a/packages/notte/src/index.ts
+++ b/packages/notte/src/index.ts
@@ -70,6 +70,13 @@ function createClient(config: NotteConfig) {
   return buildNotteClient({ baseUrl, token: apiKey });
 }
 
+const warnedUnsupported = new Set<string>();
+function warnOnce(field: string, reason: string) {
+  if (warnedUnsupported.has(field)) return;
+  warnedUnsupported.add(field);
+  console.warn(`[@computesdk/notte] '${field}' is ignored: ${reason}`);
+}
+
 /**
  * Map a single ComputeSDK `ProxyConfig` onto a Notte proxy entry.
  *
@@ -147,6 +154,10 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions): ApiSessionSta
   // Timeout — ComputeSDK uses seconds, Notte uses minutes (round up to >=1)
   if (options.timeout !== undefined) {
     body.max_duration_minutes = Math.max(1, Math.ceil(options.timeout / 60));
+  }
+
+  if (options.stealth !== undefined) {
+    warnOnce('stealth', 'Notte does not expose a per-session stealth toggle.');
   }
 
   // Proxies — `boolean` toggles Notte's default proxy pool; `ProxyConfig[]`

--- a/packages/steel/src/__tests__/options.test.ts
+++ b/packages/steel/src/__tests__/options.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ id: 'session-id', websocketUrl: 'wss://steel.example', status: 'live' })),
+}));
+
+vi.mock('steel-sdk', () => ({
+  default: class Steel {
+    sessions = {
+      create: sdk.create,
+    };
+  },
+  toFile: vi.fn(),
+}));
+
+import { steel } from '../index';
+
+describe('steel option mapping', () => {
+  it('preserves explicit false stealth and proxy values', async () => {
+    const provider = steel({ apiKey: 'test' });
+
+    await provider.session.create({
+      stealth: false,
+      proxies: false,
+      viewport: { width: 1920, height: 1080 },
+    });
+
+    expect(sdk.create).toHaveBeenCalledWith({
+      dimensions: { width: 1920, height: 1080 },
+      stealthConfig: { humanizeInteractions: false },
+      useProxy: false,
+    });
+  });
+});

--- a/packages/steel/src/index.ts
+++ b/packages/steel/src/index.ts
@@ -143,13 +143,13 @@ function mapSessionOptions(options?: CreateBrowserSessionOptions): SessionCreate
   }
 
   // Stealth wraps a few related flags. We toggle humanizeInteractions as the
-  // most user-visible knob; advanced users can override via options pass-through.
-  if (options.stealth) {
-    params.stealthConfig = { humanizeInteractions: true };
+  // most user-visible knob and preserve explicit false values.
+  if (options.stealth !== undefined) {
+    params.stealthConfig = { humanizeInteractions: options.stealth };
   }
 
-  if (options.proxies === true) {
-    params.useProxy = true;
+  if (typeof options.proxies === 'boolean') {
+    params.useProxy = options.proxies;
   } else if (Array.isArray(options.proxies) && options.proxies.length > 0) {
     applyProxy(params, options.proxies[0]!);
   }


### PR DESCRIPTION
## Summary
- preserve explicit `proxies: false` mappings for browser adapters that support disabling proxies
- preserve explicit `stealth: false` for Steel and add one-time warnings where stealth/proxy options are unsupported
- add focused adapter tests for false-value option preservation

## Verification
- `pnpm build`
- `pnpm --filter '@computesdk/browserbase' --filter '@computesdk/hyperbrowser' --filter '@computesdk/anchorbrowser' --filter '@computesdk/steel' --filter '@computesdk/browseruse' --filter '@computesdk/notte' --filter '@computesdk/kernel' test`
- `pnpm --filter '@computesdk/browserbase' --filter '@computesdk/hyperbrowser' --filter '@computesdk/anchorbrowser' --filter '@computesdk/steel' --filter '@computesdk/browseruse' --filter '@computesdk/notte' --filter '@computesdk/kernel' typecheck`