### PR TITLE
feat(bench-cli): --remote mode ships benchmarks to the platform

### DIFF
--- a/.changeset/bench-cli-remote.md
+++ b/.changeset/bench-cli-remote.md
@@ -1,0 +1,7 @@
+---
+'@computesdk/bench-cli': minor
+---
+
+Add `--remote` mode to the `bench` CLI, which plans a benchmark run + workers on the ComputeSDK platform via `@computesdk/bench`, forks one or more local `bench-worker` processes, and reports aggregated progress back through a vitest-style TUI. Supports `--slug`, `--total`, `--workers`, `--concurrency`, `--participant`, `--api-key`, `--base-url`, `--poll-interval`, and `--timeout`.
+
+This is a preview shape; v2 will generalize the worker story to remote hosts (SSH/Docker/Kubernetes).

--- a/packages/bench-cli/CHANGELOG.md
+++ b/packages/bench-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @computesdk/bench-cli
 
+## 0.2.0
+
+- New `--remote` flag turns `bench run <file>` into a platform-orchestrated run via `@computesdk/bench`.
+- Parent CLI plans the run + workers, forks local `bench-worker` processes, polls progress, and prints a summary.
+- New `--slug`, `--total`, `--workers`, `--concurrency`, `--participant`, `--api-key`, `--base-url`, `--poll-interval`, `--timeout` flags.
+
 ## 0.1.0
 
 Initial release.

--- a/packages/bench-cli/README.md
+++ b/packages/bench-cli/README.md
@@ -120,3 +120,36 @@ const { summaries } = await runCommand([], { iterations: 100 });
 project that cares about regressions in latency. Following the precedent set by
 vitest, the convention is to put a single file per concern so diffs stay
 isolated and CI can target a single benchmark with `bench run benchmarks/x.bench.ts`.
+
+## Remote execution (preview)
+
+Pass `--remote` to ship the benchmark to the ComputeSDK platform
+orchestrator instead of running it on the local box. The CLI talks to the
+existing `BenchmarkClient` + `BenchmarkReporter` API from `@computesdk/bench`,
+plans a run + workers on the platform, and forks `--workers` local processes
+that each claim work from the platform until the assigned task range is drained.
+
+```bash
+bench run benchmarks/strings.bench.ts --remote \
+  --slug strings --total 500 --workers 4 --concurrency 10
+```
+
+Flag reference for `--remote`:
+
+- `--slug <slug>` benchmark slug (default derived from filename)
+- `--run-name <name>` display name for the run
+- `--total <n>` replications per registered `bench()` function (default 100)
+- `--workers <n>` local worker processes to fork (default 1)
+- `--concurrency <n>` parallel task slots per worker (default 1)
+- `--participant <slug>` participant identifier (default `bench-cli`)
+- `--api-key <key>` / `--base-url <url>` overrides for the platform client
+- `--poll-interval <ms>` parent status poll interval (default 1000)
+- `--timeout <seconds>` parent wall-clock timeout (default 0 = unlimited)
+
+Each forked worker is invoked as `bench-worker` and reads its configuration
+from environment variables set by the parent, so the worker itself has no
+configuration surface of its own. v1 assumes workers run on the same host;
+turning them into remote workers (SSH/[Docker]/Kubernetes) is a follow-up.
+
+The CLI ships a vitest-style progress TUI (`status=… workers=… tasks=…`) and
+prints a final pass/fail summary when the run finishes.

--- a/packages/bench-cli/package.json
+++ b/packages/bench-cli/package.json
@@ -9,7 +9,8 @@
   "types": "./dist/index.d.ts",
   "bin": {
     "bench": "./dist/bin/bench.js",
-    "bench-ts": "./src/bin/bench-ts.ts"
+    "bench-ts": "./src/bin/bench-ts.ts",
+    "bench-worker": "./dist/bin/bench-worker.js"
   },
   "exports": {
     ".": {

--- a/packages/bench-cli/src/__tests__/remote-cli.test.ts
+++ b/packages/bench-cli/src/__tests__/remote-cli.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from '../cli';
+
+describe('cli parser — remote flags', () => {
+  it('parses --remote alone', () => {
+    const parsed = parseArgs(['benchmarks/x.bench.ts', '--remote']);
+    expect(parsed.remote).toBe(true);
+    expect(parsed.files).toEqual(['benchmarks/x.bench.ts']);
+  });
+
+  it('parses the full remote flag set with both --flag and --flag=value forms', () => {
+    const parsed = parseArgs([
+      'benchmarks/x.bench.ts',
+      '--remote',
+      '--slug', 'my-slug',
+      '--total=42',
+      '--workers', '3',
+      '--concurrency=2',
+      '--participant=cli',
+      '--api-key', 'k',
+      '--base-url=https://example.test',
+      '--poll-interval', '500',
+      '--timeout=120',
+    ]);
+    expect(parsed.remote).toBe(true);
+    expect(parsed.remoteOptions).toMatchObject({
+      slug: 'my-slug',
+      total: 42,
+      workers: 3,
+      concurrency: 2,
+      participant: 'cli',
+      apiKey: 'k',
+      baseUrl: 'https://example.test',
+      pollIntervalMs: 500,
+      timeoutSeconds: 120,
+    });
+  });
+
+  it('rejects unknown --remote subflag', () => {
+    expect(() => parseArgs(['x.bench.ts', '--remote', '--no-such-flag', '1'])).toThrow(/unknown option/);
+  });
+
+  it('rejects non-positive values for positive flags', () => {
+    expect(() => parseArgs(['x.bench.ts', '--remote', '--workers', '0'])).toThrow(/--workers must be a positive integer/);
+    expect(() => parseArgs(['x.bench.ts', '--remote', '--concurrency=0'])).toThrow(/--concurrency must be a positive integer/);
+  });
+});

--- a/packages/bench-cli/src/__tests__/remote-orchestrator.test.ts
+++ b/packages/bench-cli/src/__tests__/remote-orchestrator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { runRemote } from '../remote';
+import { loadBenchFile } from '../loader';
+
+const FIXTURES_DIR = fileURLToPath(new URL('./fixtures/', import.meta.url));
+const FIXTURE_FILE = `${FIXTURES_DIR}benchmarks/strings.bench.ts`;
+
+function makeFakeClient() {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const client = {
+    upsertBenchmark: vi.fn(async (...args: unknown[]) => { calls.push({ method: 'upsertBenchmark', args }); return {}; }),
+    createRun: vi.fn(async (...args: unknown[]) => { calls.push({ method: 'createRun', args }); return { run: { id: 'run-76' } }; }),
+    planWorkers: vi.fn(async (...args: unknown[]) => { calls.push({ method: 'planWorkers', args }); return {}; }),
+    getRunProgress: vi.fn(async () => ({ summary: { status: 'completed', participants: { total: 1 } }, participants: [] })),
+    getRunTaskResults: vi.fn(async () => ({ buckets: [] })),
+  };
+  return { client, calls };
+}
+
+describe('remote orchestrator', () => {
+  it('throws when the bench file registers no benchmarks', async () => {
+    const tmp = `${FIXTURE_FILE}.empty.bench.ts`;
+    const { writeFileSync, unlinkSync } = await import('node:fs');
+    writeFileSync(tmp, 'export {};\n');
+    try {
+      const sink = new PassThrough();
+      const stdout = sink as unknown as NodeJS.WriteStream;
+      const { client } = makeFakeClient();
+      try {
+        await runRemote(tmp, { clientFactory: () => client as any, stdout, workers: 1, total: 1 });
+        throw new Error('expected to throw');
+      } catch (error) {
+        expect((error as Error).message).toMatch(/No benchmarks registered/);
+      }
+    } finally {
+      unlinkSync(tmp);
+    }
+  });
+
+  it('throws on --workers < 1', async () => {
+    const sink = new PassThrough();
+    const stdout = sink as unknown as NodeJS.WriteStream;
+    const { client } = makeFakeClient();
+    await expect(runRemote(FIXTURE_FILE, { clientFactory: () => client as any, stdout, workers: 0 })).rejects.toThrow(/--workers must be >= 1/);
+  });
+
+  it('counts registered benches via loadBenchFile', async () => {
+    const entries = await loadBenchFile(FIXTURE_FILE);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/bench-cli/src/__tests__/remote-worker.test.ts
+++ b/packages/bench-cli/src/__tests__/remote-worker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readWorkerConfig } from '../remote-worker';
+
+describe('remote-worker config parser', () => {
+  it('reads required env vars and parses positive integers', () => {
+    const cfg = readWorkerConfig({
+      BENCH_CLI_REMOTE_SLUG: 'my-bench',
+      BENCH_CLI_REMOTE_RUN_ID: 'run-123',
+      BENCH_CLI_REMOTE_PARTICIPANT: 'bench-cli',
+      BENCH_CLI_REMOTE_TOTAL: '50',
+      BENCH_CLI_REMOTE_BENCH_COUNT: '4',
+      BENCH_CLI_REMOTE_CONCURRENCY: '2',
+      BENCH_CLI_REMOTE_WORKER_KEY: 'k',
+      BENCH_CLI_REMOTE_API_KEY: 'secret',
+      BENCH_CLI_REMOTE_BASE_URL: 'https://example.test',
+    });
+    expect(cfg).toMatchObject({
+      slug: 'my-bench',
+      runId: 'run-123',
+      participant: 'bench-cli',
+      total: 50,
+      benchCount: 4,
+      concurrency: 2,
+      workerKey: 'k',
+      apiKey: 'secret',
+      baseUrl: 'https://example.test',
+    });
+  });
+
+  it('throws when required env vars are missing', () => {
+    expect(() => readWorkerConfig({})).toThrow(/BENCH_CLI_REMOTE_SLUG/);
+    expect(() =>
+      readWorkerConfig({
+        BENCH_CLI_REMOTE_SLUG: 'x',
+        BENCH_CLI_REMOTE_RUN_ID: 'y',
+        BENCH_CLI_REMOTE_PARTICIPANT: 'z',
+        BENCH_CLI_REMOTE_TOTAL: '0',
+        BENCH_CLI_REMOTE_BENCH_COUNT: '1',
+        BENCH_CLI_REMOTE_CONCURRENCY: '1',
+      }),
+    ).toThrow(/BENCH_CLI_REMOTE_TOTAL/);
+  });
+});

--- a/packages/bench-cli/src/bin/bench-ts.ts
+++ b/packages/bench-cli/src/bin/bench-ts.ts
@@ -5,7 +5,9 @@
  * Runs directly through tsx so users in a monorepo can `bench` without
  * having to build this package first.
  */
+import process from 'node:process';
 import { runCli } from '../cli.js';
+import { runWorkerFromArgv } from '../remote-worker-entry.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -21,4 +23,8 @@ try {
 }
 
 const argv = process.argv.slice(2);
-await runCli(argv, version);
+if (argv.includes('--remote-worker') || process.env.BENCH_CLI_REMOTE_RUN_ID) {
+  await runWorkerFromArgv(argv);
+} else {
+  await runCli(argv, version);
+}

--- a/packages/bench-cli/src/bin/bench-worker.ts
+++ b/packages/bench-cli/src/bin/bench-worker.ts
@@ -1,0 +1,11 @@
+/**
+ * Built bench-worker entry — bundled by tsup into dist/bin/bench-worker.js.
+ *
+ * Forks from the parent orchestrator with environment variables that
+ * identify the run. This entry does not parse CLI flags; it reads its
+ * configuration from the environment exclusively.
+ */
+import { runWorkerFromArgv } from '../remote-worker-entry.js';
+
+const argv = process.argv.slice(2);
+void (await runWorkerFromArgv(argv));

--- a/packages/bench-cli/src/bin/bench.ts
+++ b/packages/bench-cli/src/bin/bench.ts
@@ -1,7 +1,9 @@
 /**
  * Built bench CLI entry point — bundled by tsup into dist/bin/bench.js.
  */
+import process from 'node:process';
 import { runCli } from '../cli.js';
+import { runWorkerFromArgv } from '../remote-worker-entry.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -17,4 +19,8 @@ try {
 }
 
 const argv = process.argv.slice(2);
-await runCli(argv, version);
+if (argv.includes('--remote-worker') || process.env.BENCH_CLI_REMOTE_RUN_ID) {
+  await runWorkerFromArgv(argv);
+} else {
+  await runCli(argv, version);
+}

--- a/packages/bench-cli/src/cli.ts
+++ b/packages/bench-cli/src/cli.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import { runCommand } from './run-command';
 import { listCommand } from './list-command';
+import { runRemote } from './remote';
 import { DEFAULT_ITERATIONS, DEFAULT_WARMUP } from './dsl';
 
 const PACKAGE_NAME = '@computesdk/bench-cli';
@@ -15,9 +16,41 @@ export interface ParsedArgs {
   reporter: 'default' | 'json';
   bail: boolean;
   cwd: string;
+  remote: boolean;
+  remoteOptions: {
+    slug?: string;
+    runName?: string;
+    total?: number;
+    workers?: number;
+    concurrency?: number;
+    participant?: string;
+    apiKey?: string;
+    baseUrl?: string;
+    pollIntervalMs?: number;
+    timeoutSeconds?: number;
+  };
   showHelp: boolean;
   showVersion: boolean;
 }
+
+interface RemoteSpec {
+  name: string;
+  dest: keyof ParsedArgs['remoteOptions'];
+  kind: 'string' | 'positive';
+}
+
+const REMOTE_SPECS: readonly RemoteSpec[] = [
+  { name: 'slug', dest: 'slug', kind: 'string' },
+  { name: 'run-name', dest: 'runName', kind: 'string' },
+  { name: 'total', dest: 'total', kind: 'positive' },
+  { name: 'workers', dest: 'workers', kind: 'positive' },
+  { name: 'concurrency', dest: 'concurrency', kind: 'positive' },
+  { name: 'participant', dest: 'participant', kind: 'string' },
+  { name: 'api-key', dest: 'apiKey', kind: 'string' },
+  { name: 'base-url', dest: 'baseUrl', kind: 'string' },
+  { name: 'poll-interval', dest: 'pollIntervalMs', kind: 'positive' },
+  { name: 'timeout', dest: 'timeoutSeconds', kind: 'positive' },
+];
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {
   const result: ParsedArgs = {
@@ -28,6 +61,8 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     reporter: 'default',
     bail: false,
     cwd: process.cwd(),
+    remote: false,
+    remoteOptions: {},
     showHelp: false,
     showVersion: false,
   };
@@ -60,38 +95,45 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       i += 1;
       continue;
     }
+    if (arg === '--remote') {
+      result.remote = true;
+      i += 1;
+      continue;
+    }
     if (arg === '--cwd' || arg.startsWith('--cwd=')) {
-      consumeValue(arg, '--cwd', argv, i, (value) => {
+      i = consumeValueOption(arg, argv, i, '--cwd', (value) => {
         result.cwd = value;
-        return 1;
       });
-      i += arg.startsWith('--cwd=') ? 1 : 2;
       continue;
     }
     if (arg === '-i' || arg === '--iterations' || arg.startsWith('--iterations=')) {
-      consumeValue(arg, '--iterations', argv, i, (value) => {
+      i = consumeValueOption(arg, argv, i, '--iterations', (value) => {
         result.iterations = parseCount(value, 'iterations');
-        return 1;
       });
-      i += arg.startsWith('--iterations=') ? 1 : 2;
       continue;
     }
     if (arg === '-w' || arg === '--warmup' || arg.startsWith('--warmup=')) {
-      consumeValue(arg, '--warmup', argv, i, (value) => {
+      i = consumeValueOption(arg, argv, i, '--warmup', (value) => {
         result.warmup = parseCount(value, 'warmup');
-        return 1;
       });
-      i += arg.startsWith('--warmup=') ? 1 : 2;
       continue;
     }
     if (arg === '-r' || arg === '--reporter' || arg.startsWith('--reporter=')) {
-      consumeValue(arg, '--reporter', argv, i, (value) => {
+      i = consumeValueOption(arg, argv, i, '--reporter', (value) => {
         result.reporter = value === 'json' ? 'json' : 'default';
-        return 1;
       });
-      i += arg.startsWith('--reporter=') ? 1 : 2;
       continue;
     }
+
+    const remoteMatch = matchRemoteOption(arg);
+    if (remoteMatch) {
+      const { spec, inlineValue } = remoteMatch;
+      i = consumeRemoteValue(arg, argv, i, spec, (value) => {
+        applyRemoteValue(result.remoteOptions, spec, value);
+      }, inlineValue);
+      continue;
+    }
+
     if (arg.startsWith('-')) {
       throw new Error(`unknown option: ${arg}`);
     }
@@ -103,23 +145,70 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   return result;
 }
 
-function consumeValue(
+function consumeValueOption(
   arg: string,
-  longName: string,
   argv: readonly string[],
   index: number,
+  longName: string,
   consume: (value: string) => void,
-): void {
+): number {
   const eq = arg.indexOf('=');
   if (eq !== -1) {
     consume(arg.slice(eq + 1));
-    return;
+    return index + 1;
   }
   const next = argv[index + 1];
   if (next === undefined) {
     throw new Error(`${longName} requires a value`);
   }
   consume(next);
+  return index + 2;
+}
+
+function matchRemoteOption(arg: string): { spec: RemoteSpec; inlineValue: string | null } | null {
+  if (!arg.startsWith('--')) return null;
+  for (const spec of REMOTE_SPECS) {
+    const full = `--${spec.name}`;
+    if (arg === full) return { spec, inlineValue: null };
+    if (arg.startsWith(full + '=')) return { spec, inlineValue: arg.slice(full.length + 1) };
+  }
+  return null;
+}
+
+function consumeRemoteValue(
+  arg: string,
+  argv: readonly string[],
+  index: number,
+  spec: RemoteSpec,
+  consume: (value: string) => void,
+  inlineValue: string | null,
+): number {
+  if (inlineValue !== null) {
+    consume(inlineValue);
+    return index + 1;
+  }
+  const next = argv[index + 1];
+  if (next === undefined) {
+    throw new Error(`--${spec.name} requires a value`);
+  }
+  consume(next);
+  return index + 2;
+}
+
+function applyRemoteValue(
+  bag: ParsedArgs['remoteOptions'],
+  spec: RemoteSpec,
+  raw: string,
+): void {
+  if (spec.kind === 'positive') {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      throw new Error(`--${spec.name} must be a positive integer, got "${raw}"`);
+    }
+    (bag as Record<string, number | string | undefined>)[spec.dest] = parsed;
+    return;
+  }
+  (bag as Record<string, number | string | undefined>)[spec.dest] = raw;
 }
 
 function parseCount(value: string, name: string): number {
@@ -138,15 +227,30 @@ export function renderHelp(): string {
     `Similar to vitest: drop *.bench.ts files in ./benchmarks/ and run \`bench\` to execute them.`,
     ``,
     `Subcommands:`,
-    `  run [files...]   (default) Run benchmark files.`,
+    `  run [files...]   (default) Run benchmark files locally, or with --remote on the platform.`,
     `  list [files...]  List discovered benchmark files.`,
     ``,
-    `Options:`,
+    `Local options:`,
     `  -i, --iterations <n>    iterations per benchmark (default ${DEFAULT_ITERATIONS})`,
     `  -w, --warmup <n>        warmup iterations (default ${DEFAULT_WARMUP})`,
     `  -r, --reporter <fmt>    reporter format: default | json (default default)`,
     `  --bail                  stop on first failure`,
     `  --cwd <path>            working directory`,
+    ``,
+    `Remote options (combine with --remote):`,
+    `  --remote                ship the benchmark to the platform orchestrator`,
+    `  --slug <slug>           benchmark slug (default derived from filename)`,
+    `  --run-name <name>       run name (default derived from filename)`,
+    `  --total <n>             replications per benchmark function (default 100)`,
+    `  --workers <n>           local worker processes to fork (default 1; v2 for true remote)`,
+    `  --concurrency <n>       parallel task slots per worker (default 1)`,
+    `  --participant <slug>    participant identifier (default bench-cli)`,
+    `  --api-key <key>         platform API key (default env COMPUTESDK_ADMIN_API_KEY)`,
+    `  --base-url <url>        platform base URL (default https://platform.computesdk.com/api/v1)`,
+    `  --poll-interval <ms>    parent status poll interval (default 1000)`,
+    `  --timeout <seconds>     parent wall-clock timeout (default 0 = unlimited)`,
+    ``,
+    `General:`,
     `  -h, --help              show this help`,
     `  -V, --version           print version`,
   ].join('\n');
@@ -183,6 +287,18 @@ export async function runCli(argv: readonly string[], version: string): Promise<
       await listCommand(parsed.files, { cwd: parsed.cwd });
       return typeof process.exitCode === 'number' ? process.exitCode : 0;
     }
+
+    if (parsed.remote) {
+      if (parsed.files.length !== 1) {
+        throw new Error('--remote mode requires exactly one benchmark file argument');
+      }
+      await runRemote(parsed.files[0]!, {
+        cwd: parsed.cwd,
+        ...parsed.remoteOptions,
+      });
+      return typeof process.exitCode === 'number' ? process.exitCode : 0;
+    }
+
     await runCommand(parsed.files, {
       cwd: parsed.cwd,
       iterations: parsed.iterations,

--- a/packages/bench-cli/src/remote-worker-entry.ts
+++ b/packages/bench-cli/src/remote-worker-entry.ts
@@ -1,0 +1,38 @@
+import process from 'node:process';
+import { readWorkerConfig, runRemoteWorker } from './remote-worker.js';
+
+/**
+ * Worker entry point invoked by the parent orchestrator. Reads its
+ * configuration from environment variables and runs the task loop until
+ * the platform-assigned range is drained.
+ */
+export async function runWorkerFromArgv(argv: readonly string[]): Promise<number> {
+  try {
+    const file = readFileArg(argv);
+    const config = readWorkerConfig(process.env);
+    const result = await runRemoteWorker({ file, config });
+    process.stdout.write(JSON.stringify({ kind: 'final', ...result }) + '\n');
+    return typeof process.exitCode === 'number' ? process.exitCode : 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`bench-cli remote worker: ${message}\n`);
+    return 1;
+  }
+}
+
+function readFileArg(argv: readonly string[]): string {
+  const idx = argv.indexOf('--file');
+  if (idx === -1) {
+    // Also accept positional file argument.
+    const positional = argv.filter((arg) => !arg.startsWith('-') && arg !== '--remote-worker');
+    if (positional.length === 0) {
+      throw new Error('remote worker requires --file <path>');
+    }
+    return positional[0]!;
+  }
+  const value = argv[idx + 1];
+  if (!value) {
+    throw new Error('remote worker --file requires a value');
+  }
+  return value;
+}

--- a/packages/bench-cli/src/remote-worker.ts
+++ b/packages/bench-cli/src/remote-worker.ts
@@ -1,0 +1,195 @@
+import path from 'node:path';
+import process from 'node:process';
+import { BenchmarkReporter, createBenchmarkClient, type BenchmarkReporterConfig, type TaskResultRecord } from '@computesdk/bench';
+import { loadBenchFile } from './loader';
+import type { BenchmarkEntry } from './types';
+
+const ENV_SLUG = 'BENCH_CLI_REMOTE_SLUG';
+const ENV_RUN_ID = 'BENCH_CLI_REMOTE_RUN_ID';
+const ENV_PARTICIPANT = 'BENCH_CLI_REMOTE_PARTICIPANT';
+const ENV_TOTAL = 'BENCH_CLI_REMOTE_TOTAL';
+const ENV_BENCH_COUNT = 'BENCH_CLI_REMOTE_BENCH_COUNT';
+const ENV_CONCURRENCY = 'BENCH_CLI_REMOTE_CONCURRENCY';
+const ENV_WORKER_KEY = 'BENCH_CLI_REMOTE_WORKER_KEY';
+const ENV_API_KEY = 'BENCH_CLI_REMOTE_API_KEY';
+const ENV_BASE_URL = 'BENCH_CLI_REMOTE_BASE_URL';
+
+export interface RemoteWorkerConfig {
+  slug: string;
+  runId: string;
+  participant: string;
+  total: number;
+  benchCount: number;
+  concurrency: number;
+  workerKey?: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+/**
+ * Parse the worker configuration from env vars. Throws if any required
+ * field is missing — the parent should always populate them.
+ */
+export function readWorkerConfig(env: NodeJS.ProcessEnv = process.env): RemoteWorkerConfig {
+  const required = [ENV_SLUG, ENV_RUN_ID, ENV_PARTICIPANT, ENV_TOTAL, ENV_BENCH_COUNT, ENV_CONCURRENCY];
+  for (const key of required) {
+    if (!(env[key] && env[key]!.length > 0)) {
+      throw new Error(`Remote worker missing env ${key}; was the parent CLI invoked correctly?`);
+    }
+  }
+  return {
+    slug: env[ENV_SLUG]!,
+    runId: env[ENV_RUN_ID]!,
+    participant: env[ENV_PARTICIPANT]!,
+    total: parsePositiveInt(env[ENV_TOTAL]!, ENV_TOTAL),
+    benchCount: parsePositiveInt(env[ENV_BENCH_COUNT]!, ENV_BENCH_COUNT),
+    concurrency: parsePositiveInt(env[ENV_CONCURRENCY]!, ENV_CONCURRENCY),
+    workerKey: env[ENV_WORKER_KEY],
+    apiKey: env[ENV_API_KEY],
+    baseUrl: env[ENV_BASE_URL],
+  };
+}
+
+/**
+ * Run the worker loop. Returns the count of successful/failed tasks run
+ * by this process for reporting back to the parent.
+ */
+export async function runRemoteWorker(options: {
+  file: string;
+  config: RemoteWorkerConfig;
+  reporterFactory?: (cfg: BenchmarkReporterConfig) => Promise<BenchmarkReporter | null>;
+  clientFactory?: (cfg: { apiKey?: string; baseUrl?: string }) => ReturnType<typeof createBenchmarkClient>;
+}): Promise<{ pass: number; failed: number }> {
+  const config = options.config;
+  const entries = await loadBenchFile(path.resolve(options.file));
+  const reporterFactory = options.reporterFactory ?? defaultReporterFactory;
+  const reporter = await reporterFactory({
+    benchmarkSlug: config.slug,
+    runId: config.runId,
+    participantSlug: config.participant,
+    processKind: 'container',
+    processKey: config.workerKey ?? `bench-cli-${process.pid}`,
+    batchSize: 100,
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+  });
+  if (!reporter) {
+    process.stderr.write(`bench-cli: remote worker could not claim assignment for ${config.slug}/${config.runId}\n`);
+    process.exitCode = 1;
+    return { pass: 0, failed: 0 };
+  }
+
+  const range = reporter.workerAssignment.taskRange;
+  const benchEntries: BenchmarkEntry[] = entries;
+
+  let pass = 0;
+  let failed = 0;
+  const startedAt = new Date().toISOString();
+
+  for (let taskIndex = range.start; taskIndex < range.start + range.count; taskIndex += 1) {
+    const benchIdx = Math.floor(taskIndex / config.total);
+    const repIdx = taskIndex % config.total;
+    const entry = benchEntries[benchIdx];
+    if (!entry) {
+      failed += 1;
+      reporter.recordResult(buildFailedRecord(taskIndex, startedAt, `bench index ${benchIdx} out of range`));
+      continue;
+    }
+    const record = await runTask(taskIndex, entry, repIdx);
+    if (record.status === 'success') pass += 1;
+    else failed += 1;
+    reporter.recordResult(record);
+  }
+
+  reporter.setProgress({ done: pass + failed, inFlight: 0, errors: failed, total: range.count });
+  await reporter.finish(failed > 0);
+  reportProgress({ kind: 'progress', pass, failed });
+  return { pass, failed };
+}
+
+async function runTask(taskIndex: number, entry: BenchmarkEntry, repIdx: number): Promise<TaskResultRecord> {
+  const staticIterations = entry.options.iterations ?? 100;
+  const iterations = Math.min(staticIterations, 100);
+  const warmup = Math.min(entry.options.warmup ?? 5, 10);
+  const startedAt = new Date().toISOString();
+
+  try {
+    await entry.options.setup();
+    for (let i = 0; i < warmup; i += 1) await entry.fn();
+    const tickStart = now();
+    for (let i = 0; i < iterations; i += 1) await entry.fn();
+    const totalMs = now() - tickStart;
+    const hz = totalMs > 0 ? (iterations / totalMs) * 1000 : 0;
+    const teardown = entry.options.teardown();
+    if (teardown && typeof (teardown as Promise<unknown>).catch === 'function') {
+      await (teardown as Promise<unknown>).catch(() => {});
+    }
+    return {
+      taskIndex,
+      status: 'success',
+      startedAt,
+      completedAt: new Date().toISOString(),
+      latencyMs: totalMs,
+      steps: [],
+      data: {
+        taskName: entry.id,
+        benchName: entry.name,
+        benchId: entry.id,
+        repIdx,
+        hz,
+        meanMs: totalMs / Math.max(iterations, 1),
+        iterations,
+        warmup,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    return buildFailedRecord(taskIndex, startedAt, message, entry);
+  }
+}
+
+function buildFailedRecord(taskIndex: number, startedAt: string, message: string, entry?: BenchmarkEntry): TaskResultRecord {
+  return {
+    taskIndex,
+    status: 'failed',
+    startedAt,
+    completedAt: new Date().toISOString(),
+    latencyMs: 0,
+    errorCode: 'BENCH_FAILED',
+    data: {
+      taskName: entry ? entry.id : '<unknown>',
+      benchName: entry ? entry.name : '<unknown>',
+      benchId: entry ? entry.id : '<unknown>',
+      errorMessage: message,
+    },
+  };
+}
+
+function reportProgress(message: { kind: 'progress'; pass: number; failed: number }): void {
+  if (typeof process.send === 'function') {
+    try {
+      process.send(message);
+    } catch {
+      // IPC may not be available in all contexts (e.g., tests).
+    }
+  }
+}
+
+function parsePositiveInt(value: string, name: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`env ${name} must be a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function defaultReporterFactory(cfg: BenchmarkReporterConfig): Promise<BenchmarkReporter | null> {
+  return BenchmarkReporter.claim(cfg);
+}
+
+function now(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}

--- a/packages/bench-cli/src/remote.ts
+++ b/packages/bench-cli/src/remote.ts
@@ -1,0 +1,317 @@
+import { fork } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import pc from 'picocolors';
+import { createBenchmarkClient, BenchmarkReporter, type BenchmarkClient } from '@computesdk/bench';
+import type { BenchmarkEntry, RemoteOptions } from './types';
+import { loadBenchFile } from './loader';
+
+const PACKAGE_NAME = '@computesdk/bench-cli';
+const DEFAULT_PARTICIPANT = 'bench-cli';
+const DEFAULT_TOTAL = 100;
+const DEFAULT_WORKERS = 1;
+const DEFAULT_CONCURRENCY = 1;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_KIND = 'bench-cli';
+
+export interface RemoteRunOptions extends RemoteOptions {
+  cwd?: string;
+  /** Override the writer for status updates. */
+  stdout?: NodeJS.WritableStream;
+  /** Override the platform client for tests. */
+  clientFactory?: (config: { apiKey?: string; baseUrl?: string }) => BenchmarkClient;
+}
+
+export interface RemoteRunResult {
+  benchmarkSlug: string;
+  runId: string;
+  totalTasks: number;
+  workerCount: number;
+  pass: number;
+  failed: number;
+}
+
+/**
+ * Plan a benchmark run on the platform and fork local worker processes.
+ */
+export async function runRemote(
+  file: string,
+  options: RemoteRunOptions = {},
+): Promise<RemoteRunResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const absoluteFile = path.resolve(cwd, file);
+  const out = options.stdout ?? process.stdout;
+
+  // Phase 1: capture entry list (no measurement yet)
+  const entries = await loadBenchFile(absoluteFile);
+  const benchCount = entries.length;
+  if (benchCount === 0) {
+    throw new Error(`No benchmarks registered in ${absoluteFile}; nothing to ship to the platform.`);
+  }
+
+  const slug = options.slug ?? defaultSlug(absoluteFile);
+  const runName = options.runName ?? defaultRunName(absoluteFile);
+  const total = options.total ?? DEFAULT_TOTAL;
+  const workers = options.workers ?? DEFAULT_WORKERS;
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const participant = options.participant ?? DEFAULT_PARTICIPANT;
+  const totalTasks = benchCount * total;
+
+  if (workers < 1) throw new Error('--workers must be >= 1');
+  if (concurrency < 1) throw new Error('--concurrency must be >= 1');
+  if (total < 1) throw new Error('--total must be >= 1');
+
+  const clientFactory = options.clientFactory ?? defaultClientFactory;
+  const client = clientFactory({
+    apiKey: options.apiKey,
+    baseUrl: options.baseUrl,
+  });
+
+  out.write(`${pc.cyan(pc.bold(' bench '))}${pc.dim(' planning ')}${pc.cyan(`${slug} `)}${pc.dim('on')} ${pc.cyan(participant)}\n`);
+  out.write(`  ${pc.dim('file:')}        ${absoluteFile}\n`);
+  out.write(`  ${pc.dim('benchmarks:')}  ${benchCount}\n`);
+  out.write(`  ${pc.dim('total/bench:')} ${total}\n`);
+  out.write(`  ${pc.dim('totalTasks:')}  ${totalTasks}\n`);
+  out.write(`  ${pc.dim('workers:')}     ${workers}\n`);
+  out.write(`  ${pc.dim('concurrency:')} ${concurrency}\n\n`);
+
+  await client.upsertBenchmark(slug, {
+    name: slug,
+    kind: DEFAULT_KIND,
+    config: {
+      source: PACKAGE_NAME,
+      benchFile: absoluteFile,
+      benchCount,
+      totalPerBench: total,
+      iterations: 1,
+    },
+  });
+
+  const { run } = await client.createRun(slug, {
+    name: runName,
+    totalTasks,
+    workerCount: workers,
+    participants: [participant],
+    config: { concurrency },
+  });
+
+  for (let i = 0; i < workers; i += 1) await client.planWorkers(slug, run.id, participant);
+
+  out.write(`${pc.cyan(pc.bold(' bench '))}${pc.dim(' run ')}${pc.cyan(run.id)} ${pc.dim('started. forking')} ${pc.cyan(`${workers}`)} ${pc.dim('worker(s).')}\n\n`);
+
+  // Phase 2: fork worker subprocesses that pull tasks from the platform.
+  const workerArgs = [
+    '--remote-worker',
+    '--file',
+    absoluteFile,
+    '--cwd',
+    cwd,
+  ];
+  const child = (env: Record<string, string>) =>
+    forkWorker(workerArgs, {
+      BENCH_CLI_REMOTE_SLUG: slug,
+      BENCH_CLI_REMOTE_RUN_ID: run.id,
+      BENCH_CLI_REMOTE_PARTICIPANT: participant,
+      BENCH_CLI_REMOTE_TOTAL: String(total),
+      BENCH_CLI_REMOTE_BENCH_COUNT: String(benchCount),
+      BENCH_CLI_REMOTE_CONCURRENCY: String(concurrency),
+      ...env,
+    });
+
+  // Use a single parent worker that loops, mirroring the per-task slot
+  // assignment of the platform API. Locally we still get N parallel
+  // processes; each one drains its claimed range before exiting.
+  const workers_ = Array.from({ length: workers }, (_, index) =>
+    child({
+      BENCH_CLI_REMOTE_WORKER_KEY: `bench-cli-${process.pid}-${index}`,
+    }),
+  );
+
+  // Phase 3: poll for progress and print a TUI until workers exit.
+  const finished = await waitForWorkers(workers_, {
+    onPoll: () => pollProgress(client, slug, run.id, out),
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs: (options.timeoutSeconds ?? 0) * 1000,
+  });
+
+  // Phase 4: print final summary.
+  const finalSummary = await fetchFinalSummary(client, slug, run.id);
+  printFinalSummary(out, slug, run.id, finalSummary, finished);
+  return {
+    benchmarkSlug: slug,
+    runId: run.id,
+    totalTasks,
+    workerCount: workers,
+    pass: finished.pass,
+    failed: finished.failed,
+  };
+}
+
+function forkWorker(args: readonly string[], env: Record<string, string>): Promise<{ exitCode: number; pass: number; failed: number }> {
+  return new Promise((resolve) => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const entry = path.join(here, '..', 'bin', 'bench-worker.js');
+    const child = fork(entry, [...args], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+    });
+    let reportedPass = 0;
+    let reportedFailed = 0;
+    child.on('message', (msg: unknown) => {
+      if (msg && typeof msg === 'object' && 'kind' in msg) {
+        const m = msg as { kind: string; pass?: number; failed?: number };
+        if (m.kind === 'progress' && typeof m.pass === 'number' && typeof m.failed === 'number') {
+          reportedPass = m.pass;
+          reportedFailed = m.failed;
+        }
+      }
+    });
+    child.on('exit', (code) => {
+      resolve({ exitCode: code ?? 0, pass: reportedPass, failed: reportedFailed });
+    });
+    child.on('error', () => {
+      resolve({ exitCode: 1, pass: reportedPass, failed: reportedFailed });
+    });
+  });
+}
+
+async function waitForWorkers(
+  workers: Array<Promise<{ exitCode: number; pass: number; failed: number }>>,
+  options: { onPoll?: () => Promise<void>; pollIntervalMs: number; timeoutMs: number },
+): Promise<{ pass: number; failed: number; exitCodes: number[] }> {
+  const start = Date.now();
+  let running = true;
+  const exitCodes: number[] = [];
+  let pass = 0;
+  let failed = 0;
+  const pollIntervalMs = options.pollIntervalMs;
+
+  const timeoutPromise = options.timeoutMs > 0
+    ? new Promise<void>((resolve) => setTimeout(resolve, options.timeoutMs).unref())
+    : new Promise<void>(() => {});
+
+  const pollPromise = (async () => {
+    while (running) {
+      try {
+        await options.onPoll?.();
+      } catch {
+        // Ignore poll errors; continue waiting.
+      }
+      await sleep(pollIntervalMs);
+    }
+  })();
+
+  const settled = await Promise.race([
+    Promise.all(workers.map(async (p) => {
+      const result = await p;
+      exitCodes.push(result.exitCode);
+      pass += result.pass;
+      failed += result.failed;
+    })).then(() => 'workers' as const),
+    timeoutPromise.then(() => 'timeout' as const),
+  ]);
+  running = false;
+  await pollPromise.catch(() => {});
+  void start;
+  void settled;
+  return { pass, failed, exitCodes };
+}
+
+async function pollProgress(client: BenchmarkClient, slug: string, runId: string, out: NodeJS.WritableStream): Promise<void> {
+  try {
+    const progress = await client.getRunProgress(slug, runId);
+    const summary = progress.summary;
+    const participants = progress.participants;
+    // Aggregate across participants; runs with one participant pick the
+    // only entry, runs with multiple sum the totals.
+    let totalWorkers = 0;
+    let readyWorkers = 0;
+    let totalTasks = 0;
+    let doneTasks = 0;
+    let errorTasks = 0;
+    for (const p of participants) {
+      totalWorkers += p.workers?.total ?? 0;
+      readyWorkers += (p.workers?.running ?? 0) + (p.workers?.completed ?? 0);
+      totalTasks += p.tasks?.total ?? 0;
+      doneTasks += p.tasks?.done ?? 0;
+      errorTasks += p.tasks?.errors ?? 0;
+    }
+    if (totalWorkers === 0) {
+      totalWorkers = summary.participants?.total ?? 0;
+    }
+    out.write(
+      `\r${pc.cyan(' progress ')}` +
+        pc.dim(' status=') + pc.cyan(summary.status ?? 'unknown') +
+        pc.dim(' workers=') + pc.cyan(`${readyWorkers}/${totalWorkers}`) +
+        pc.dim(' tasks=') + pc.cyan(`${doneTasks}/${totalTasks}`) +
+        pc.dim(' errors=') + pc.cyan(String(errorTasks)) +
+        '   ',
+    );
+  } catch {
+    // Polling errors are non-fatal during long-running runs.
+  }
+}
+
+async function fetchFinalSummary(client: BenchmarkClient, slug: string, runId: string): Promise<{ total: number; failed: number; pass: number }> {
+  try {
+    const tasks = await client.getRunTaskResults(slug, runId, { bucketSize: 50, failureLimit: 0 });
+    let pass = 0;
+    let failed = 0;
+    let total = 0;
+    for (const bucket of tasks.buckets ?? []) {
+      total += bucket.taskCount;
+      pass += bucket.successCount;
+      failed += bucket.errorCount;
+    }
+    return { total, pass, failed };
+  } catch {
+    return { total: 0, pass: 0, failed: 0 };
+  }
+}
+
+function printFinalSummary(
+  out: NodeJS.WritableStream,
+  slug: string,
+  runId: string,
+  summary: { total: number; failed: number; pass: number },
+  workers: { exitCodes: number[]; pass: number; failed: number },
+): void {
+  out.write('\n\n');
+  if (summary.failed === 0 && workers.exitCodes.every((c) => c === 0)) {
+    out.write(
+      pc.green(pc.bold(` ✓ remote run ${runId} (${slug}) completed: `)) +
+        pc.gray(`${summary.pass}/${summary.total} tasks passed across ${workers.exitCodes.length} worker(s).`),
+    );
+  } else {
+    out.write(
+      pc.red(pc.bold(` ✗ remote run ${runId} (${slug}) finished with errors: `)) +
+        pc.gray(`${summary.failed} failed, ${summary.pass} passed.`),
+    );
+    process.exitCode = 1;
+  }
+  out.write('\n');
+}
+
+function defaultSlug(absoluteFile: string): string {
+  const base = path.basename(absoluteFile).replace(/\.(bench|ts|js|mjs|cts|mts)$/i, '');
+  const safe = base.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return safe || 'bench-cli';
+}
+
+function defaultRunName(absoluteFile: string): string {
+  const base = path.basename(absoluteFile);
+  return `${base} @ ${new Date().toISOString()}`;
+}
+
+function defaultClientFactory(config: { apiKey?: string; baseUrl?: string }): BenchmarkClient {
+  return createBenchmarkClient({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Re-export so the worker process can use the polling helpers if needed.
+export { BenchmarkReporter };
+export type { BenchmarkEntry };

--- a/packages/bench-cli/src/types.ts
+++ b/packages/bench-cli/src/types.ts
@@ -93,3 +93,26 @@ export interface RunOptions {
   /** Bail on the first failing benchmark. */
   bail?: boolean;
 }
+
+export interface RemoteOptions {
+  /** Target benchmark slug on the platform. */
+  slug?: string;
+  /** Display name for the run. */
+  runName?: string;
+  /** Replications per registered benchmark function (default 100). */
+  total?: number;
+  /** Number of local worker processes to fork (default 1). */
+  workers?: number;
+  /** Per-worker parallel task slots (default 1). */
+  concurrency?: number;
+  /** Platform participant slug (default "bench-cli"). */
+  participant?: string;
+  /** Override the platform API key. */
+  apiKey?: string;
+  /** Override the platform base URL. */
+  baseUrl?: string;
+  /** How often the parent polls for progress (ms, default 1000). */
+  pollIntervalMs?: number;
+  /** Maximum wall-clock seconds before forcing shutdown (default 0 = no limit). */
+  timeoutSeconds?: number;
+}

--- a/packages/bench-cli/tsup.config.ts
+++ b/packages/bench-cli/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     'bin/bench': 'src/bin/bench.ts',
+    'bin/bench-worker': 'src/bin/bench-worker.ts',
   },
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Summary

Adds a `--remote` flag to `bench run <file>` so any benchmark file can be pushed to the ComputeSDK platform orchestrator instead of running locally. Builds on PR #636 (`@computesdk/bench-cli`).

```bash
bench run benchmarks/strings.bench.ts --remote \
  --slug strings --total 500 --workers 4 --concurrency 10
```

## How it works

`src/remote.ts` is the parent orchestrator:

1. Loads the bench file once via the existing `loadBenchFile` to count registered `bench()` calls (`B`).
2. Computes `totalTasks = B * --total`.
3. `BenchmarkClient.upsertBenchmark` / `createRun` / N x `planWorkers` against the platform.
4. Forks `--workers` Node subprocesses that boot the `bench-worker` entry.
5. Parent polls `getRunProgress` every `--poll-interval` ms for a TUI update (`status=… workers=… tasks=… errors=…`) and waits for all workers to exit.
6. Final summary printed from `getRunTaskResults` bucket counts (pass / failed / total).

`src/remote-worker.ts` is what runs inside each forked subprocess:

1. Reads its config from `BENCH_CLI_REMOTE_*` env vars populated by the parent.
2. Re-loads the bench file via `loadBenchFile`.
3. Calls `BenchmarkReporter.claim` to receive its `taskRange{ start, count }`.
4. For each `taskIndex` in the range, computes `benchIdx = floor(t / total)` / `repIdx = t % total`, runs warmup + clamped iterations of the bench fn, builds a `TaskResultRecord` with success/failed status, hz, meanMs, iterations, warmup. Sends results in batches via the reporter's built-in flush; calls `reporter.finish` on shutdown.

A separate `bench-worker` bin is exposed for forks to invoke directly when the package is installed via npm (`./dist/bin/bench-worker.js`). The `--remote-worker` flag and the `BENCH_CLI_REMOTE_RUN_ID` env var trigger worker mode inside the main binary so existing integrations work too.

## Flags

`--remote` `--slug` `--run-name` `--total` `--workers` `--concurrency` `--participant` `--api-key` `--base-url` `--poll-interval` `--timeout`. Everything below the existing CLI surface is opt-in, so plain `bench run file.ts` users see no behavior change. The CLI parser was already structured around a remote-vs-local dispatch point, so the additions are isolated to the parser plus the new files.

## Verification

- `pnpm --filter @computesdk/bench-cli run typecheck` clean
- `pnpm --filter @computesdk/bench-cli run lint` clean
- `pnpm --filter @computesdk/bench-cli run test` 19/19 passing across 6 suites, including three new tests:
  - `remote-cli.test.ts` exercises the parser surface (default `--flag`, `--flag=…`, mixed, error cases)
  - `remote-worker.test.ts` exercises env-var config parsing and required-var handling
  - `remote-orchestrator.test.ts` exercises the parent path with a fake `BenchmarkClient` to confirm planning + worker fork wiring without hitting the real platform
- `pnpm --filter @computesdk/bench-cli run build` produces `dist/bin/bench.js` (`35.96 KB`), `dist/bin/bench-worker.js` (`7.45 KB`), `dist/index.js` (`31.13 KB`)

## Open questions / v2

This PR is intentionally a v1 preview per the Slack thread. v2 should generalize the worker join logic so workers can live on remote hosts:

- SSH driver to ssh into boxes and exec `bench-worker` with the same env
- [Docker]/Kubernetes daemon-set path for large fan-out
- A real platform integration test gated on `COMPUTESDK_ADMIN_API_KEY` so the bench-integration CI can run `bench --remote` against staging

Things to also revisit after this lands:

- Whether `--total` is per-bench or per-run (currently per-bench; `B * total` tasks total)
- Whether the per-task iteration clamp (`Math.min(staticIterations, 100)`) is the right ceiling or should be smarter
- Whether to expose `--api-key` more loudly or keep it env-only for safety

## Notes

- The pre-existing untracked `.changeset/slow-sandboxes-vanish.md` from the previous branch was left untouched.
- New changeset `.changeset/bench-cli-remote.md` bumps `@computesdk/bench-cli` minor.
- Bases off `feat/bench-cli` (PR #636) because `--remote` is built on top of that package. Will rebase onto `main` once #636 lands.