### PR TITLE
Use monotonic Cloud Run command timing

### DIFF
--- a/.changeset/cloud-run-monotonic-duration.md
+++ b/.changeset/cloud-run-monotonic-duration.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cloud-run": patch
+---
+
+Use monotonic timing for Cloud Run command duration measurements.

--- a/.changeset/cloud-run-monotonic-duration.md
+++ b/.changeset/cloud-run-monotonic-duration.md
@@ -1,5 +1,0 @@
----
-"@computesdk/cloud-run": patch
----
-
-Use monotonic timing for Cloud Run command duration measurements.

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -9,6 +9,7 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { access } from 'node:fs/promises'
+import { performance } from 'node:perf_hooks'
 import { defineProvider, escapeShellArg } from '@computesdk/provider'
 import type {
   CommandResult,
@@ -213,7 +214,7 @@ function withShellOptions(command: string, options?: RunCommandOptions): string 
 }
 
 async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> {
-  const start = Date.now()
+  const start = performance.now()
   if (sandbox.remote) {
     try {
       const result = await gatewayRequest(sandbox.config, '/v1/sandbox/exec', {
@@ -227,10 +228,10 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
         stdout: result.stdout || '',
         stderr: result.stderr || '',
         exitCode: result.exitCode ?? 0,
-        durationMs: Date.now() - start,
+        durationMs: Math.round(performance.now() - start),
       }
     } catch (error) {
-      return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - start }
+      return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Math.round(performance.now() - start) }
     }
   }
 
@@ -243,7 +244,7 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
     onStdout: options?.onStdout,
     onStderr: options?.onStderr,
   })
-  return { ...result, durationMs: Date.now() - start }
+  return { ...result, durationMs: Math.round(performance.now() - start) }
 }
 
 type FsRunCommand = (sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>


### PR DESCRIPTION
## Summary
- replace Cloud Run command duration measurement from Date.now() to performance.now()
- round durationMs to integer milliseconds
- add a patch changeset

## Tests
- pnpm --filter @computesdk/cloud-run build
- pnpm --filter @computesdk/cloud-run typecheck
- pnpm --filter @computesdk/cloud-run test