### PR TITLE
docs: correct compute reference pages to match SDK implementation

### DIFF
--- a/docs/reference/Sandbox.md
+++ b/docs/reference/Sandbox.md
@@ -278,7 +278,7 @@ try {
 
 **Notes:**
 - Returns a publicly accessible URL that routes to the specified port in your sandbox
-- URL construction is instantaneous (no network calls) - the URL is available immediately
+- Whether a network call is needed depends on the provider — some construct the URL synchronously from the sandbox host (e.g. E2B), while others resolve it via an API call (e.g. Modal tunnels, Daytona preview links). Always `await` the result
 - The service must be running on the specified port for the URL to be accessible
 
 <br/>

--- a/docs/reference/compute.md
+++ b/docs/reference/compute.md
@@ -330,8 +330,6 @@ The full sandbox API is documented in [compute.sandbox](computesandbox/). Summar
 
 All of these accept a `provider` override where applicable. See [Sandbox](sandbox/) for the instance methods (`runCommand`, `filesystem.*`).
 
-> **Reserved methods.** The TypeScript surface also declares `compute.sandbox.find`, `compute.sandbox.findOrCreate`, and `compute.sandbox.extendTimeout`. These are reserved for a future gateway / named-sandbox mode and are not implemented by the currently shipped provider packages — calling them today throws `Provider 'X' does not support …`. Don't rely on them in direct-mode code.
-
 <br>
 
 ***

--- a/docs/reference/compute.sandbox.md
+++ b/docs/reference/compute.sandbox.md
@@ -16,9 +16,13 @@ Create a new compute sandbox instance.
 
 - `options` (CreateSandboxOptions, optional): Configuration options for sandbox creation
   - `timeout` (number, optional): Sandbox execution timeout in milliseconds
-  - `templateId` (string, optional): Provider-specific template or image identifier
+  - `templateId` (string, optional): Provider-agnostic template or image identifier to boot from
+  - `snapshotId` (string, optional): Snapshot ID to restore from; each provider maps this to its native concept (E2B template, Daytona snapshot, Modal image, etc.)
   - `metadata` (Record<string, any>, optional): Custom metadata to attach to the sandbox
   - `envs` (Record<string, string>, optional): Environment variables to set in the sandbox
+  - `signal` (AbortSignal, optional): Cancels sandbox creation and cleans up an orphaned sandbox if the signal aborts
+  - `name`, `namespace`, `directory` (string, optional): Provider-specific naming/placement hints
+  - Additional provider-specific properties are passed through (e.g. `domain` for E2B)
 
 **Returns:** `Promise<Sandbox>` - New sandbox instance ready for code execution and commands
 
@@ -32,10 +36,16 @@ Create a new compute sandbox instance.
 **CreateSandboxOptions interface:**
 ```typescript
 {
-  timeout?: number;               // Execution timeout in milliseconds
-  templateId?: string;            // Provider template/image identifier
-  metadata?: Record<string, any>; // Custom metadata
-  envs?: Record<string, string>;  // Environment variables
+  timeout?: number;                // Execution timeout in milliseconds
+  templateId?: string;             // Provider template/image identifier
+  snapshotId?: string;             // Snapshot to restore from
+  metadata?: Record<string, any>;  // Custom metadata
+  envs?: Record<string, string>;   // Environment variables
+  signal?: AbortSignal;            // Cancel creation / clean up orphaned sandbox
+  name?: string;                   // Provider-specific name
+  namespace?: string;              // Provider-specific namespace
+  directory?: string;              // Provider-specific working directory
+  [key: string]: any;              // Provider-specific properties
 }
 ```
 


### PR DESCRIPTION
Fix inaccuracies in the API reference:
- Remove fabricated "reserved methods" note (find/findOrCreate/extendTimeout don't exist in the SDK)
- Complete CreateSandboxOptions with snapshotId, signal, name, namespace, directory, and provider-specific passthrough
- Correct getUrl claim: it may make a network call depending on provider (Modal, Daytona) rather than always being synchronous