### PR TITLE
docs: design doc for unified bench CLI + SDK

### DIFF
--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -156,12 +156,12 @@ The `--platform` mode uses two layers:
 
 1. **ComputeSDK platform** (`platform.computesdk.com`) — benchmark coordination: create runs, plan workers, task claiming, result aggregation, progress tracking, historical runs. This is the existing API (`BenchmarkClient`, `BenchmarkReporter`).
 
-2. **Namespace** (`namespaceapis.com`) — compute infrastructure: build images, launch worker VMs, stream logs, collect metrics, destroy VMs. The platform (not the CLI) talks to Namespace. Three services:
+2. **Namespace** (first ComputeSDK provider for benchmarks) — compute infrastructure: build images, launch worker VMs, stream logs, collect metrics, destroy VMs. The platform (not the CLI) talks to Namespace through ComputeSDK's provider abstraction. Other providers (E2B, Modal, etc.) can be added by implementing the provider interface.
    - `ImageService` — build Docker images from blueprints ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.image.v1beta))
    - `ComputeService` — create/monitor/destroy micro-VM instances with containers ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.compute.v1beta))
    - `ObservabilityService` — stream/fetch instance logs
 
-This is a clean separation: Namespace = compute, ComputeSDK platform = orchestration + coordination. The CLI only talks to the platform.
+This is a clean separation: ComputeSDK providers = compute, ComputeSDK platform = orchestration + coordination. The CLI only talks to the platform. The platform uses ComputeSDK's provider abstraction, making it multi-provider — Namespace is the first implementation.
 
 ComputeSDK itself is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark runner is a separate system that uses Namespace for its compute — it does not use ComputeSDK sandboxes.
 
@@ -172,21 +172,22 @@ The scale test infrastructure in `computesdk/benchmarks/src/scale` is the protot
 The CLI talks only to the ComputeSDK platform. The platform handles all Namespace interaction internally. Users never need Namespace credentials.
 
 ```
-CLI -----> ComputeSDK Platform -----> Namespace
-           (benchmark runner)         (compute)
+CLI -----> ComputeSDK Platform -----> ComputeSDK Providers
+           (benchmark runner)         (Namespace, E2B, Modal, ...)
               |                           |
               |  POST /runs (files)       |
               |  -> build image           |
-              |     via Namespace         |
-              |     ImageService          |
+              |     via provider          |
+              |     image.build()         |
               |  -> launch workers        |
-              |     via Namespace         |
-              |     ComputeService        |
+              |     via provider          |
+              |     sandbox.create()      |
               |  -> workers claim tasks   |
               |     and report results    |
               |     back to platform      |
               |  -> destroy VMs           |
-              |     via Namespace         |
+              |     via provider          |
+              |     sandbox.destroy()     |
               |                           |
               |  GET /runs/:id            |
               |  <- status + progress     |
@@ -194,7 +195,53 @@ CLI -----> ComputeSDK Platform -----> Namespace
               |  <- aggregated results    |
 ```
 
+The platform uses ComputeSDK's provider abstraction for compute, making it multi-provider from the start. Namespace is the first provider implementation; E2B, Modal, and others can be added by implementing the provider interface.
+
 The platform productizes what `start.ts` does today: build images, launch VMs, coordinate workers, aggregate results, clean up. The CLI is a thin client with three API calls.
+
+### Multi-provider: platform uses ComputeSDK for compute
+
+The platform needs two compute operations:
+
+1. **Image build** — build a Docker image from a Dockerfile or source files
+2. **Image run** — launch a VM/container from an image, run a command, collect output
+
+These are not unique to Namespace. Every compute provider can do them:
+- Namespace: `ImageService.Build` + `ComputeService.CreateInstance`
+- E2B: sandbox from image + run commands
+- Modal: image build + container run
+- AWS/GCP/Azure: container build services + VM/container run
+- Local Docker: `docker build` + `docker run`
+
+If the platform uses ComputeSDK's provider abstraction, it becomes multi-provider from day one. Namespace is the first implementation; adding another provider means implementing the interface, not writing platform-specific code. This is also the right way to dogfood ComputeSDK — the benchmark platform is a ComputeSDK application.
+
+This requires extending the ComputeSDK provider interface with image build:
+
+```ts
+interface Provider {
+  // Existing
+  sandbox: {
+    create(options: { image: string; env?: Record<string, string>; ... }): Promise<Sandbox>;
+    // sandbox.runCommand() and sandbox.destroy() already exist
+  };
+
+  // New: image build capability
+  image?: {
+    build(options: {
+      dockerfile?: string;        // Dockerfile content
+      context?: Uint8Array;       // build context (tarball or zip)
+      aptPackages?: string[];     // alternative: APT-based build (no Dockerfile)
+      tag?: string;               // optional name/tag for the image
+    }): Promise<{
+      imageRef: string;           // reference to use in sandbox.create()
+    }>;
+  };
+}
+```
+
+`sandbox.create()` already covers "image run" — it launches a sandbox from an image reference. The missing piece is `image.build()`.
+
+Not every provider will support `image.build()` initially. The platform can fall back to requiring a pre-built image (`--image` mode) for providers that don't support building. This is a graceful degradation: `bench --platform` (build from files) works with providers that support `image.build()`; `bench --platform --image <ref>` works with any provider.
 
 ### Platform API shape (minimal)
 
@@ -203,7 +250,7 @@ The platform needs just three new endpoints (or extensions to existing ones):
 1. `POST /benchmarks/:slug/runs` — create a run. Request body includes:
    - Bench files (multipart upload or zip) — or `image` field for pre-built image mode
    - Config: `total`, `workers`, `concurrency`, `participant`, env vars/secrets
-   - Platform handles: build image via Namespace (if files provided), launch worker VMs via Namespace ComputeService, workers claim and execute tasks
+   - Platform handles: build image via ComputeSDK provider (if files provided), launch worker sandboxes via provider, workers claim and execute tasks
    - Returns: `{ runId, status: "building" | "running" }`
 
 2. `GET /runs/:id` — get run state. Returns:
@@ -572,10 +619,10 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 ### Phase 4: Add `--platform --image` mode to the CLI (pre-built image)
 
 - CLI accepts `--image <image>` pointing to a pre-built Docker image
-- CLI creates benchmark run on the platform, plans workers
-- Platform launches worker VMs from the image via Namespace
-- Worker VMs call `runBenchWorker()` with the loaded entries
-- CLI polls progress, prints TUI
+- CLI calls `POST /runs` on the platform with the image ref + config
+- Platform launches worker sandboxes from the image via ComputeSDK provider (Namespace first)
+- Worker sandboxes call `runBenchWorker()` with the loaded entries
+- CLI polls `GET /runs/:id`, prints TUI
 - This replaces `start.ts` from `benchmarks/src/scale` — zero new infrastructure
 
 ### Phase 5: Migrate scale tests to the CLI
@@ -584,23 +631,32 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Replace `start.ts` with `bench --platform --image`
 - The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
 
-### Phase 6: Add Namespace ImageService integration (CLI-built images)
+### Phase 6: Add `image.build()` to ComputeSDK provider interface
 
-- CLI integrates with Namespace `ImageService` API (`CreateBlueprint`, `Build`, `FetchBlueprint`)
-- `bench --platform` (without `--image`) generates a Dockerfile, ships bench files, builds via Namespace
-- Blueprint caching: hash Dockerfile + bench file contents, skip rebuild if cached and `STATE_READY`
-- Also support `AptBasedImage` spec for lightweight images (Node.js + APT packages, no Dockerfile needed)
-- No local Docker required — Namespace builds on its infrastructure
-- No new ComputeSDK platform endpoints needed — build happens through Namespace API directly
+- Extend the ComputeSDK `Provider` interface with `image.build()` (build from Dockerfile or APT packages)
+- Implement `image.build()` for the Namespace provider (wraps `ImageService.CreateBlueprint` + `Build`)
+- Other providers can implement `image.build()` later (E2B, Modal, etc.)
+- Providers that don't support `image.build()` fall back to `--image` mode (pre-built image)
+
+### Phase 7: Add `--platform` (build from files) to the CLI
+
+- `bench --platform` (without `--image`) ships bench files to the platform
+- Platform calls `provider.image.build()` to build the image
+- Platform launches worker sandboxes from the built image
+- Blueprint/image caching: hash Dockerfile + bench file contents, skip rebuild if cached
+- No local Docker required — the provider builds on its infrastructure
+- Multi-provider: works with any ComputeSDK provider that implements `image.build()`
 
 ## Open Questions
 
-1. **Build context upload.** Namespace's `BlueprintSpec.Dockerfile` takes the Dockerfile content as a string, but the build context (bench files, `package.json`, etc.) needs to reach the builder. How does Namespace handle build context? Options: git-connected blueprint, artifact upload via a separate API, or the Dockerfile pulls files from a URL. Need to check Namespace's full API surface for build context handling.
+1. **ComputeSDK provider interface for image build.** The current `Provider` interface has `sandbox.create()` (image run) but no `image.build()`. What should the `image.build()` signature look like? Should it support Dockerfile content, build context (tarball/zip), APT packages, or all of the above? How does build context reach the provider's builder (upload, git URL, inline)?
 
-2. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker VM. How do secrets flow from the user's environment to the platform to the worker VM? The existing flow uses env vars set in the Docker image or VM startup script. The CLI needs a `--env` or `--secret` flag. Secrets should not be baked into the Dockerfile/blueprint — they should be injected at VM launch time.
+2. **Provider capability detection.** Not all providers will support `image.build()`. Should the CLI/platform detect this at runtime and fall back to `--image` mode? Or should the API advertise capabilities per provider?
 
-3. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
+3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker sandbox. How do secrets flow from the user's environment to the platform to the worker sandbox? Secrets should not be baked into the image — they should be injected at sandbox launch time via env vars. The CLI needs a `--env` or `--secret` flag.
 
-4. **Step readiness barriers.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Should the CLI expose this as a `defineStep` option, or should it be implicit? The current SDK already supports `readiness: 'poll'` on `DefineStepOptions`.
+4. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
 
-5. **Blueprint lifecycle.** Should the CLI create a new blueprint per run, or should it manage blueprints as long-lived objects (create once, rebuild when files change)? The caching strategy in the doc assumes long-lived blueprints keyed by content hash, but this needs a cleanup/retention policy.
+5. **Step readiness barriers.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Should the CLI expose this as a `defineStep` option, or should it be implicit? The current SDK already supports `readiness: 'poll'` on `DefineStepOptions`.
+
+6. **Image lifecycle.** Should the platform cache built images across runs (content-addressed by file hash)? What is the retention/cleanup policy? This applies to both Namespace blueprints and any provider's image build output.

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -136,23 +136,19 @@ bench --platform --image my-image --total 500 --workers 4 --concurrency 10
 
 Renamed from `--remote` to `--platform` to accurately describe what it does: ship benchmarks to the first-party benchmark runner platform for execution.
 
-The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive work, run workers, aggregate, report. It has its own compute infrastructure (VMs/containers) for running benchmarks. It is not a ComputeSDK sandbox — ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark platform is a separate product with its own compute capacity, purpose-built for running `*.bench.ts` workloads.
+The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive work, build, run workers, aggregate, report. It uses Namespace for compute (image building, VM launch, logs) but the CLI never talks to Namespace directly — everything routes through the platform. Users only need ComputeSDK platform credentials.
 
-The initial release uses the Docker image path (the same pattern as `benchmarks/src/scale`): the user builds a Docker image containing the bench files + deps, the platform launches worker VMs from that image via Namespace ComputeService, each VM runs a coordinator that claims work and executes entries. A future release will add ship-files capability so users can skip the Docker build step.
+The initial release uses the Docker image path (the same pattern as `benchmarks/src/scale`): the user provides a pre-built image (or the platform builds one from files), the platform launches worker VMs via Namespace, each VM runs a coordinator that claims work and executes entries.
 
-1. CLI discovers and loads bench files (same as local) — or the Docker image contains them.
-2. CLI creates a benchmark run on the ComputeSDK platform, plans workers.
-3. CLI launches worker VMs via Namespace `ComputeService.CreateInstance` — one instance per worker, each running a container from the image with env vars for the ComputeSDK platform connection (slug, run ID, participant, API key).
-4. Each worker VM loads the bench files, claims a task range from the ComputeSDK platform, and executes entries through the SDK's `runWorker()`:
-   - Real concurrency via `mapPool(taskIndices, concurrency, ...)`
-   - Automatic heartbeats to the ComputeSDK platform
-   - Batched result flushing to the ComputeSDK platform
-   - Step-level concurrency barriers (`waitForStepReady`)
-5. CLI polls ComputeSDK platform for progress (`getRunProgress`), streams worker logs via Namespace `ObservabilityService.StreamInstanceLogs`, prints TUI.
-6. When all workers finish, CLI destroys instances via Namespace `ComputeService.DestroyInstance`.
-7. CLI fetches final results from ComputeSDK platform, prints summary.
+1. CLI discovers and loads bench files (same as local) — or uses a pre-built `--image`.
+2. CLI calls `POST /runs` on the ComputeSDK platform with bench files (or image ref) + config.
+3. Platform builds the image via Namespace `ImageService` (if files were provided, not a pre-built image).
+4. Platform launches worker VMs via Namespace `ComputeService.CreateInstance` — one instance per worker, each running a container from the image with env vars for platform connection.
+5. Each worker VM claims a task range from the platform, executes entries through the SDK's `runWorker()` (real concurrency, heartbeats, batched flushing, step barriers), and reports results back to the platform.
+6. CLI polls `GET /runs/:id` — platform returns `phase` (building -> running -> completed) and progress.
+7. When complete, CLI calls `GET /runs/:id/results` for aggregated results and prints summary.
 
-The key change: the CLI does NOT fork local processes. The platform runs workers on its own compute. The SDK's `runWorker()` is the single execution path for remote work. The CLI replaces `start.ts` from the scale test repo.
+The CLI does three API calls. The platform handles all Namespace interaction (build, launch, monitor, destroy). Users only need ComputeSDK platform credentials.
 
 ### The first-party benchmark runner platform
 
@@ -160,12 +156,12 @@ The `--platform` mode uses two layers:
 
 1. **ComputeSDK platform** (`platform.computesdk.com`) — benchmark coordination: create runs, plan workers, task claiming, result aggregation, progress tracking, historical runs. This is the existing API (`BenchmarkClient`, `BenchmarkReporter`).
 
-2. **Namespace** (`namespaceapis.com`) — compute infrastructure: build images, launch worker VMs, stream logs, collect metrics, destroy VMs. Namespace provides three services the CLI uses:
+2. **Namespace** (`namespaceapis.com`) — compute infrastructure: build images, launch worker VMs, stream logs, collect metrics, destroy VMs. The platform (not the CLI) talks to Namespace. Three services:
    - `ImageService` — build Docker images from blueprints ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.image.v1beta))
    - `ComputeService` — create/monitor/destroy micro-VM instances with containers ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.compute.v1beta))
    - `ObservabilityService` — stream/fetch instance logs
 
-This is a clean separation: Namespace = compute, ComputeSDK platform = coordination. The CLI is the orchestrator that talks to both.
+This is a clean separation: Namespace = compute, ComputeSDK platform = orchestration + coordination. The CLI only talks to the platform.
 
 ComputeSDK itself is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark runner is a separate system that uses Namespace for its compute — it does not use ComputeSDK sandboxes.
 
@@ -173,26 +169,62 @@ The scale test infrastructure in `computesdk/benchmarks/src/scale` is the protot
 
 ### Architecture
 
+The CLI talks only to the ComputeSDK platform. The platform handles all Namespace interaction internally. Users never need Namespace credentials.
+
 ```
-                    CLI (bench --platform)
-                   /                      \
-          ComputeSDK Platform             Namespace
-     (coordination layer)             (compute layer)
-          /          \                /           \
-   create run    aggregate       ImageService    ComputeService
-   plan workers  results         (build image)   (launch VMs)
-   poll progress historical      StorageService   ObservabilityService
-                 runs             (cache volumes)  (stream logs)
-                      \              /
-                       \            /
-                   Worker VM (Namespace instance)
-                   - runs bench-worker container
-                   - claims tasks from ComputeSDK platform
-                   - executes entries via runBenchWorker()
-                   - reports results to ComputeSDK platform
+CLI -----> ComputeSDK Platform -----> Namespace
+           (benchmark runner)         (compute)
+              |                           |
+              |  POST /runs (files)       |
+              |  -> build image           |
+              |     via Namespace         |
+              |     ImageService          |
+              |  -> launch workers        |
+              |     via Namespace         |
+              |     ComputeService        |
+              |  -> workers claim tasks   |
+              |     and report results    |
+              |     back to platform      |
+              |  -> destroy VMs           |
+              |     via Namespace         |
+              |                           |
+              |  GET /runs/:id            |
+              |  <- status + progress     |
+              |  GET /runs/:id/results    |
+              |  <- aggregated results    |
 ```
 
-The worker VM is the bridge between the two layers: it runs on Namespace compute but talks to the ComputeSDK platform API for task claiming and result reporting. This is exactly what the scale test coordinator does today — it runs in a Namespace VM and calls `createBenchmarkClient()` + `runBenchmarkWorker()` to claim and report work.
+The platform productizes what `start.ts` does today: build images, launch VMs, coordinate workers, aggregate results, clean up. The CLI is a thin client with three API calls.
+
+### Platform API shape (minimal)
+
+The platform needs just three new endpoints (or extensions to existing ones):
+
+1. `POST /benchmarks/:slug/runs` — create a run. Request body includes:
+   - Bench files (multipart upload or zip) — or `image` field for pre-built image mode
+   - Config: `total`, `workers`, `concurrency`, `participant`, env vars/secrets
+   - Platform handles: build image via Namespace (if files provided), launch worker VMs via Namespace ComputeService, workers claim and execute tasks
+   - Returns: `{ runId, status: "building" | "running" }`
+
+2. `GET /runs/:id` — get run state. Returns:
+   - `phase`: `"building" | "running" | "completed" | "failed"`
+   - `progress`: task counts (done, total, errors) — already exists as `getRunProgress`
+   - `workers`: VM status per worker
+   - This is an extension of the existing `getRun` / `getRunProgress` endpoints, adding `phase` and `buildStatus`
+
+3. `GET /runs/:id/results` — get aggregated results. Already exists as `getRunResults` / `getRunTaskResults`.
+
+Optional:
+4. `POST /runs/:id/stop` — stop the run early (destroy worker VMs, mark run as failed). Already exists as `updateRun` with `status: "failed"`.
+
+That is the entire API surface. The CLI does:
+```
+POST /runs (with files or image)
+poll GET /runs/:id until phase=completed
+GET /runs/:id/results
+```
+
+Three calls. Everything else is the platform's job.
 
 ## Remote Execution: Ship Files vs Docker Image
 
@@ -243,52 +275,47 @@ CLI packages bench files, generates a default Dockerfile (or uses a user-provide
 
 For benchmarks that just need Node.js + a few system packages, the CLI can use Namespace's `AptBasedImage` spec instead of a full Dockerfile. This is faster to build and simpler to configure.
 
-### Build flow (Mode 2: CLI builds via Namespace)
+### Build flow (all routed through the platform)
 
 ```
-CLI                Namespace ImageService        Namespace ComputeService      ComputeSDK Platform
- |                         |                            |                            |
- |  CreateBlueprint(spec)  |                            |                            |
- |  Build(blueprint)       |                            |                            |
- |                         |  async build               |                            |
- |  FetchBlueprint()       |                            |                            |
- |  <--- STATE_READY ------+                            |                            |
- |  (got image_ref)        |                            |                            |
- |                         |                            |                            |
- |  (create run, plan workers) ------------------------>|                            |
- |                         |                            |  POST /benchmarks/:slug    |
- |                         |                            |  POST /runs                |
- |                         |                            |  POST /planWorkers         |
- |                         |                            |                            |
- |  CreateInstance(image_ref, env: {SLUG, RUN_ID, ...}) |                            |
- |                         |                            |  launch worker VMs         |
- |                         |                            |    from image_ref          |
- |                         |                            |                            |
- |                         |                            |  each worker VM:           |
- |                         |                            |    claimWorker() --------->|
- |                         |                            |    runBenchWorker()        |
- |                         |                            |    sendTaskResults() ----->|
- |                         |                            |    completeWorker() ------>|
- |                         |                            |                            |
- |  StreamInstanceLogs()   |                            |                            |
- |  <--- live logs --------+----------------------------+                            |
- |                         |                            |                            |
- |  getRunProgress() ----------------------------------------------------------------->|
- |  <--- progress updates -------------------------------------------------------------|
- |                         |                            |                            |
- |  DestroyInstance()      |                            |                            |
- |                         |                            |  destroy worker VMs        |
- |                         |                            |                            |
- |  getRunResults() ------------------------------------------------------------------>|
- |  <--- final summary ----------------------------------------------------------------|
+CLI                      ComputeSDK Platform                    Namespace
+ |                            |                                    |
+ |  POST /runs (files)        |                                    |
+ |  ------------------------->|                                    |
+ |                            |  CreateBlueprint + Build           |
+ |                            |  --------------------------------->|
+ |                            |  FetchBlueprint (poll)             |
+ |                            |  <--- STATE_READY + image_ref -----|
+ |                            |                                    |
+ |                            |  CreateInstance (per worker)       |
+ |                            |  --------------------------------->|
+ |                            |  <--- instances launched ----------|
+ |                            |                                    |
+ |                            |  (workers claim tasks from        |
+ |                            |   platform, execute, report)      |
+ |                            |                                    |
+ |  GET /runs/:id             |                                    |
+ |  <--- phase=building ------|                                    |
+ |  GET /runs/:id             |                                    |
+ |  <--- phase=running --------|                                    |
+ |  GET /runs/:id             |                                    |
+ |  <--- phase=completed ------|                                    |
+ |                            |                                    |
+ |  GET /runs/:id/results     |                                    |
+ |  <--- aggregated results --|                                    |
+ |                            |  DestroyInstance (cleanup)         |
+ |                            |  --------------------------------->|
 ```
 
-No `POST /runs/:id/build` endpoint needed on the ComputeSDK platform. The CLI orchestrates directly:
-- Namespace ImageService for building
-- Namespace ComputeService for launching/monitoring/destroying worker VMs
-- ComputeSDK platform for benchmark coordination (runs, task claims, results)
+The CLI never talks to Namespace. The platform is the sole orchestrator:
+- Receives files from CLI
+- Builds image via Namespace ImageService
+- Launches worker VMs via Namespace ComputeService
+- Workers claim tasks from the platform and report results back
+- Platform destroys VMs via Namespace ComputeService when done
+- Platform returns aggregated results to CLI
 
-The worker VM is the bridge: it runs on Namespace but talks to the ComputeSDK platform for task claiming and result reporting. This is the same pattern as `benchmarks/src/scale/sdk-coordinator.ts` — it runs in a Namespace VM and calls `createBenchmarkClient()` + `runBenchmarkWorker()`.
+The platform productizes `start.ts` from `benchmarks/src/scale`. The same logic (create run, build image, launch VMs, coordinate, aggregate, destroy) becomes a hosted service instead of a script.
 
 ### Blueprint caching strategy
 

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -136,160 +136,122 @@ bench --platform --image my-image --total 500 --workers 4 --concurrency 10
 
 Renamed from `--remote` to `--platform` to accurately describe what it does: ship benchmarks to the first-party benchmark runner platform for execution.
 
-The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive work, build, run workers, aggregate, report. It uses Namespace for compute (image building, VM launch, logs) but the CLI never talks to Namespace directly — everything routes through the platform. Users only need ComputeSDK platform credentials.
-
-The initial release uses the Docker image path (the same pattern as `benchmarks/src/scale`): the user provides a pre-built image (or the platform builds one from files), the platform launches worker VMs via Namespace, each VM runs a coordinator that claims work and executes entries.
+The CLI uses ComputeSDK providers directly for execution. The platform is optional (historical storage only).
 
 1. CLI discovers and loads bench files (same as local) — or uses a pre-built `--image`.
-2. CLI calls `POST /runs` on the ComputeSDK platform with bench files (or image ref) + config.
-3. Platform builds the image via Namespace `ImageService` (if files were provided, not a pre-built image).
-4. Platform launches worker VMs via Namespace `ComputeService.CreateInstance` — one instance per worker, each running a container from the image with env vars for platform connection.
-5. Each worker VM claims a task range from the platform, executes entries through the SDK's `runWorker()` (real concurrency, heartbeats, batched flushing, step barriers), and reports results back to the platform.
-6. CLI polls `GET /runs/:id` — platform returns `phase` (building -> running -> completed) and progress.
-7. When complete, CLI calls `GET /runs/:id/results` for aggregated results and prints summary.
+2. CLI builds image via `provider.image.build()` (if files provided, not `--image`).
+3. CLI divides tasks among N workers (static range assignment).
+4. CLI launches N worker sandboxes via `provider.sandbox.create()`, each with env vars for its task range.
+5. Each worker loads bench files, executes its task range through `runBenchWorker()` (real concurrency, step barriers), and streams results back to the CLI.
+6. CLI collects results, aggregates, prints TUI/JSON.
+7. CLI destroys sandboxes via `provider.sandbox.destroy()`.
+8. (Optional) CLI pushes results to the platform for historical storage.
 
-The CLI does three API calls. The platform handles all Namespace interaction (build, launch, monitor, destroy). Users only need ComputeSDK platform credentials.
+### The first-party benchmark runner platform (optional)
 
-### The first-party benchmark runner platform
+The `--platform` mode uses ComputeSDK providers directly for execution. The ComputeSDK platform (`platform.computesdk.com`) is optional — it provides historical storage and a web UI, but is not required for running benchmarks.
 
-The `--platform` mode uses two layers:
+1. **ComputeSDK providers** (Namespace, E2B, Modal, etc.) — compute: build images, launch worker sandboxes, stream logs, destroy. The CLI talks to providers directly through ComputeSDK's provider abstraction.
 
-1. **ComputeSDK platform** (`platform.computesdk.com`) — benchmark coordination: create runs, plan workers, task claiming, result aggregation, progress tracking, historical runs. This is the existing API (`BenchmarkClient`, `BenchmarkReporter`).
+2. **ComputeSDK platform** (optional) — historical run storage, result aggregation across runs, web UI, trend tracking. The CLI can optionally push results here after a run completes.
 
-2. **Namespace** (first ComputeSDK provider for benchmarks) — compute infrastructure: build images, launch worker VMs, stream logs, collect metrics, destroy VMs. The platform (not the CLI) talks to Namespace through ComputeSDK's provider abstraction. Other providers (E2B, Modal, etc.) can be added by implementing the provider interface.
-   - `ImageService` — build Docker images from blueprints ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.image.v1beta))
-   - `ComputeService` — create/monitor/destroy micro-VM instances with containers ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.compute.v1beta))
-   - `ObservabilityService` — stream/fetch instance logs
+This means:
+- `bench --platform` works without any platform API — just a ComputeSDK provider
+- `bench --platform --store` (optional) pushes results to the platform for history
+- The platform does not need to know about image building, VM launch, or worker coordination
 
-This is a clean separation: ComputeSDK providers = compute, ComputeSDK platform = orchestration + coordination. The CLI only talks to the platform. The platform uses ComputeSDK's provider abstraction, making it multi-provider — Namespace is the first implementation.
+### Architecture: CLI orchestrates directly via ComputeSDK providers
 
-ComputeSDK itself is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark runner is a separate system that uses Namespace for its compute — it does not use ComputeSDK sandboxes.
-
-The scale test infrastructure in `computesdk/benchmarks/src/scale` is the prototype: `start.ts` creates runs, launches Namespace VMs, and each VM runs a coordinator that claims work. The CLI replaces `start.ts` — it creates the run on the ComputeSDK platform, builds the image via Namespace ImageService, launches worker VMs via Namespace ComputeService, and polls the ComputeSDK platform for progress.
-
-### Architecture
-
-The CLI talks only to the ComputeSDK platform. The platform handles all Namespace interaction internally. Users never need Namespace credentials.
+If the CLI uses ComputeSDK's provider abstraction directly, the platform is not needed in the execution path. The CLI is the orchestrator. This eliminates an entire layer of complexity.
 
 ```
-CLI -----> ComputeSDK Platform -----> ComputeSDK Providers
-           (benchmark runner)         (Namespace, E2B, Modal, ...)
-              |                           |
-              |  POST /runs (files)       |
-              |  -> build image           |
-              |     via provider          |
-              |     image.build()         |
-              |  -> launch workers        |
-              |     via provider          |
-              |     sandbox.create()      |
-              |  -> workers claim tasks   |
-              |     and report results    |
-              |     back to platform      |
-              |  -> destroy VMs           |
-              |     via provider          |
-              |     sandbox.destroy()     |
-              |                           |
-              |  GET /runs/:id            |
-              |  <- status + progress     |
-              |  GET /runs/:id/results    |
-              |  <- aggregated results    |
+CLI -----> ComputeSDK Providers (Namespace, E2B, Modal, ...)
+  |
+  |  provider.image.build()    -> build Docker image
+  |  provider.sandbox.create() -> launch N worker sandboxes
+  |  (each worker gets a task range via env vars)
+  |
+  |  workers execute, stream results back to CLI
+  |  provider.sandbox.destroy() -> clean up
+  |
+  |  CLI aggregates results, prints TUI/JSON
+  |
+  v
+ (optional) ComputeSDK Platform
+   -> store results for historical comparison
+   -> web UI for viewing runs
+   -> NOT required for execution
 ```
 
-The platform uses ComputeSDK's provider abstraction for compute, making it multi-provider from the start. Namespace is the first provider implementation; E2B, Modal, and others can be added by implementing the provider interface.
+The CLI does everything `start.ts` does today, but as a CLI using ComputeSDK providers:
+1. Load bench files, compute entry count and total tasks
+2. Divide tasks among N workers (static assignment — each worker gets a range)
+3. Build image via `provider.image.build()` (if files provided, not `--image`)
+4. Launch N worker sandboxes via `provider.sandbox.create()`, each with env vars for its task range
+5. Workers execute their range, stream results back (stdout/IPC)
+6. CLI collects, aggregates, prints
+7. CLI destroys sandboxes via `provider.sandbox.destroy()`
 
-The platform productizes what `start.ts` does today: build images, launch VMs, coordinate workers, aggregate results, clean up. The CLI is a thin client with three API calls.
+No platform API calls for execution. The platform is optional — only for storing results if you want historical comparisons or a web UI.
 
-### Multi-provider: platform uses ComputeSDK for compute
+### What the platform is still good for (optional)
 
-The platform needs two compute operations:
+- Historical run storage (past results, trend tracking, regression detection)
+- Web UI for viewing runs across a team
+- Cross-run comparisons and analytics
+- Long-running scale tests where the CLI might crash (platform holds the state)
 
-1. **Image build** — build a Docker image from a Dockerfile or source files
-2. **Image run** — launch a VM/container from an image, run a command, collect output
+For CI and local use, the CLI-only path is sufficient. The platform is an opt-in storage layer, not a required execution layer.
 
-These are not unique to Namespace. Every compute provider can do them:
-- Namespace: `ImageService.Build` + `ComputeService.CreateInstance`
-- E2B: sandbox from image + run commands
-- Modal: image build + container run
-- AWS/GCP/Azure: container build services + VM/container run
-- Local Docker: `docker build` + `docker run`
+### Worker coordination without the platform
 
-If the platform uses ComputeSDK's provider abstraction, it becomes multi-provider from day one. Namespace is the first implementation; adding another provider means implementing the interface, not writing platform-specific code. This is also the right way to dogfood ComputeSDK — the benchmark platform is a ComputeSDK application.
+Currently, the SDK's `runWorker()` claims tasks from the platform API. Without the platform, the CLI assigns task ranges directly:
 
-This requires extending the ComputeSDK provider interface with image build:
+- CLI computes `totalTasks = entryCount * total`
+- CLI divides `totalTasks` among N workers: worker 0 gets tasks 0..K-1, worker 1 gets K..2K-1, etc.
+- Each worker receives its range via env vars (`BENCH_TASK_START`, `BENCH_TASK_COUNT`)
+- Workers execute their range and stream results back to the CLI
 
-```ts
-interface Provider {
-  // Existing
-  sandbox: {
-    create(options: { image: string; env?: Record<string, string>; ... }): Promise<Sandbox>;
-    // sandbox.runCommand() and sandbox.destroy() already exist
-  };
+This is simpler than dynamic claiming (no claim/release lifecycle, no platform round-trips). The tradeoff is no dynamic rebalancing — if one worker is slow, others can't steal its work. For benchmark workloads (uniform per-task cost), this is fine. For scale tests with variable per-task latency, dynamic claiming via the platform may still be valuable.
 
-  // New: image build capability
-  image?: {
-    build(options: {
-      dockerfile?: string;        // Dockerfile content
-      context?: Uint8Array;       // build context (tarball or zip)
-      aptPackages?: string[];     // alternative: APT-based build (no Dockerfile)
-      tag?: string;               // optional name/tag for the image
-    }): Promise<{
-      imageRef: string;           // reference to use in sandbox.create()
-    }>;
-  };
-}
-```
+Step readiness barriers (`waitForStepReady`) need rethinking without the platform. Options:
+- CLI-orchestrated barriers: CLI waits for all workers to report step completion before signaling them to proceed
+- Provider-level coordination: use provider networking (e.g., shared volumes, message queues) for barriers
+- Platform-assisted barriers: use the platform only for barrier coordination, not for task claiming
 
-`sandbox.create()` already covers "image run" — it launches a sandbox from an image reference. The missing piece is `image.build()`.
+This is an open question — see Open Questions below.
 
-Not every provider will support `image.build()` initially. The platform can fall back to requiring a pre-built image (`--image` mode) for providers that don't support building. This is a graceful degradation: `bench --platform` (build from files) works with providers that support `image.build()`; `bench --platform --image <ref>` works with any provider.
+### Platform API shape (optional, for storage only)
 
-### Platform API shape (minimal)
+If the platform is used for historical storage, it just needs:
 
-The platform needs just three new endpoints (or extensions to existing ones):
+1. `POST /runs/:id/results` — store results from a completed run (CLI pushes after aggregation)
+2. `GET /runs` — list past runs
+3. `GET /runs/:id/results` — fetch past results for comparison
 
-1. `POST /benchmarks/:slug/runs` — create a run. Request body includes:
-   - Bench files (multipart upload or zip) — or `image` field for pre-built image mode
-   - Config: `total`, `workers`, `concurrency`, `participant`, env vars/secrets
-   - Platform handles: build image via ComputeSDK provider (if files provided), launch worker sandboxes via provider, workers claim and execute tasks
-   - Returns: `{ runId, status: "building" | "running" }`
-
-2. `GET /runs/:id` — get run state. Returns:
-   - `phase`: `"building" | "running" | "completed" | "failed"`
-   - `progress`: task counts (done, total, errors) — already exists as `getRunProgress`
-   - `workers`: VM status per worker
-   - This is an extension of the existing `getRun` / `getRunProgress` endpoints, adding `phase` and `buildStatus`
-
-3. `GET /runs/:id/results` — get aggregated results. Already exists as `getRunResults` / `getRunTaskResults`.
-
-Optional:
-4. `POST /runs/:id/stop` — stop the run early (destroy worker VMs, mark run as failed). Already exists as `updateRun` with `status: "failed"`.
-
-That is the entire API surface. The CLI does:
-```
-POST /runs (with files or image)
-poll GET /runs/:id until phase=completed
-GET /runs/:id/results
-```
-
-Three calls. Everything else is the platform's job.
+The platform does NOT need endpoints for building, launching, or coordinating workers. Those happen in the CLI via ComputeSDK providers.
 
 ## Remote Execution: Ship Files vs Docker Image
 
-### The question
+### Two modes, both via ComputeSDK providers
 
-Should `--platform` build a Docker image locally and push it, or should it ship source files to the platform and let the platform build and run them?
+**Mode 1: Pre-built image**
 
-### Recommendation: unified approach using Namespace ImageService
+```
+bench --platform --image my-registry/bench:latest --provider namespace
+```
 
-Namespace provides an `ImageService` API ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.image.v1beta)) that builds Docker images asynchronously from a blueprint spec. This bridges the gap between ship-files and Docker images — the CLI can ship a Dockerfile + bench files to Namespace, Namespace builds the image, and the CLI gets back an `image_ref` to launch workers. No local Docker required.
+CLI launches worker sandboxes directly from the image via `provider.sandbox.create()`. Works with any provider. User (or CI) builds the image beforehand.
 
-The flow:
+**Mode 2: Build from files (default)**
 
-1. CLI packages bench files + `package.json` + lockfile
-2. CLI generates a Dockerfile (or uses a user-provided one) that bundles the bench files + deps + bench CLI
-3. CLI calls Namespace `CreateBlueprint` with the Dockerfile content as the spec
-4. CLI calls `Build` to trigger an asynchronous build
-5. CLI polls `FetchBlueprint` until `State = STATE_READY`
+```
+bench --platform --provider namespace
+```
+
+CLI calls `provider.image.build()` with a generated Dockerfile + bench files. Provider builds the image. CLI gets `imageRef` back. CLI launches workers from that image. No local Docker required — the provider builds on its infrastructure.
+
+This requires `image.build()` on the provider (see Multi-provider section). Providers that don't support it fall back to Mode 1.
 6. CLI gets the `image_ref` from the build response
 7. Platform launches worker VMs from that `image_ref` (via Namespace instance API)
 8. Each worker VM runs `bench-worker`, claims a task range, executes entries through `runWorker()`
@@ -304,65 +266,41 @@ This is the best of both worlds:
 
 **Mode 1: Pre-built image (user provides image)**
 
-```
-bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
-```
-
-User (or CI) has already built and pushed an image. CLI skips the build step and launches workers directly. This is the existing `benchmarks/src/scale` pattern — `start.ts` replaced by the CLI.
-
-**Mode 2: CLI builds via Namespace (default)**
+### Execution flow (CLI orchestrates directly)
 
 ```
-bench --platform
+CLI                     ComputeSDK Provider (Namespace/E2B/Modal)
+  |                              |
+  |  image.build(dockerfile)     |
+  |  --------------------------->|
+  |  <-- imageRef ---------------|  (skip if --image provided)
+  |                              |
+  |  sandbox.create(imageRef, env: {TASK_START, TASK_COUNT, ...}) x N
+  |  --------------------------->|
+  |  <-- sandboxes launched -----|
+  |                              |
+  |  (each worker:               |
+  |    load bench files          |
+  |    execute task range        |
+  |    stream results to CLI)    |
+  |                              |
+  |  <-- results stream back ----|
+  |                              |
+  |  sandbox.destroy() x N       |
+  |  --------------------------->|
+  |                              |
+  |  (CLI aggregates, prints)    |
+  |                              |
+  |  (optional) POST results --> ComputeSDK Platform (historical storage)
 ```
 
-CLI packages bench files, generates a default Dockerfile (or uses a user-provided `Dockerfile.bench`), and calls Namespace's `ImageService` to build the image. No local Docker needed. Blueprint caching means rebuilds only happen when the Dockerfile or bench files change.
+The CLI is the orchestrator. No platform in the execution path. The provider handles all compute (build, launch, destroy). Workers stream results back to the CLI, which aggregates and prints.
 
-**Mode 3: APT-based image (lightweight)**
+For `--image` mode, skip the `image.build()` step — the user provides the image reference directly.
 
-For benchmarks that just need Node.js + a few system packages, the CLI can use Namespace's `AptBasedImage` spec instead of a full Dockerfile. This is faster to build and simpler to configure.
+### Blueprint/image caching
 
-### Build flow (all routed through the platform)
-
-```
-CLI                      ComputeSDK Platform                    Namespace
- |                            |                                    |
- |  POST /runs (files)        |                                    |
- |  ------------------------->|                                    |
- |                            |  CreateBlueprint + Build           |
- |                            |  --------------------------------->|
- |                            |  FetchBlueprint (poll)             |
- |                            |  <--- STATE_READY + image_ref -----|
- |                            |                                    |
- |                            |  CreateInstance (per worker)       |
- |                            |  --------------------------------->|
- |                            |  <--- instances launched ----------|
- |                            |                                    |
- |                            |  (workers claim tasks from        |
- |                            |   platform, execute, report)      |
- |                            |                                    |
- |  GET /runs/:id             |                                    |
- |  <--- phase=building ------|                                    |
- |  GET /runs/:id             |                                    |
- |  <--- phase=running --------|                                    |
- |  GET /runs/:id             |                                    |
- |  <--- phase=completed ------|                                    |
- |                            |                                    |
- |  GET /runs/:id/results     |                                    |
- |  <--- aggregated results --|                                    |
- |                            |  DestroyInstance (cleanup)         |
- |                            |  --------------------------------->|
-```
-
-The CLI never talks to Namespace. The platform is the sole orchestrator:
-- Receives files from CLI
-- Builds image via Namespace ImageService
-- Launches worker VMs via Namespace ComputeService
-- Workers claim tasks from the platform and report results back
-- Platform destroys VMs via Namespace ComputeService when done
-- Platform returns aggregated results to CLI
-
-The platform productizes `start.ts` from `benchmarks/src/scale`. The same logic (create run, build image, launch VMs, coordinate, aggregate, destroy) becomes a hosted service instead of a script.
+If the provider supports `image.build()`, the CLI can hash the Dockerfile + bench file contents and cache the built image. On subsequent runs with the same content, skip the build. This gives fast iteration without manual image management. The caching mechanism is provider-specific (Namespace uses blueprints, other providers may use tags or digests).
 
 ### Blueprint caching strategy
 
@@ -616,20 +554,22 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Passes `defineTask()` entries through with full step graph
 - Uses existing `mapPool` for concurrency, existing heartbeat/flush infrastructure
 
-### Phase 4: Add `--platform --image` mode to the CLI (pre-built image)
+### Phase 4: Add `--platform --image` mode to the CLI (pre-built image, CLI orchestrates)
 
-- CLI accepts `--image <image>` pointing to a pre-built Docker image
-- CLI calls `POST /runs` on the platform with the image ref + config
-- Platform launches worker sandboxes from the image via ComputeSDK provider (Namespace first)
-- Worker sandboxes call `runBenchWorker()` with the loaded entries
-- CLI polls `GET /runs/:id`, prints TUI
-- This replaces `start.ts` from `benchmarks/src/scale` — zero new infrastructure
+- CLI accepts `--image <image>` and `--provider <name>` flags
+- CLI divides tasks among N workers (static range assignment)
+- CLI launches N worker sandboxes via `provider.sandbox.create()` with the image
+- Each worker executes its range via `runBenchWorker()`, streams results back to CLI
+- CLI aggregates results, prints TUI, destroys sandboxes
+- No platform API needed — CLI orchestrates directly via ComputeSDK provider
+- This replaces `start.ts` from `benchmarks/src/scale`
 
 ### Phase 5: Migrate scale tests to the CLI
 
 - Replace `benchmarks/src/scale/sdk-coordinator.ts` with a `scale.bench.ts` file using `defineTask`/`defineStep`
-- Replace `start.ts` with `bench --platform --image`
+- Replace `start.ts` with `bench --platform --image --provider namespace`
 - The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
+- Barrier coordination: CLI orchestrates barriers (wait for all workers to report step completion before signaling proceed)
 
 ### Phase 6: Add `image.build()` to ComputeSDK provider interface
 
@@ -640,23 +580,32 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 
 ### Phase 7: Add `--platform` (build from files) to the CLI
 
-- `bench --platform` (without `--image`) ships bench files to the platform
-- Platform calls `provider.image.build()` to build the image
-- Platform launches worker sandboxes from the built image
-- Blueprint/image caching: hash Dockerfile + bench file contents, skip rebuild if cached
+- `bench --platform` (without `--image`) calls `provider.image.build()` with bench files + generated Dockerfile
+- Provider builds the image, CLI gets `imageRef` back
+- CLI launches workers from the built image (same as Phase 4)
+- Image caching: hash Dockerfile + bench file contents, skip rebuild if cached
 - No local Docker required — the provider builds on its infrastructure
 - Multi-provider: works with any ComputeSDK provider that implements `image.build()`
+
+### Phase 8: Optional platform storage (future)
+
+- `bench --platform --store` pushes results to the ComputeSDK platform after a run
+- Platform stores historical runs for trend tracking and regression detection
+- Web UI for viewing runs across a team
+- Platform is optional — not required for execution
 
 ## Open Questions
 
 1. **ComputeSDK provider interface for image build.** The current `Provider` interface has `sandbox.create()` (image run) but no `image.build()`. What should the `image.build()` signature look like? Should it support Dockerfile content, build context (tarball/zip), APT packages, or all of the above? How does build context reach the provider's builder (upload, git URL, inline)?
 
-2. **Provider capability detection.** Not all providers will support `image.build()`. Should the CLI/platform detect this at runtime and fall back to `--image` mode? Or should the API advertise capabilities per provider?
+2. **Provider capability detection.** Not all providers will support `image.build()`. Should the CLI detect this at runtime and fall back to `--image` mode? Or should the API advertise capabilities per provider?
 
-3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker sandbox. How do secrets flow from the user's environment to the platform to the worker sandbox? Secrets should not be baked into the image — they should be injected at sandbox launch time via env vars. The CLI needs a `--env` or `--secret` flag.
+3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker sandbox. How do secrets flow from the user's environment to the worker sandbox? Secrets should not be baked into the image — they should be injected at sandbox launch time via env vars. The CLI needs a `--env` or `--secret` flag.
 
-4. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
+4. **Step readiness barriers without the platform.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Without the platform as a coordination point, how do workers coordinate barriers? Options: CLI-orchestrated barriers (CLI waits for all workers to report, then signals proceed), provider-level networking (shared volumes, message queues), or use the platform only for barrier coordination. This is the main open question for the platform-less architecture.
 
-5. **Step readiness barriers.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Should the CLI expose this as a `defineStep` option, or should it be implicit? The current SDK already supports `readiness: 'poll'` on `DefineStepOptions`.
+5. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
 
-6. **Image lifecycle.** Should the platform cache built images across runs (content-addressed by file hash)? What is the retention/cleanup policy? This applies to both Namespace blueprints and any provider's image build output.
+6. **Image lifecycle.** Should the CLI cache built images across runs (content-addressed by file hash)? What is the retention/cleanup policy? This applies to both Namespace blueprints and any provider's image build output.
+
+7. **CLI crash recovery.** If the CLI crashes mid-run, worker sandboxes may be orphaned. Should the CLI register cleanup handlers (SIGTERM/SIGINT) to destroy sandboxes? Should sandboxes have a TTL so they self-destruct?

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -199,7 +199,7 @@ This is exactly how `benchmarks/src/scale` works today:
 - `start.ts` creates the run, plans workers, launches VMs with the image
 - Each VM runs the coordinator which claims a worker and executes tasks
 
-The CLI replaces `start.ts`. The Docker image, VM launch, and coordinator pattern stay the same.
+The CLI replaces `start.ts`. The Docker image, VM launch, and coordinator pattern stay the same. Namespace provides the infrastructure for all of it — registry, image building, and VM orchestration are already in place. This is a minor integration detail, not a blocker.
 
 **Phase 2: Ship files (future enhancement)**
 
@@ -488,10 +488,10 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 
 - CLI accepts `--image <image>` pointing to a pre-built Docker image
 - CLI creates benchmark run on the platform, plans workers
-- Platform launches worker VMs from the image (existing infrastructure)
+- Platform launches worker VMs from the image via Namespace (existing infrastructure — Namespace handles registry, image building, and VM launch)
 - Worker VMs call `runBenchWorker()` with the loaded entries
 - CLI polls progress, prints TUI
-- This replaces `start.ts` from `benchmarks/src/scale` — zero new platform infrastructure
+- This replaces `start.ts` from `benchmarks/src/scale` — zero new platform infrastructure, Namespace already provides registry + image build + VM orchestration
 
 ### Phase 5: Migrate scale tests to the CLI
 

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -23,8 +23,8 @@ This doc proposes a unified design that fixes all three. Since there is zero ext
 - One authoring API with two levels of complexity: `bench()` for micro-benchmarks, `defineTask()`/`defineStep()` for multi-phase workloads. Both coexist in the same `*.bench.ts` files.
 - One execution path: the SDK's `runWorker()` handles concurrency, heartbeats, and flushing for both local and remote runs. The CLI does not reimplement worker logic.
 - One CLI: `bench` discovers files, loads entries, runs them locally or on the platform. No fork-and-reimplement.
-- Remote execution that actually runs remotely: bench files ship to the platform, the platform builds and runs them in sandboxes. No local Docker required for the default path.
-- The scale coordinator pattern in `computesdk/benchmarks/src/scale/sdk-coordinator.ts` is the reference implementation for what `--remote` should look like.
+- Remote execution that actually runs remotely: bench files ship to the first-party benchmark runner platform, which builds and runs them on its own compute. No local Docker required for the default path.
+- The scale coordinator pattern in `computesdk/benchmarks/src/scale/sdk-coordinator.ts` is the reference implementation for what `--platform` should look like.
 
 ## Authoring API
 
@@ -134,11 +134,13 @@ bench --platform
 bench --platform --total 500 --workers 4 --concurrency 10
 ```
 
-Renamed from `--remote` to `--platform` to accurately describe what it does: orchestrate the run on the ComputeSDK platform.
+Renamed from `--remote` to `--platform` to accurately describe what it does: ship benchmarks to the first-party benchmark runner platform for execution.
+
+The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive files, build, run workers, aggregate, report. It has its own compute infrastructure (VMs/containers) for building and running benchmarks. It is not a ComputeSDK sandbox — ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark platform is a separate product with its own compute capacity, purpose-built for running `*.bench.ts` workloads.
 
 1. CLI discovers and loads bench files (same as local).
-2. CLI ships the bench files + `package.json` + lockfile to the platform (see Remote Execution below).
-3. Platform builds the project on its own compute infrastructure (install deps, compile TS). Note: ComputeSDK is a framework that connects to sandbox providers (E2B, Modal, etc.), not a sandbox provider itself. The platform uses its own VM capacity — the same infrastructure it already uses to launch scale test workers.
+2. CLI ships the bench files + `package.json` + lockfile to the platform.
+3. Platform builds the project on its compute infrastructure (install deps, compile TS).
 4. Platform creates a benchmark run, plans workers, and spawns worker VMs from the build output.
 5. Each worker VM loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
    - Real concurrency via `mapPool(taskIndices, concurrency, ...)`
@@ -148,7 +150,23 @@ Renamed from `--remote` to `--platform` to accurately describe what it does: orc
 6. CLI polls progress and prints a TUI until all workers finish.
 7. Platform aggregates results; CLI prints final summary.
 
-The key change: the CLI does NOT fork local processes. It ships files to the platform, and the platform runs workers on its own VMs. The SDK's `runWorker()` is the single execution path for remote work.
+The key change: the CLI does NOT fork local processes. It ships files to the platform, and the platform runs workers on its own compute. The SDK's `runWorker()` is the single execution path for remote work. The CLI is a thin client: discover, ship, poll, report.
+
+### The first-party benchmark runner platform
+
+The `--platform` mode assumes a first-party benchmark runner platform — a hosted service that owns the entire benchmark lifecycle:
+
+1. **Receive** bench files + `package.json` from the CLI
+2. **Build** the project (install deps, compile TS) on its own compute
+3. **Run** worker VMs from the build output, each claiming tasks and executing entries
+4. **Aggregate** results across workers
+5. **Report** progress and final summary back to the CLI
+
+This is a separate product from ComputeSDK itself. ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, Vercel, etc.). The benchmark runner platform is a first-party service with its own compute infrastructure, purpose-built for running `*.bench.ts` workloads at scale.
+
+The existing `platform.computesdk.com` API (benchmark/run/worker coordination, result aggregation, artifact storage) is the foundation. The first-party runner adds build capability and managed worker execution on top of that coordination layer.
+
+The scale test infrastructure in `computesdk/benchmarks/src/scale` is the prototype: `start.ts` creates runs, launches VMs, and each VM runs a coordinator that claims work. The first-party platform productizes this flow — the CLI replaces `start.ts`, and the platform handles VM launch and coordination internally.
 
 ## Remote Execution: Ship Files vs Docker Image
 
@@ -164,15 +182,17 @@ Should `--platform` build a Docker image locally and push it, or should it ship 
 bench --platform
 ```
 
-The CLI packages the bench files, `package.json`, and lockfile, then uploads them to the platform. The platform builds the project on its own compute infrastructure (VM capacity it already uses for scale test workers) and spawns worker VMs from the build output.
+The CLI packages the bench files, `package.json`, and lockfile, then uploads them to the first-party benchmark runner platform. The platform builds the project on its own compute and spawns worker VMs from the build output.
+
+This is the natural fit for a first-party benchmark runner platform. If the platform's job is to run benchmarks, it should be able to build them too. The CLI is a thin client: package files, ship, poll for results.
 
 Why this is the right default:
 
 1. **No local Docker required.** The vitest mental model is "run a command, it works." Asking users to install Docker, authenticate to a registry, and wait for image builds breaks that.
 
-2. **Iteration speed.** Shipping TS files + installing deps on a platform VM is much faster than build -> push -> pull -> run, especially with cached `node_modules` layers on the platform.
+2. **Iteration speed.** Shipping TS files + installing deps on the platform is much faster than build -> push -> pull -> run, especially with cached `node_modules` on the platform side.
 
-3. **The platform already has compute capacity.** It launches VMs for scale tests today. The ship-files path reuses that infrastructure with a "build from source" step instead of a pre-built Docker image. No new infrastructure needed — just a new API endpoint.
+3. **The platform owns the lifecycle.** A first-party benchmark runner platform should handle building, running, and reporting as a unified pipeline. Ship-files makes the platform responsible for the build step, which is where it belongs — the platform controls the build environment, can cache builds across runs, and can reproduce builds.
 
 4. **The scale test is the exception, not the rule.** The existing `benchmarks/src/scale` Dockerfile exists because scale testing needs specific system-level access (provider SDKs, API keys, `/proc` access for metrics). Simple `bench()` micro-benchmarks just need Node.js and `npm install`. The default should optimize for the common case.
 
@@ -189,7 +209,7 @@ This mirrors the existing `benchmarks/src/scale` flow: build the image in CI, pu
 ### Platform build flow (ship-files path)
 
 ```
-CLI                          Platform API                    Build/Worker VMs
+CLI                          Benchmark Runner Platform           Compute
  |                               |                              |
  |  POST /benchmarks/:slug       |                              |
  |  POST /runs (totalTasks)      |                              |
@@ -210,7 +230,7 @@ CLI                          Platform API                    Build/Worker VMs
  |  <--- final summary ---------+                              |
 ```
 
-The `POST /runs/:id/build` endpoint is new. It tells the platform to take the uploaded artifact (bench files + package.json), build it on a VM, and spawn worker VMs from the result. This keeps the build logic on the platform side, where it can be cached, shared across workers, and reproduced.
+The `POST /runs/:id/build` endpoint is new. It tells the benchmark runner platform to take the uploaded artifact (bench files + package.json), build it on its compute, and spawn worker VMs from the result. The platform owns the build environment, can cache builds across runs, and can reproduce builds — this is a first-party capability of the benchmark runner, not a bolt-on.
 
 ### What about the existing scale coordinator?
 
@@ -225,7 +245,7 @@ Over time, `start.ts` can be replaced by `bench --platform --image` + a `benchma
 ```
 bench [run] [files...]     Run benchmarks (default subcommand)
 bench list [files...]      List discovered benchmarks without running
-bench --platform [files..] Run on the ComputeSDK platform
+bench --platform [files..] Run on the benchmark runner platform
 ```
 
 ### Flags
@@ -241,9 +261,9 @@ Local flags:
 
 Platform flags:
 ```
---platform               Run on the ComputeSDK platform
+--platform               Run on the benchmark runner platform
 --total <n>              Replications per benchmark function (default 100)
---workers <n>            Worker sandboxes to spawn (default 1)
+--workers <n>            Worker VMs to spawn (default 1)
 --concurrency <n>        Parallel task slots per worker (default 1)
 --participant <slug>     Participant identifier (default bench-cli)
 --slug <slug>            Benchmark slug (default derived from filename)
@@ -470,7 +490,7 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 
 ## Open Questions
 
-1. **Platform build endpoint.** Does the platform API already have a way to upload and build source files on a VM, or does `POST /runs/:id/build` need to be added? The existing `createWorkerArtifact` / `uploadWorkerArtifact` endpoints upload artifacts, but there is no "build from source" endpoint.
+1. **Platform build endpoint.** Does the benchmark runner platform already have a way to upload and build source files, or does `POST /runs/:id/build` need to be added? The existing `createWorkerArtifact` / `uploadWorkerArtifact` endpoints upload artifacts, but there is no "build from source" endpoint.
 
 2. **Worker VM base image.** When the platform builds bench files and spawns worker VMs, what base image do the workers use? A Node.js image with the bench CLI pre-installed? Or does the build step produce a self-contained bundle?
 

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -138,9 +138,9 @@ Renamed from `--remote` to `--platform` to accurately describe what it does: orc
 
 1. CLI discovers and loads bench files (same as local).
 2. CLI ships the bench files + `package.json` + lockfile to the platform (see Remote Execution below).
-3. Platform builds the project in a sandbox (install deps, compile TS).
-4. Platform creates a benchmark run, plans workers, and spawns worker sandboxes.
-5. Each worker sandbox loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
+3. Platform builds the project on its own compute infrastructure (install deps, compile TS). Note: ComputeSDK is a framework that connects to sandbox providers (E2B, Modal, etc.), not a sandbox provider itself. The platform uses its own VM capacity — the same infrastructure it already uses to launch scale test workers.
+4. Platform creates a benchmark run, plans workers, and spawns worker VMs from the build output.
+5. Each worker VM loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
    - Real concurrency via `mapPool(taskIndices, concurrency, ...)`
    - Automatic heartbeats
    - Batched result flushing
@@ -148,7 +148,7 @@ Renamed from `--remote` to `--platform` to accurately describe what it does: orc
 6. CLI polls progress and prints a TUI until all workers finish.
 7. Platform aggregates results; CLI prints final summary.
 
-The key change: the CLI does NOT fork local processes. It ships files to the platform, and the platform runs workers in sandboxes. The SDK's `runWorker()` is the single execution path for remote work.
+The key change: the CLI does NOT fork local processes. It ships files to the platform, and the platform runs workers on its own VMs. The SDK's `runWorker()` is the single execution path for remote work.
 
 ## Remote Execution: Ship Files vs Docker Image
 
@@ -164,15 +164,15 @@ Should `--platform` build a Docker image locally and push it, or should it ship 
 bench --platform
 ```
 
-The CLI packages the bench files, `package.json`, and lockfile, then uploads them to the platform. The platform builds the project in a ComputeSDK sandbox (the product running its own benchmarks) and spawns worker sandboxes from the build output.
+The CLI packages the bench files, `package.json`, and lockfile, then uploads them to the platform. The platform builds the project on its own compute infrastructure (VM capacity it already uses for scale test workers) and spawns worker VMs from the build output.
 
 Why this is the right default:
 
 1. **No local Docker required.** The vitest mental model is "run a command, it works." Asking users to install Docker, authenticate to a registry, and wait for image builds breaks that.
 
-2. **Iteration speed.** Shipping TS files + installing deps in a sandbox is much faster than build -> push -> pull -> run, especially with cached `node_modules` layers on the platform.
+2. **Iteration speed.** Shipping TS files + installing deps on a platform VM is much faster than build -> push -> pull -> run, especially with cached `node_modules` layers on the platform.
 
-3. **Dogfooding.** ComputeSDK is a sandbox execution platform. Using it to build and run its own benchmarks is the strongest possible proof of the product.
+3. **The platform already has compute capacity.** It launches VMs for scale tests today. The ship-files path reuses that infrastructure with a "build from source" step instead of a pre-built Docker image. No new infrastructure needed — just a new API endpoint.
 
 4. **The scale test is the exception, not the rule.** The existing `benchmarks/src/scale` Dockerfile exists because scale testing needs specific system-level access (provider SDKs, API keys, `/proc` access for metrics). Simple `bench()` micro-benchmarks just need Node.js and `npm install`. The default should optimize for the common case.
 
@@ -189,18 +189,18 @@ This mirrors the existing `benchmarks/src/scale` flow: build the image in CI, pu
 ### Platform build flow (ship-files path)
 
 ```
-CLI                          Platform API                    Sandbox
+CLI                          Platform API                    Build/Worker VMs
  |                               |                              |
  |  POST /benchmarks/:slug       |                              |
  |  POST /runs (totalTasks)      |                              |
  |  POST /runs/:id/artifact      |                              |
  |    (upload bench files zip)   |                              |
  |  POST /runs/:id/build         |                              |
- |                               |  create build sandbox        |
+ |                               |  launch build VM             |
  |                               |  -> install deps             |
  |                               |  -> compile TS               |
  |                               |  <- build ready              |
- |                               |  spawn worker sandboxes      |
+ |                               |  launch worker VMs           |
  |                               |    from build output         |
  |                               |                              |
  |  GET /runs/:id/progress       |                              |
@@ -210,7 +210,7 @@ CLI                          Platform API                    Sandbox
  |  <--- final summary ---------+                              |
 ```
 
-The `POST /runs/:id/build` endpoint is new. It tells the platform to take the uploaded artifact (bench files + package.json), build it in a sandbox, and spawn workers from the result. This keeps the build logic on the platform side, where it can be cached, shared across workers, and reproduced.
+The `POST /runs/:id/build` endpoint is new. It tells the platform to take the uploaded artifact (bench files + package.json), build it on a VM, and spawn worker VMs from the result. This keeps the build logic on the platform side, where it can be cached, shared across workers, and reproduced.
 
 ### What about the existing scale coordinator?
 
@@ -457,8 +457,8 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 ### Phase 4: Add `--platform` mode to the CLI
 
 - CLI ships files to platform (new `POST /runs/:id/build` endpoint)
-- Platform builds in sandbox, spawns worker sandboxes
-- Worker sandboxes call `runBenchWorker()` with the loaded entries
+- Platform builds on a VM, spawns worker VMs from build output
+- Worker VMs call `runBenchWorker()` with the loaded entries
 - CLI polls progress, prints TUI
 - Add `--image` flag for pre-built Docker image path
 
@@ -470,11 +470,11 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 
 ## Open Questions
 
-1. **Platform build endpoint.** Does the platform API already have a way to upload and build source files in a sandbox, or does `POST /runs/:id/build` need to be added? The existing `createWorkerArtifact` / `uploadWorkerArtifact` endpoints upload artifacts, but there is no "build from source" endpoint.
+1. **Platform build endpoint.** Does the platform API already have a way to upload and build source files on a VM, or does `POST /runs/:id/build` need to be added? The existing `createWorkerArtifact` / `uploadWorkerArtifact` endpoints upload artifacts, but there is no "build from source" endpoint.
 
-2. **Worker sandbox image.** When the platform builds bench files and spawns workers, what base image do the worker sandboxes use? A Node.js image with the bench CLI pre-installed? Or does the build step produce a self-contained bundle?
+2. **Worker VM base image.** When the platform builds bench files and spawns worker VMs, what base image do the workers use? A Node.js image with the bench CLI pre-installed? Or does the build step produce a self-contained bundle?
 
-3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker sandbox. How do secrets flow from the user's environment to the platform to the worker sandbox? The existing flow uses env vars set in the Docker image or VM startup script. The ship-files path needs a `--env` or `--secret` flag.
+3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker VM. How do secrets flow from the user's environment to the platform to the worker VM? The existing flow uses env vars set in the Docker image or VM startup script. The ship-files path needs a `--env` or `--secret` flag.
 
 4. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (ship a zip, build all, run all), or should it be limited to one file per run for simplicity?
 

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -175,63 +175,68 @@ The scale test infrastructure in `computesdk/benchmarks/src/scale` is the protot
 
 Should `--platform` build a Docker image locally and push it, or should it ship source files to the platform and let the platform build and run them?
 
-### Recommendation: phased — Docker image first, ship files as future enhancement
+### Recommendation: unified approach using Namespace ImageService
 
-The best bang-for-buck is to ship the two things that already work:
+Namespace provides an `ImageService` API ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.image.v1beta)) that builds Docker images asynchronously from a blueprint spec. This bridges the gap between ship-files and Docker images — the CLI can ship a Dockerfile + bench files to Namespace, Namespace builds the image, and the CLI gets back an `image_ref` to launch workers. No local Docker required.
 
-1. **Local execution** — `bench` runs benchmarks on your machine (no platform dependency)
-2. **Platform execution via Docker image** — `bench --platform --image <image>` uses the existing pattern from `benchmarks/src/scale`: build a Docker image in CI, the platform launches worker VMs from that image, each VM runs a coordinator that claims work and executes entries
+The flow:
 
-This requires zero new platform infrastructure. The Docker image + VM launch + coordinator pattern is already proven in the scale test repo. The CLI just replaces `start.ts` as the entry point.
+1. CLI packages bench files + `package.json` + lockfile
+2. CLI generates a Dockerfile (or uses a user-provided one) that bundles the bench files + deps + bench CLI
+3. CLI calls Namespace `CreateBlueprint` with the Dockerfile content as the spec
+4. CLI calls `Build` to trigger an asynchronous build
+5. CLI polls `FetchBlueprint` until `State = STATE_READY`
+6. CLI gets the `image_ref` from the build response
+7. Platform launches worker VMs from that `image_ref` (via Namespace instance API)
+8. Each worker VM runs `bench-worker`, claims a task range, executes entries through `runWorker()`
 
-Ship-files (platform builds from source) is a future enhancement that requires a new `POST /runs/:id/build` endpoint and build capability on the platform. It is the better long-term UX, but it is not needed for the initial release.
+This is the best of both worlds:
+- **No local Docker required** — Namespace builds the image on its infrastructure
+- **Uses the proven Docker image pattern** — works with any system-level dependencies, provider SDKs, etc.
+- **Blueprint caching** — blueprints are versioned; if the Dockerfile hasn't changed, the existing image is reused without rebuilding
+- **Multi-site builds** — Namespace builds per deployment site, so workers launch from a locally-cached image
 
-**Phase 1: Docker image (initial release)**
+### Three modes
+
+**Mode 1: Pre-built image (user provides image)**
 
 ```
 bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
 ```
 
-The user (or CI) builds a Docker image containing the bench files + deps + the bench CLI. The platform launches worker VMs from that image. Each VM runs `bench-worker` (or a user-specified entrypoint), claims a task range, and executes entries through the SDK's `runWorker()`.
+User (or CI) has already built and pushed an image. CLI skips the build step and launches workers directly. This is the existing `benchmarks/src/scale` pattern — `start.ts` replaced by the CLI.
 
-This is exactly how `benchmarks/src/scale` works today:
-- `Dockerfile` bundles the coordinator + deps
-- `start.ts` creates the run, plans workers, launches VMs with the image
-- Each VM runs the coordinator which claims a worker and executes tasks
-
-The CLI replaces `start.ts`. The Docker image, VM launch, and coordinator pattern stay the same. Namespace provides the infrastructure for all of it — registry, image building, and VM orchestration are already in place. This is a minor integration detail, not a blocker.
-
-**Phase 2: Ship files (future enhancement)**
+**Mode 2: CLI builds via Namespace (default)**
 
 ```
 bench --platform
 ```
 
-The CLI packages bench files + `package.json` + lockfile and uploads them to the platform. The platform builds the project on its own compute and spawns worker VMs from the build output. No local Docker required.
+CLI packages bench files, generates a default Dockerfile (or uses a user-provided `Dockerfile.bench`), and calls Namespace's `ImageService` to build the image. No local Docker needed. Blueprint caching means rebuilds only happen when the Dockerfile or bench files change.
 
-This requires:
-- New `POST /runs/:id/build` endpoint on the platform
-- Build capability (VM that installs deps, compiles TS, produces a runnable bundle)
-- Build caching across runs
+**Mode 3: APT-based image (lightweight)**
 
-This is the better long-term UX (no Docker, faster iteration, vitest-like "just run it" experience), but it is net-new platform infrastructure. It should be designed after the Docker image path is shipping and proven.
+For benchmarks that just need Node.js + a few system packages, the CLI can use Namespace's `AptBasedImage` spec instead of a full Dockerfile. This is faster to build and simpler to configure.
 
-### Platform build flow (ship-files path)
+### Build flow (Mode 2: CLI builds via Namespace)
 
 ```
-CLI                          Benchmark Runner Platform           Compute
+CLI                     Namespace ImageService          Namespace Instances
  |                               |                              |
- |  POST /benchmarks/:slug       |                              |
- |  POST /runs (totalTasks)      |                              |
- |  POST /runs/:id/artifact      |                              |
- |    (upload bench files zip)   |                              |
- |  POST /runs/:id/build         |                              |
- |                               |  launch build VM             |
- |                               |  -> install deps             |
- |                               |  -> compile TS               |
- |                               |  <- build ready              |
+ |  CreateBlueprint(spec)        |                              |
+ |  Build(blueprint)             |                              |
+ |                               |  async build                 |
+ |  FetchBlueprint()             |                              |
+ |  <--- STATE_BUILDING --------+                              |
+ |  FetchBlueprint()             |                              |
+ |  <--- STATE_READY ------------+                              |
+ |  (got image_ref)              |                              |
+ |                               |                              |
+ |  (create run on platform,     |                              |
+ |   plan workers, launch VMs    |                              |
+ |   from image_ref)             |                              |
  |                               |  launch worker VMs           |
- |                               |    from build output         |
+ |                               |    from image_ref            |
  |                               |                              |
  |  GET /runs/:id/progress       |                              |
  |  <--- progress updates ------+                              |
@@ -240,7 +245,17 @@ CLI                          Benchmark Runner Platform           Compute
  |  <--- final summary ---------+                              |
 ```
 
-The `POST /runs/:id/build` endpoint is new. It tells the benchmark runner platform to take the uploaded artifact (bench files + package.json), build it on its compute, and spawn worker VMs from the result. The platform owns the build environment, can cache builds across runs, and can reproduce builds — this is a first-party capability of the benchmark runner, not a bolt-on.
+No `POST /runs/:id/build` endpoint needed on the ComputeSDK platform — the build happens directly through Namespace's `ImageService` API. The ComputeSDK platform only needs to know the `image_ref` to launch workers. Blueprint management (create, build, poll, cache) is handled by Namespace.
+
+### Blueprint caching strategy
+
+Namespace blueprints are versioned. The CLI can hash the Dockerfile content + bench file contents and use that hash as the blueprint name. On subsequent runs:
+
+1. CLI computes the hash
+2. CLI calls `FetchBlueprint(hash)` — if it exists and `State = STATE_READY`, skip the build
+3. If not, `CreateBlueprint` + `Build`
+
+This gives fast iteration (cached builds) without requiring the user to manage image versions manually.
 
 ### What about the existing scale coordinator?
 
@@ -484,14 +499,14 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Passes `defineTask()` entries through with full step graph
 - Uses existing `mapPool` for concurrency, existing heartbeat/flush infrastructure
 
-### Phase 4: Add `--platform --image` mode to the CLI (Docker image path)
+### Phase 4: Add `--platform --image` mode to the CLI (pre-built image)
 
 - CLI accepts `--image <image>` pointing to a pre-built Docker image
 - CLI creates benchmark run on the platform, plans workers
-- Platform launches worker VMs from the image via Namespace (existing infrastructure — Namespace handles registry, image building, and VM launch)
+- Platform launches worker VMs from the image via Namespace
 - Worker VMs call `runBenchWorker()` with the loaded entries
 - CLI polls progress, prints TUI
-- This replaces `start.ts` from `benchmarks/src/scale` — zero new platform infrastructure, Namespace already provides registry + image build + VM orchestration
+- This replaces `start.ts` from `benchmarks/src/scale` — zero new infrastructure
 
 ### Phase 5: Migrate scale tests to the CLI
 
@@ -499,22 +514,23 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Replace `start.ts` with `bench --platform --image`
 - The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
 
-### Phase 6: Ship-files platform build (future enhancement)
+### Phase 6: Add Namespace ImageService integration (CLI-built images)
 
-- New `POST /runs/:id/build` endpoint on the platform
-- CLI ships bench files + package.json + lockfile without requiring a Docker image
-- Platform builds on its compute, spawns worker VMs from build output
-- `bench --platform` (without `--image`) becomes the simple default
-- Requires build capability, caching, and reproducible build environments on the platform side
+- CLI integrates with Namespace `ImageService` API (`CreateBlueprint`, `Build`, `FetchBlueprint`)
+- `bench --platform` (without `--image`) generates a Dockerfile, ships bench files, builds via Namespace
+- Blueprint caching: hash Dockerfile + bench file contents, skip rebuild if cached and `STATE_READY`
+- Also support `AptBasedImage` spec for lightweight images (Node.js + APT packages, no Dockerfile needed)
+- No local Docker required — Namespace builds on its infrastructure
+- No new ComputeSDK platform endpoints needed — build happens through Namespace API directly
 
 ## Open Questions
 
-1. **Platform build endpoint.** Does the benchmark runner platform already have a way to upload and build source files, or does `POST /runs/:id/build` need to be added? The existing `createWorkerArtifact` / `uploadWorkerArtifact` endpoints upload artifacts, but there is no "build from source" endpoint.
+1. **Build context upload.** Namespace's `BlueprintSpec.Dockerfile` takes the Dockerfile content as a string, but the build context (bench files, `package.json`, etc.) needs to reach the builder. How does Namespace handle build context? Options: git-connected blueprint, artifact upload via a separate API, or the Dockerfile pulls files from a URL. Need to check Namespace's full API surface for build context handling.
 
-2. **Worker VM base image.** When the platform builds bench files and spawns worker VMs, what base image do the workers use? A Node.js image with the bench CLI pre-installed? Or does the build step produce a self-contained bundle?
+2. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker VM. How do secrets flow from the user's environment to the platform to the worker VM? The existing flow uses env vars set in the Docker image or VM startup script. The CLI needs a `--env` or `--secret` flag. Secrets should not be baked into the Dockerfile/blueprint — they should be injected at VM launch time.
 
-3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker VM. How do secrets flow from the user's environment to the platform to the worker VM? The existing flow uses env vars set in the Docker image or VM startup script. The ship-files path needs a `--env` or `--secret` flag.
+3. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
 
-4. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (ship a zip, build all, run all), or should it be limited to one file per run for simplicity?
+4. **Step readiness barriers.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Should the CLI expose this as a `defineStep` option, or should it be implicit? The current SDK already supports `readiness: 'poll'` on `DefineStepOptions`.
 
-5. **Step readiness barriers.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Should the CLI expose this as a `defineStep` option, or should it be implicit? The current SDK already supports `readiness: 'poll'` on `DefineStepOptions`.
+5. **Blueprint lifecycle.** Should the CLI create a new blueprint per run, or should it manage blueprints as long-lived objects (create once, rebuild when files change)? The caching strategy in the doc assumes long-lived blueprints keyed by content hash, but this needs a cleanup/retention policy.

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -130,27 +130,28 @@ The local runner is the existing `runner.ts` from PR #636, extended to handle `d
 ### Remote mode (`--platform`)
 
 ```
-bench --platform
-bench --platform --total 500 --workers 4 --concurrency 10
+bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
+bench --platform --image my-image --total 500 --workers 4 --concurrency 10
 ```
 
 Renamed from `--remote` to `--platform` to accurately describe what it does: ship benchmarks to the first-party benchmark runner platform for execution.
 
-The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive files, build, run workers, aggregate, report. It has its own compute infrastructure (VMs/containers) for building and running benchmarks. It is not a ComputeSDK sandbox — ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark platform is a separate product with its own compute capacity, purpose-built for running `*.bench.ts` workloads.
+The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive work, run workers, aggregate, report. It has its own compute infrastructure (VMs/containers) for running benchmarks. It is not a ComputeSDK sandbox — ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark platform is a separate product with its own compute capacity, purpose-built for running `*.bench.ts` workloads.
 
-1. CLI discovers and loads bench files (same as local).
-2. CLI ships the bench files + `package.json` + lockfile to the platform.
-3. Platform builds the project on its compute infrastructure (install deps, compile TS).
-4. Platform creates a benchmark run, plans workers, and spawns worker VMs from the build output.
-5. Each worker VM loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
+The initial release uses the Docker image path (the same pattern as `benchmarks/src/scale`): the user builds a Docker image containing the bench files + deps, the platform launches worker VMs from that image, each VM runs a coordinator that claims work and executes entries. A future release will add ship-files capability so users can skip the Docker build step.
+
+1. CLI discovers and loads bench files (same as local) — or the Docker image contains them.
+2. CLI creates a benchmark run on the platform, plans workers, and provides the image reference.
+3. Platform launches worker VMs from the image.
+4. Each worker VM loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
    - Real concurrency via `mapPool(taskIndices, concurrency, ...)`
    - Automatic heartbeats
    - Batched result flushing
    - Step-level concurrency barriers (`waitForStepReady`)
-6. CLI polls progress and prints a TUI until all workers finish.
-7. Platform aggregates results; CLI prints final summary.
+5. CLI polls progress and prints a TUI until all workers finish.
+6. Platform aggregates results; CLI prints final summary.
 
-The key change: the CLI does NOT fork local processes. It ships files to the platform, and the platform runs workers on its own compute. The SDK's `runWorker()` is the single execution path for remote work. The CLI is a thin client: discover, ship, poll, report.
+The key change: the CLI does NOT fork local processes. The platform runs workers on its own compute. The SDK's `runWorker()` is the single execution path for remote work. The CLI replaces `start.ts` from the scale test repo.
 
 ### The first-party benchmark runner platform
 
@@ -174,37 +175,46 @@ The scale test infrastructure in `computesdk/benchmarks/src/scale` is the protot
 
 Should `--platform` build a Docker image locally and push it, or should it ship source files to the platform and let the platform build and run them?
 
-### Recommendation: ship files by default, Docker image as opt-in
+### Recommendation: phased — Docker image first, ship files as future enhancement
 
-**Default path: ship files to the platform.**
+The best bang-for-buck is to ship the two things that already work:
 
-```
-bench --platform
-```
+1. **Local execution** — `bench` runs benchmarks on your machine (no platform dependency)
+2. **Platform execution via Docker image** — `bench --platform --image <image>` uses the existing pattern from `benchmarks/src/scale`: build a Docker image in CI, the platform launches worker VMs from that image, each VM runs a coordinator that claims work and executes entries
 
-The CLI packages the bench files, `package.json`, and lockfile, then uploads them to the first-party benchmark runner platform. The platform builds the project on its own compute and spawns worker VMs from the build output.
+This requires zero new platform infrastructure. The Docker image + VM launch + coordinator pattern is already proven in the scale test repo. The CLI just replaces `start.ts` as the entry point.
 
-This is the natural fit for a first-party benchmark runner platform. If the platform's job is to run benchmarks, it should be able to build them too. The CLI is a thin client: package files, ship, poll for results.
+Ship-files (platform builds from source) is a future enhancement that requires a new `POST /runs/:id/build` endpoint and build capability on the platform. It is the better long-term UX, but it is not needed for the initial release.
 
-Why this is the right default:
-
-1. **No local Docker required.** The vitest mental model is "run a command, it works." Asking users to install Docker, authenticate to a registry, and wait for image builds breaks that.
-
-2. **Iteration speed.** Shipping TS files + installing deps on the platform is much faster than build -> push -> pull -> run, especially with cached `node_modules` on the platform side.
-
-3. **The platform owns the lifecycle.** A first-party benchmark runner platform should handle building, running, and reporting as a unified pipeline. Ship-files makes the platform responsible for the build step, which is where it belongs — the platform controls the build environment, can cache builds across runs, and can reproduce builds.
-
-4. **The scale test is the exception, not the rule.** The existing `benchmarks/src/scale` Dockerfile exists because scale testing needs specific system-level access (provider SDKs, API keys, `/proc` access for metrics). Simple `bench()` micro-benchmarks just need Node.js and `npm install`. The default should optimize for the common case.
-
-**Opt-in path: pre-built Docker image.**
+**Phase 1: Docker image (initial release)**
 
 ```
 bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
 ```
 
-For workloads that need system-level dependencies, custom runtimes, or specific provider SDKs, users can provide a pre-built image. The platform launches worker containers from that image. The image's entrypoint should be `bench-worker` (or a user-specified command that calls `runWorker`).
+The user (or CI) builds a Docker image containing the bench files + deps + the bench CLI. The platform launches worker VMs from that image. Each VM runs `bench-worker` (or a user-specified entrypoint), claims a task range, and executes entries through the SDK's `runWorker()`.
 
-This mirrors the existing `benchmarks/src/scale` flow: build the image in CI, push to a registry, point the CLI at it.
+This is exactly how `benchmarks/src/scale` works today:
+- `Dockerfile` bundles the coordinator + deps
+- `start.ts` creates the run, plans workers, launches VMs with the image
+- Each VM runs the coordinator which claims a worker and executes tasks
+
+The CLI replaces `start.ts`. The Docker image, VM launch, and coordinator pattern stay the same.
+
+**Phase 2: Ship files (future enhancement)**
+
+```
+bench --platform
+```
+
+The CLI packages bench files + `package.json` + lockfile and uploads them to the platform. The platform builds the project on its own compute and spawns worker VMs from the build output. No local Docker required.
+
+This requires:
+- New `POST /runs/:id/build` endpoint on the platform
+- Build capability (VM that installs deps, compiles TS, produces a runnable bundle)
+- Build caching across runs
+
+This is the better long-term UX (no Docker, faster iteration, vitest-like "just run it" experience), but it is net-new platform infrastructure. It should be designed after the Docker image path is shipping and proven.
 
 ### Platform build flow (ship-files path)
 
@@ -474,19 +484,28 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Passes `defineTask()` entries through with full step graph
 - Uses existing `mapPool` for concurrency, existing heartbeat/flush infrastructure
 
-### Phase 4: Add `--platform` mode to the CLI
+### Phase 4: Add `--platform --image` mode to the CLI (Docker image path)
 
-- CLI ships files to platform (new `POST /runs/:id/build` endpoint)
-- Platform builds on a VM, spawns worker VMs from build output
+- CLI accepts `--image <image>` pointing to a pre-built Docker image
+- CLI creates benchmark run on the platform, plans workers
+- Platform launches worker VMs from the image (existing infrastructure)
 - Worker VMs call `runBenchWorker()` with the loaded entries
 - CLI polls progress, prints TUI
-- Add `--image` flag for pre-built Docker image path
+- This replaces `start.ts` from `benchmarks/src/scale` — zero new platform infrastructure
 
-### Phase 5: Migrate scale tests
+### Phase 5: Migrate scale tests to the CLI
 
 - Replace `benchmarks/src/scale/sdk-coordinator.ts` with a `scale.bench.ts` file using `defineTask`/`defineStep`
 - Replace `start.ts` with `bench --platform --image`
 - The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
+
+### Phase 6: Ship-files platform build (future enhancement)
+
+- New `POST /runs/:id/build` endpoint on the platform
+- CLI ships bench files + package.json + lockfile without requiring a Docker image
+- Platform builds on its compute, spawns worker VMs from build output
+- `bench --platform` (without `--image`) becomes the simple default
+- Requires build capability, caching, and reproducible build environments on the platform side
 
 ## Open Questions
 

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -23,7 +23,8 @@ This doc proposes a unified design that fixes all three. Since there is zero ext
 - One authoring API with two levels of complexity: `bench()` for micro-benchmarks, `defineTask()`/`defineStep()` for multi-phase workloads. Both coexist in the same `*.bench.ts` files.
 - One execution path: the SDK's `runWorker()` handles concurrency, heartbeats, and flushing for both local and remote runs. The CLI does not reimplement worker logic.
 - One CLI: `bench` discovers files, loads entries, runs them locally or on the platform. No fork-and-reimplement.
-- Remote execution that actually runs remotely: bench files ship to the first-party benchmark runner platform, which builds and runs them on its own compute. No local Docker required for the default path.
+- Remote execution that actually runs remotely: the CLI orchestrates via ComputeSDK providers (multi-provider from day one). No local Docker required for the default path.
+- The platform is always-on for storage/ingestion — even local runs push results. The platform handles zero execution.
 - The scale coordinator pattern in `computesdk/benchmarks/src/scale/sdk-coordinator.ts` is the reference implementation for what `--platform` should look like.
 
 ## Authoring API
@@ -134,100 +135,94 @@ bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
 bench --platform --image my-image --total 500 --workers 4 --concurrency 10
 ```
 
-Renamed from `--remote` to `--platform` to accurately describe what it does: ship benchmarks to the first-party benchmark runner platform for execution.
+Renamed from `--remote` to `--platform` to accurately describe what it does: run benchmarks on remote compute via ComputeSDK providers.
 
-The CLI uses ComputeSDK providers directly for execution. The platform is optional (historical storage only).
+The CLI uses ComputeSDK providers directly for execution. The platform handles zero execution — it is always-on for storage/ingestion only.
 
 1. CLI discovers and loads bench files (same as local) — or uses a pre-built `--image`.
-2. CLI builds image via `provider.image.build()` (if files provided, not `--image`).
+2. CLI builds image via `compute.template.create({ dockerfile, baseImage })` (if files provided, not `--image`). This uses the unified template primitive from PR #639 — multi-provider from day one.
 3. CLI divides tasks among N workers (static range assignment).
-4. CLI launches N worker sandboxes via `provider.sandbox.create()`, each with env vars for its task range.
+4. CLI launches N worker sandboxes via `compute.sandbox.create({ template: templateId })`, each with env vars for its task range.
 5. Each worker loads bench files, executes its task range through `runBenchWorker()` (real concurrency, step barriers), and streams results back to the CLI.
 6. CLI collects results, aggregates, prints TUI/JSON.
-7. CLI destroys sandboxes via `provider.sandbox.destroy()`.
-8. (Optional) CLI pushes results to the platform for historical storage.
+7. CLI destroys sandboxes via `compute.sandbox.destroy()`.
+8. CLI pushes results to the platform for storage/ingestion (always on, even for local runs).
 
-### The first-party benchmark runner platform (optional)
+### The platform: storage/ingestion only, always on
 
-The `--platform` mode uses ComputeSDK providers directly for execution. The ComputeSDK platform (`platform.computesdk.com`) is optional — it provides historical storage and a web UI, but is not required for running benchmarks.
+The platform (`platform.computesdk.com`) handles zero execution. It is the storage and ingestion layer, always on:
 
-1. **ComputeSDK providers** (Namespace, E2B, Modal, etc.) — compute: build images, launch worker sandboxes, stream logs, destroy. The CLI talks to providers directly through ComputeSDK's provider abstraction.
+1. **ComputeSDK providers** (Namespace, E2B, Modal, etc.) — compute: build images via `template.create()`, launch worker sandboxes, stream logs, destroy. The CLI talks to providers directly through ComputeSDK's provider abstraction.
 
-2. **ComputeSDK platform** (optional) — historical run storage, result aggregation across runs, web UI, trend tracking. The CLI can optionally push results here after a run completes.
+2. **ComputeSDK platform** (always on) — run storage, result ingestion, web UI, trend tracking, regression detection. The CLI always pushes results here after a run completes, whether local or remote.
 
 This means:
-- `bench --platform` works without any platform API — just a ComputeSDK provider
-- `bench --platform --store` (optional) pushes results to the platform for history
-- The platform does not need to know about image building, VM launch, or worker coordination
+- `bench run ./file.bench.ts` (local) — runs locally, pushes results to platform
+- `bench --platform --provider namespace` (remote) — CLI orchestrates via provider, pushes results to platform
+- The platform never touches execution — no building, no launching, no worker coordination
+- The platform is NOT optional for storage — it is always on
 
-### Architecture: CLI orchestrates directly via ComputeSDK providers
+### Architecture: CLI orchestrates, platform stores
 
-If the CLI uses ComputeSDK's provider abstraction directly, the platform is not needed in the execution path. The CLI is the orchestrator. This eliminates an entire layer of complexity.
+The CLI is the execution orchestrator. The platform is the storage layer. Two separate concerns, cleanly separated.
 
 ```
 CLI -----> ComputeSDK Providers (Namespace, E2B, Modal, ...)
+  |         (execution)
   |
-  |  provider.image.build()    -> build Docker image
-  |  provider.sandbox.create() -> launch N worker sandboxes
-  |  (each worker gets a task range via env vars)
+  |  compute.template.create({ dockerfile, baseImage })  -> build image
+  |  compute.sandbox.create({ template, env })  x N     -> launch workers
   |
   |  workers execute, stream results back to CLI
-  |  provider.sandbox.destroy() -> clean up
+  |  compute.sandbox.destroy()  x N                      -> clean up
   |
   |  CLI aggregates results, prints TUI/JSON
   |
   v
- (optional) ComputeSDK Platform
-   -> store results for historical comparison
-   -> web UI for viewing runs
-   -> NOT required for execution
+ ComputeSDK Platform (always on)
+   -> POST /runs (create run record)
+   -> POST /runs/:id/results (ingest results)
+   -> web UI, trend tracking, regression detection
+   -> ZERO execution logic
 ```
 
 The CLI does everything `start.ts` does today, but as a CLI using ComputeSDK providers:
 1. Load bench files, compute entry count and total tasks
 2. Divide tasks among N workers (static assignment — each worker gets a range)
-3. Build image via `provider.image.build()` (if files provided, not `--image`)
-4. Launch N worker sandboxes via `provider.sandbox.create()`, each with env vars for its task range
+3. Build image via `compute.template.create({ dockerfile, baseImage })` (if files provided, not `--image`)
+4. Launch N worker sandboxes via `compute.sandbox.create({ template, env })`, each with env vars for its task range
 5. Workers execute their range, stream results back (stdout/IPC)
 6. CLI collects, aggregates, prints
-7. CLI destroys sandboxes via `provider.sandbox.destroy()`
+7. CLI destroys sandboxes via `compute.sandbox.destroy()`
+8. CLI pushes results to the platform (always on)
 
-No platform API calls for execution. The platform is optional — only for storing results if you want historical comparisons or a web UI.
+The platform has zero execution logic. It receives results and stores them. That's it.
 
-### What the platform is still good for (optional)
+### Worker coordination (CLI-orchestrated, no platform claiming)
 
-- Historical run storage (past results, trend tracking, regression detection)
-- Web UI for viewing runs across a team
-- Cross-run comparisons and analytics
-- Long-running scale tests where the CLI might crash (platform holds the state)
-
-For CI and local use, the CLI-only path is sufficient. The platform is an opt-in storage layer, not a required execution layer.
-
-### Worker coordination without the platform
-
-Currently, the SDK's `runWorker()` claims tasks from the platform API. Without the platform, the CLI assigns task ranges directly:
+The CLI assigns task ranges directly — no platform claiming needed:
 
 - CLI computes `totalTasks = entryCount * total`
 - CLI divides `totalTasks` among N workers: worker 0 gets tasks 0..K-1, worker 1 gets K..2K-1, etc.
 - Each worker receives its range via env vars (`BENCH_TASK_START`, `BENCH_TASK_COUNT`)
 - Workers execute their range and stream results back to the CLI
 
-This is simpler than dynamic claiming (no claim/release lifecycle, no platform round-trips). The tradeoff is no dynamic rebalancing — if one worker is slow, others can't steal its work. For benchmark workloads (uniform per-task cost), this is fine. For scale tests with variable per-task latency, dynamic claiming via the platform may still be valuable.
+This is simpler than dynamic claiming (no claim/release lifecycle, no platform round-trips). The tradeoff is no dynamic rebalancing — if one worker is slow, others can't steal its work. For benchmark workloads (uniform per-task cost), this is fine. For scale tests with variable per-task latency, dynamic claiming may still be valuable as a future enhancement.
 
-Step readiness barriers (`waitForStepReady`) need rethinking without the platform. Options:
+Step readiness barriers (`waitForStepReady`) need rethinking without the platform as a coordinator. Options:
 - CLI-orchestrated barriers: CLI waits for all workers to report step completion before signaling them to proceed
 - Provider-level coordination: use provider networking (e.g., shared volumes, message queues) for barriers
-- Platform-assisted barriers: use the platform only for barrier coordination, not for task claiming
 
 This is an open question — see Open Questions below.
 
-### Platform API shape (optional, for storage only)
+### Platform API shape (storage/ingestion, always on)
 
-If the platform is used for historical storage, it just needs:
+The platform needs endpoints for storage and ingestion only:
 
-1. `POST /runs/:id/results` — store results from a completed run (CLI pushes after aggregation)
-2. `GET /runs` — list past runs
-3. `GET /runs/:id/results` — fetch past results for comparison
+1. `POST /runs` — create a run record (CLI calls at start of run)
+2. `POST /runs/:id/results` — ingest results (CLI pushes after completion)
+3. `GET /runs` — list past runs
+4. `GET /runs/:id/results` — fetch past results for comparison
 
 The platform does NOT need endpoints for building, launching, or coordinating workers. Those happen in the CLI via ComputeSDK providers.
 
@@ -241,7 +236,7 @@ The platform does NOT need endpoints for building, launching, or coordinating wo
 bench --platform --image my-registry/bench:latest --provider namespace
 ```
 
-CLI launches worker sandboxes directly from the image via `provider.sandbox.create()`. Works with any provider. User (or CI) builds the image beforehand.
+CLI launches worker sandboxes directly from the image via `compute.sandbox.create({ template: imageRef })`. Works with any provider. User (or CI) builds the image beforehand.
 
 **Mode 2: Build from files (default)**
 
@@ -249,33 +244,20 @@ CLI launches worker sandboxes directly from the image via `provider.sandbox.crea
 bench --platform --provider namespace
 ```
 
-CLI calls `provider.image.build()` with a generated Dockerfile + bench files. Provider builds the image. CLI gets `imageRef` back. CLI launches workers from that image. No local Docker required — the provider builds on its infrastructure.
+CLI calls `compute.template.create({ dockerfile, baseImage })` with a generated Dockerfile + bench files. Provider builds the image via the unified template primitive (PR #639). CLI gets `templateId` back. CLI launches workers from that template. No local Docker required — the provider builds on its infrastructure.
 
-This requires `image.build()` on the provider (see Multi-provider section). Providers that don't support it fall back to Mode 1.
-6. CLI gets the `image_ref` from the build response
-7. Platform launches worker VMs from that `image_ref` (via Namespace instance API)
-8. Each worker VM runs `bench-worker`, claims a task range, executes entries through `runWorker()`
-
-This is the best of both worlds:
-- **No local Docker required** — Namespace builds the image on its infrastructure
-- **Uses the proven Docker image pattern** — works with any system-level dependencies, provider SDKs, etc.
-- **Blueprint caching** — blueprints are versioned; if the Dockerfile hasn't changed, the existing image is reused without rebuilding
-- **Multi-site builds** — Namespace builds per deployment site, so workers launch from a locally-cached image
-
-### Three modes
-
-**Mode 1: Pre-built image (user provides image)**
+This uses `template.create()` from PR #639, which is already multi-provider. Any provider that implements `template.create()` with build-from-spec (E2B, Modal, Daytona, Runloop, Beam, etc.) works immediately. Providers that don't support it fall back to Mode 1 (`--image`).
 
 ### Execution flow (CLI orchestrates directly)
 
 ```
 CLI                     ComputeSDK Provider (Namespace/E2B/Modal)
   |                              |
-  |  image.build(dockerfile)     |
+  |  template.create({dockerfile, baseImage})
   |  --------------------------->|
-  |  <-- imageRef ---------------|  (skip if --image provided)
+  |  <-- templateId -------------|  (skip if --image provided)
   |                              |
-  |  sandbox.create(imageRef, env: {TASK_START, TASK_COUNT, ...}) x N
+  |  sandbox.create({template, env: {TASK_START, TASK_COUNT, ...}}) x N
   |  --------------------------->|
   |  <-- sandboxes launched -----|
   |                              |
@@ -289,28 +271,21 @@ CLI                     ComputeSDK Provider (Namespace/E2B/Modal)
   |  sandbox.destroy() x N       |
   |  --------------------------->|
   |                              |
-  |  (CLI aggregates, prints)    |
+  |  CLI aggregates, prints      |
   |                              |
-  |  (optional) POST results --> ComputeSDK Platform (historical storage)
+  v
+ ComputeSDK Platform (always on)
+   POST /runs (create record)
+   POST /runs/:id/results (ingest)
 ```
 
-The CLI is the orchestrator. No platform in the execution path. The provider handles all compute (build, launch, destroy). Workers stream results back to the CLI, which aggregates and prints.
+The CLI is the orchestrator. The provider handles all compute (build, launch, destroy). Workers stream results back to the CLI, which aggregates and prints. The CLI always pushes results to the platform for storage.
 
-For `--image` mode, skip the `image.build()` step — the user provides the image reference directly.
+For `--image` mode, skip the `template.create()` step — the user provides the image reference directly.
 
-### Blueprint/image caching
+### Template/image caching
 
-If the provider supports `image.build()`, the CLI can hash the Dockerfile + bench file contents and cache the built image. On subsequent runs with the same content, skip the build. This gives fast iteration without manual image management. The caching mechanism is provider-specific (Namespace uses blueprints, other providers may use tags or digests).
-
-### Blueprint caching strategy
-
-Namespace blueprints are versioned. The CLI can hash the Dockerfile content + bench file contents and use that hash as the blueprint name. On subsequent runs:
-
-1. CLI computes the hash
-2. CLI calls `FetchBlueprint(hash)` — if it exists and `State = STATE_READY`, skip the build
-3. If not, `CreateBlueprint` + `Build`
-
-This gives fast iteration (cached builds) without requiring the user to manage image versions manually.
+If the provider supports `template.create()` with build-from-spec, the CLI can hash the Dockerfile + bench file contents and cache the built template. On subsequent runs with the same content, skip the build. This gives fast iteration without manual image management. The caching mechanism is provider-specific (Namespace uses blueprints, E2B uses template IDs, etc.).
 
 ### What about the existing scale coordinator?
 
@@ -538,74 +513,47 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Remove: all `@computesdk/bench` re-exports from `index.ts`
 - Remove: `commander` dependency
 - Fix: changeset bumps to `patch`
-- This is a clean, shippable local benchmark runner
+- CLI pushes results to the platform for storage/ingestion (always on, even for local runs)
+- This is a clean, shippable local benchmark runner with platform storage
 
-### Phase 2: Add `defineTask`/`defineStep` to the CLI
+### Phase 2: Add `defineTask`/`defineStep` + `runBenchWorker` to the SDK
 
-- Re-export `defineTask`/`defineStep` from `@computesdk/bench`
+- Re-export `defineTask`/`defineStep` from `@computesdk/bench` in the CLI
+- Implement `runBenchWorker()` in `@computesdk/bench` (translates `bench()` entries to single-step tasks, passes `defineTask()` entries through with full step graph)
 - Extend the local runner to handle `defineTask` entries (execute steps, record per-step latency)
 - Extend the reporter to show per-step results
 - Extend `bench list` to show steps
 
-### Phase 3: Add `runBenchWorker` to the SDK
+### Phase 3: Add `--platform` mode to the CLI (multi-provider execution)
 
-- Implement `runBenchWorker()` in `@computesdk/bench`
-- Translates `bench()` entries to single-step tasks
-- Passes `defineTask()` entries through with full step graph
-- Uses existing `mapPool` for concurrency, existing heartbeat/flush infrastructure
-
-### Phase 4: Add `--platform --image` mode to the CLI (pre-built image, CLI orchestrates)
-
-- CLI accepts `--image <image>` and `--provider <name>` flags
-- CLI divides tasks among N workers (static range assignment)
-- CLI launches N worker sandboxes via `provider.sandbox.create()` with the image
+- CLI accepts `--provider <name>`, `--image <ref>`, `--workers <n>`, `--total <n>`, `--concurrency <n>` flags
+- `--image` mode: CLI launches N worker sandboxes via `compute.sandbox.create({ template: imageRef, env })`
+- Build-from-files mode: CLI calls `compute.template.create({ dockerfile, baseImage })` (from PR #639's unified template primitive), then launches workers from the built template
+- CLI divides tasks among N workers (static range assignment via env vars)
 - Each worker executes its range via `runBenchWorker()`, streams results back to CLI
-- CLI aggregates results, prints TUI, destroys sandboxes
-- No platform API needed — CLI orchestrates directly via ComputeSDK provider
+- CLI aggregates results, prints TUI, destroys sandboxes, pushes results to platform
+- Multi-provider from day one — works with any ComputeSDK provider that implements `template.create()` (E2B, Modal, Daytona, Runloop, Beam, etc.)
 - This replaces `start.ts` from `benchmarks/src/scale`
 
-### Phase 5: Migrate scale tests to the CLI
+### Phase 4: Migrate scale tests to the CLI
 
 - Replace `benchmarks/src/scale/sdk-coordinator.ts` with a `scale.bench.ts` file using `defineTask`/`defineStep`
-- Replace `start.ts` with `bench --platform --image --provider namespace`
+- Replace `start.ts` with `bench --platform --provider namespace --image <scale-image>`
 - The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
 - Barrier coordination: CLI orchestrates barriers (wait for all workers to report step completion before signaling proceed)
 
-### Phase 6: Add `image.build()` to ComputeSDK provider interface
-
-- Extend the ComputeSDK `Provider` interface with `image.build()` (build from Dockerfile or APT packages)
-- Implement `image.build()` for the Namespace provider (wraps `ImageService.CreateBlueprint` + `Build`)
-- Other providers can implement `image.build()` later (E2B, Modal, etc.)
-- Providers that don't support `image.build()` fall back to `--image` mode (pre-built image)
-
-### Phase 7: Add `--platform` (build from files) to the CLI
-
-- `bench --platform` (without `--image`) calls `provider.image.build()` with bench files + generated Dockerfile
-- Provider builds the image, CLI gets `imageRef` back
-- CLI launches workers from the built image (same as Phase 4)
-- Image caching: hash Dockerfile + bench file contents, skip rebuild if cached
-- No local Docker required — the provider builds on its infrastructure
-- Multi-provider: works with any ComputeSDK provider that implements `image.build()`
-
-### Phase 8: Optional platform storage (future)
-
-- `bench --platform --store` pushes results to the ComputeSDK platform after a run
-- Platform stores historical runs for trend tracking and regression detection
-- Web UI for viewing runs across a team
-- Platform is optional — not required for execution
-
 ## Open Questions
 
-1. **ComputeSDK provider interface for image build.** The current `Provider` interface has `sandbox.create()` (image run) but no `image.build()`. What should the `image.build()` signature look like? Should it support Dockerfile content, build context (tarball/zip), APT packages, or all of the above? How does build context reach the provider's builder (upload, git URL, inline)?
+1. **Namespace `template.create()` implementation.** PR #639 adds the unified `template` primitive to the Provider interface, but Namespace is listed as Tier 3 ("not-implemented") in the feature matrix. Namespace needs a `template` block added that wraps `ImageService.CreateBlueprint` + `Build` for build-from-spec mode. This is the first provider implementation needed for `bench --platform --provider namespace` (build-from-files mode).
 
-2. **Provider capability detection.** Not all providers will support `image.build()`. Should the CLI detect this at runtime and fall back to `--image` mode? Or should the API advertise capabilities per provider?
+2. **Provider capability detection.** Not all providers support `template.create()` with build-from-spec. Should the CLI detect this at runtime and fall back to `--image` mode? Or should the API advertise capabilities per provider?
 
 3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker sandbox. How do secrets flow from the user's environment to the worker sandbox? Secrets should not be baked into the image — they should be injected at sandbox launch time via env vars. The CLI needs a `--env` or `--secret` flag.
 
-4. **Step readiness barriers without the platform.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Without the platform as a coordination point, how do workers coordinate barriers? Options: CLI-orchestrated barriers (CLI waits for all workers to report, then signals proceed), provider-level networking (shared volumes, message queues), or use the platform only for barrier coordination. This is the main open question for the platform-less architecture.
+4. **Step readiness barriers without the platform.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Without the platform as a coordination point, how do workers coordinate barriers? Options: CLI-orchestrated barriers (CLI waits for all workers to report, then signals proceed), or provider-level networking (shared volumes, message queues).
 
 5. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
 
-6. **Image lifecycle.** Should the CLI cache built images across runs (content-addressed by file hash)? What is the retention/cleanup policy? This applies to both Namespace blueprints and any provider's image build output.
+6. **Template lifecycle.** Should the CLI cache built templates across runs (content-addressed by file hash)? What is the retention/cleanup policy? This applies to all providers' template build output.
 
 7. **CLI crash recovery.** If the CLI crashes mid-run, worker sandboxes may be orphaned. Should the CLI register cleanup handlers (SIGTERM/SIGINT) to destroy sandboxes? Should sandboxes have a TTL so they self-destruct?

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -25,7 +25,7 @@ This doc proposes a unified design that fixes all three. Since there is zero ext
 - One CLI: `bench` discovers files, loads entries, runs them locally or on the platform. No fork-and-reimplement.
 - Remote execution that actually runs remotely: the CLI orchestrates via ComputeSDK providers (multi-provider from day one). No local Docker required for the default path.
 - The platform is always-on for storage/ingestion — even local runs push results. The platform handles zero execution.
-- The scale coordinator pattern in `computesdk/benchmarks/src/scale/sdk-coordinator.ts` is the reference implementation for what `--platform` should look like.
+- The scale coordinator pattern in `computesdk/benchmarks/src/scale/sdk-coordinator.ts` is the reference implementation for what remote execution should look like.
 
 ## Authoring API
 
@@ -128,16 +128,15 @@ bench run benchmarks/*.bench.ts
 
 The local runner is the existing `runner.ts` from PR #636, extended to handle `defineTask` entries in addition to `bench()` entries.
 
-### Remote mode (`--platform`)
+### Remote mode (`--provider`)
 
 ```
-bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
-bench --platform --image my-image --total 500 --workers 4 --concurrency 10
+bench run --provider namespace --image ghcr.io/computesdk/scale-coordinator:latest
+bench run --provider namespace --image my-image --total 500 --workers 4 --concurrency 10
+bench run --provider e2b --workers 4
 ```
 
-Renamed from `--remote` to `--platform` to accurately describe what it does: run benchmarks on remote compute via ComputeSDK providers.
-
-The CLI uses ComputeSDK providers directly for execution. The platform handles zero execution — it is always-on for storage/ingestion only.
+The presence of `--provider` triggers remote execution. Without it, benchmarks run locally in-process. The CLI uses ComputeSDK providers directly for execution. The platform handles zero execution — it is always-on for storage/ingestion only.
 
 1. CLI discovers and loads bench files (same as local) — or uses a pre-built `--image`.
 2. CLI builds image via `compute.template.create({ dockerfile, baseImage })` (if files provided, not `--image`). This uses the unified template primitive from PR #639 — multi-provider from day one.
@@ -154,13 +153,13 @@ The platform (`platform.computesdk.com`) handles zero execution. It is the stora
 
 1. **ComputeSDK providers** (Namespace, E2B, Modal, etc.) — compute: build images via `template.create()`, launch worker sandboxes, stream logs, destroy. The CLI talks to providers directly through ComputeSDK's provider abstraction.
 
-2. **ComputeSDK platform** (always on) — run storage, result ingestion, web UI, trend tracking, regression detection. The CLI always pushes results here after a run completes, whether local or remote.
+2. **ComputeSDK platform** (always on) — run storage, result ingestion, web UI, trend tracking, regression detection. The CLI always pushes results here after a run completes, whether local or remote. Platform credentials are required — the CLI errors if they are missing.
 
 This means:
 - `bench run ./file.bench.ts` (local) — runs locally, pushes results to platform
-- `bench --platform --provider namespace` (remote) — CLI orchestrates via provider, pushes results to platform
+- `bench run --provider namespace ./file.bench.ts` (remote) — CLI orchestrates via provider, pushes results to platform
 - The platform never touches execution — no building, no launching, no worker coordination
-- The platform is NOT optional for storage — it is always on
+- Ingestion is forced — every run is stored
 
 ### Architecture: CLI orchestrates, platform stores
 
@@ -228,12 +227,12 @@ The platform does NOT need endpoints for building, launching, or coordinating wo
 
 ## Remote Execution: Ship Files vs Docker Image
 
-### Two modes, both via ComputeSDK providers
+### Two modes, both via ComputeSDK providers (`--provider` triggers remote)
 
 **Mode 1: Pre-built image**
 
 ```
-bench --platform --image my-registry/bench:latest --provider namespace
+bench run --provider namespace --image my-registry/bench:latest
 ```
 
 CLI launches worker sandboxes directly from the image via `compute.sandbox.create({ template: imageRef })`. Works with any provider. User (or CI) builds the image beforehand.
@@ -241,7 +240,7 @@ CLI launches worker sandboxes directly from the image via `compute.sandbox.creat
 **Mode 2: Build from files (default)**
 
 ```
-bench --platform --provider namespace
+bench run --provider namespace
 ```
 
 CLI calls `compute.template.create({ dockerfile, baseImage })` with a generated Dockerfile + bench files. Provider builds the image via the unified template primitive (PR #639). CLI gets `templateId` back. CLI launches workers from that template. No local Docker required — the provider builds on its infrastructure.
@@ -289,9 +288,9 @@ If the provider supports `template.create()` with build-from-spec, the CLI can h
 
 ### What about the existing scale coordinator?
 
-The existing `computesdk/benchmarks/src/scale` flow (build Docker image, push, `start.ts` launches VMs) continues to work for scale testing. The CLI's `--platform --image` path is the integration point: the scale coordinator image is built in CI, and `bench --platform --image <scale-image>` launches it through the platform API instead of the custom `start.ts` script.
+The existing `computesdk/benchmarks/src/scale` flow (build Docker image, push, `start.ts` launches VMs) continues to work for scale testing. The CLI's `--provider --image` path is the integration point: the scale coordinator image is built in CI, and `bench run --provider namespace --image <scale-image>` launches it through the CLI instead of the custom `start.ts` script.
 
-Over time, `start.ts` can be replaced by `bench --platform --image` + a `benchmarks/scale.bench.ts` file that uses `defineTask`/`defineStep`, unifying the scale test under the same CLI.
+Over time, `start.ts` can be replaced by `bench run --provider namespace --image` + a `benchmarks/scale.bench.ts` file that uses `defineTask`/`defineStep`, unifying the scale test under the same CLI.
 
 ## CLI Surface
 
@@ -300,7 +299,6 @@ Over time, `start.ts` can be replaced by `bench --platform --image` + a `benchma
 ```
 bench [run] [files...]     Run benchmarks (default subcommand)
 bench list [files...]      List discovered benchmarks without running
-bench --platform [files..] Run on the benchmark runner platform
 ```
 
 ### Flags
@@ -314,16 +312,13 @@ Local flags:
 --cwd <path>             Working directory
 ```
 
-Platform flags:
+Remote flags (presence of --provider triggers remote execution):
 ```
---platform               Run on the benchmark runner platform
+--provider <name>        Compute provider (namespace, e2b, modal, etc.)
 --total <n>              Replications per benchmark function (default 100)
---workers <n>            Worker VMs to spawn (default 1)
+--workers <n>            Worker sandboxes to spawn (default 1)
 --concurrency <n>        Parallel task slots per worker (default 1)
---participant <slug>     Participant identifier (default bench-cli)
---slug <slug>            Benchmark slug (default derived from filename)
---run-name <name>        Run display name (default derived from filename)
---image <image>          Pre-built Docker image (skips platform build)
+--image <image>          Pre-built Docker image (skips template build)
 --api-key <key>          Platform API key (default env COMPUTESDK_ADMIN_API_KEY)
 --base-url <url>         Platform base URL
 --poll-interval <ms>     Progress poll interval (default 1000)
@@ -393,7 +388,7 @@ Internally:
 - The existing `mapPool(taskIndices, concurrency, ...)` provides parallelism.
 - Results include rich metrics in `TaskResultRecord.data` (hz, meanMs, p50, stdev, rme for `bench()` entries; per-step latencies for `defineTask()` entries).
 
-This is the function the CLI calls in `--platform` mode. It replaces the current `runRemoteWorker()` in `bench-cli/src/remote-worker.ts`.
+This is the function the CLI calls in remote mode (`--provider`). It replaces the current `runRemoteWorker()` in `bench-cli/src/remote-worker.ts`.
 
 ## Package Structure
 
@@ -438,7 +433,7 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 
 `bench()` entries show ops/sec. `defineTask()` entries show per-step latencies.
 
-### Platform TUI
+### Remote TUI
 
 ```
  bench  planning  sandbox-latency on bench-cli
@@ -524,7 +519,7 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 - Extend the reporter to show per-step results
 - Extend `bench list` to show steps
 
-### Phase 3: Add `--platform` mode to the CLI (multi-provider execution)
+### Phase 3: Add remote execution to the CLI (multi-provider, `--provider` trigger)
 
 - CLI accepts `--provider <name>`, `--image <ref>`, `--workers <n>`, `--total <n>`, `--concurrency <n>` flags
 - `--image` mode: CLI launches N worker sandboxes via `compute.sandbox.create({ template: imageRef, env })`
@@ -538,13 +533,13 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 ### Phase 4: Migrate scale tests to the CLI
 
 - Replace `benchmarks/src/scale/sdk-coordinator.ts` with a `scale.bench.ts` file using `defineTask`/`defineStep`
-- Replace `start.ts` with `bench --platform --provider namespace --image <scale-image>`
+- Replace `start.ts` with `bench run --provider namespace --image <scale-image>`
 - The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
 - Barrier coordination: CLI orchestrates barriers (wait for all workers to report step completion before signaling proceed)
 
 ## Open Questions
 
-1. **Namespace `template.create()` implementation.** PR #639 adds the unified `template` primitive to the Provider interface, but Namespace is listed as Tier 3 ("not-implemented") in the feature matrix. Namespace needs a `template` block added that wraps `ImageService.CreateBlueprint` + `Build` for build-from-spec mode. This is the first provider implementation needed for `bench --platform --provider namespace` (build-from-files mode).
+1. **Namespace `template.create()` implementation.** PR #639 adds the unified `template` primitive to the Provider interface, but Namespace is listed as Tier 3 ("not-implemented") in the feature matrix. Namespace needs a `template` block added that wraps `ImageService.CreateBlueprint` + `Build` for build-from-spec mode. This is the first provider implementation needed for `bench run --provider namespace` (build-from-files mode).
 
 2. **Provider capability detection.** Not all providers support `template.create()` with build-from-spec. Should the CLI detect this at runtime and fall back to `--image` mode? Or should the API advertise capabilities per provider?
 
@@ -552,7 +547,7 @@ The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import ev
 
 4. **Step readiness barriers without the platform.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Without the platform as a coordination point, how do workers coordinate barriers? Options: CLI-orchestrated barriers (CLI waits for all workers to report, then signals proceed), or provider-level networking (shared volumes, message queues).
 
-5. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
+5. **Multiple files in remote mode.** Local mode can run multiple files. Should remote mode (`--provider`) also support multiple files (build all into one image, run all), or should it be limited to one file per run for simplicity?
 
 6. **Template lifecycle.** Should the CLI cache built templates across runs (content-addressed by file hash)? What is the retention/cleanup policy? This applies to all providers' template build output.
 

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -1,0 +1,481 @@
+# Design Doc: Unified Bench CLI + SDK
+
+## Status
+
+Draft — July 2026
+
+## Problem
+
+PR #636 introduces `@computesdk/bench-cli`, a vitest-style runner for `*.bench.ts` files. The local runner is solid. The `--remote` mode and the relationship between the CLI and the `@computesdk/bench` SDK are not.
+
+Three concrete problems:
+
+1. **Two worker implementations that do not compose.** The SDK's `runWorker()` has real concurrency (`mapPool`), automatic heartbeats, batched flushing, and step-level concurrency barriers. The CLI's `--remote` mode ignores all of that and reimplements a sequential loop using `BenchmarkReporter.claim()` directly. `--concurrency` does nothing because the CLI never calls the code that implements it.
+
+2. **Two authoring APIs with no clear boundary.** `bench()`/`describe()` is the simple path (ops/sec, local). `defineTask()`/`defineStep()` is the platform path (multi-step, remote). They share an import path but not an execution model. Users do not know which to use or when.
+
+3. **`--remote` does not run remotely.** Workers fork as local child processes. The only thing remote is the platform API. The name creates a false expectation.
+
+This doc proposes a unified design that fixes all three. Since there is zero external usage of either package, we can redesign freely.
+
+## Design Goals
+
+- One authoring API with two levels of complexity: `bench()` for micro-benchmarks, `defineTask()`/`defineStep()` for multi-phase workloads. Both coexist in the same `*.bench.ts` files.
+- One execution path: the SDK's `runWorker()` handles concurrency, heartbeats, and flushing for both local and remote runs. The CLI does not reimplement worker logic.
+- One CLI: `bench` discovers files, loads entries, runs them locally or on the platform. No fork-and-reimplement.
+- Remote execution that actually runs remotely: bench files ship to the platform, the platform builds and runs them in sandboxes. No local Docker required for the default path.
+- The scale coordinator pattern in `computesdk/benchmarks/src/scale/sdk-coordinator.ts` is the reference implementation for what `--remote` should look like.
+
+## Authoring API
+
+### Two primitives, one file
+
+```ts
+// benchmarks/sandbox-latency.bench.ts
+import { bench, describe, defineTask, defineStep } from '@computesdk/bench-cli';
+
+// Simple: measure ops/sec
+describe('string operations', () => {
+  bench('concatenation', () => 'a' + 'b' + 'c');
+  bench('template literal', () => `${'a'}${'b'}${'c'}`);
+});
+
+// Advanced: multi-phase workload with per-step latency
+defineTask('sandbox.lifecycle', [
+  defineStep('create', async ({ state }) => {
+    state.sandbox = await compute.sandbox.create();
+  }),
+  defineStep('exec.initial', async ({ state }) => {
+    await state.sandbox.runCommand('node -v');
+  }),
+  defineStep('sandbox.live', async () => {
+    await new Promise(r => setTimeout(r, 90_000));
+  }),
+  defineStep('exec.final', async ({ state }) => {
+    await state.sandbox.runCommand('node -v');
+  }),
+  defineStep('destroy', async ({ state }) => {
+    await state.sandbox?.destroy();
+  }),
+]);
+```
+
+### How they relate
+
+| Primitive | Measures | Use case | Platform mapping |
+|-----------|----------|----------|------------------|
+| `bench(name, fn)` | ops/sec, mean, p50, stdev, rme | Micro-benchmarks, regression detection | Single-step task, `total` replications |
+| `describe(name, fn)` | (grouping only) | Organizing related benches | Group label in task metadata |
+| `defineTask(name, steps[])` | Per-step latency, status per step | Multi-phase workloads (sandbox lifecycle, API load tests) | Multi-step task, `total` replications |
+| `defineStep(name, fn)` | Latency for one phase | Sub-unit of a task | `TaskStepRecord` in `TaskResultRecord` |
+
+### What is removed from the public API
+
+- `defineBench()` — was a wrapper around `defineWorker()` with a slug. The CLI handles slug/worker creation. Users never call this.
+- `defineWorker()` — was a factory for claiming a worker and running a task. The CLI/SDK handles this internally. Users never call this.
+
+These become internal SDK functions used by the worker execution layer. They are not exported from `@computesdk/bench-cli`.
+
+### Options
+
+Both primitives accept the same options shape:
+
+```ts
+interface BenchOptions {
+  iterations?: number;    // measured iterations (default 100)
+  warmup?: number;        // discarded warmup iterations (default 5)
+  setup?: () => void | Promise<void>;
+  teardown?: () => void | Promise<void>;
+}
+```
+
+`defineTask` additionally accepts per-task options:
+
+```ts
+interface DefineTaskOptions {
+  cleanup?: (ctx: CleanupContext) => Promise<void> | void;
+}
+```
+
+`defineStep` accepts step-level options (unchanged from current SDK):
+
+```ts
+interface DefineStepOptions {
+  reportConcurrency?: boolean;
+  concurrency?: number;
+  readiness?: 'poll' | 'internal';
+  readyPollIntervalMs?: number;
+  readyTimeoutMs?: number;
+}
+```
+
+## Execution Model
+
+### Local mode (default)
+
+```
+bench
+bench run benchmarks/*.bench.ts
+```
+
+1. CLI discovers `*.bench.ts` files under `./benchmarks/` (or explicit paths).
+2. CLI loads each file via `tsx`, collecting registered `bench()` and `defineTask()` entries into a fresh per-file registry.
+3. CLI runs entries sequentially through the local runner:
+   - `bench()` entries: measure wall-clock time per iteration, compute ops/sec, mean, p50, stdev, rme.
+   - `defineTask()` entries: execute steps in order, record per-step latency and status.
+4. Reporter prints results (TUI or JSON).
+
+The local runner is the existing `runner.ts` from PR #636, extended to handle `defineTask` entries in addition to `bench()` entries.
+
+### Remote mode (`--platform`)
+
+```
+bench --platform
+bench --platform --total 500 --workers 4 --concurrency 10
+```
+
+Renamed from `--remote` to `--platform` to accurately describe what it does: orchestrate the run on the ComputeSDK platform.
+
+1. CLI discovers and loads bench files (same as local).
+2. CLI ships the bench files + `package.json` + lockfile to the platform (see Remote Execution below).
+3. Platform builds the project in a sandbox (install deps, compile TS).
+4. Platform creates a benchmark run, plans workers, and spawns worker sandboxes.
+5. Each worker sandbox loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
+   - Real concurrency via `mapPool(taskIndices, concurrency, ...)`
+   - Automatic heartbeats
+   - Batched result flushing
+   - Step-level concurrency barriers (`waitForStepReady`)
+6. CLI polls progress and prints a TUI until all workers finish.
+7. Platform aggregates results; CLI prints final summary.
+
+The key change: the CLI does NOT fork local processes. It ships files to the platform, and the platform runs workers in sandboxes. The SDK's `runWorker()` is the single execution path for remote work.
+
+## Remote Execution: Ship Files vs Docker Image
+
+### The question
+
+Should `--platform` build a Docker image locally and push it, or should it ship source files to the platform and let the platform build and run them?
+
+### Recommendation: ship files by default, Docker image as opt-in
+
+**Default path: ship files to the platform.**
+
+```
+bench --platform
+```
+
+The CLI packages the bench files, `package.json`, and lockfile, then uploads them to the platform. The platform builds the project in a ComputeSDK sandbox (the product running its own benchmarks) and spawns worker sandboxes from the build output.
+
+Why this is the right default:
+
+1. **No local Docker required.** The vitest mental model is "run a command, it works." Asking users to install Docker, authenticate to a registry, and wait for image builds breaks that.
+
+2. **Iteration speed.** Shipping TS files + installing deps in a sandbox is much faster than build -> push -> pull -> run, especially with cached `node_modules` layers on the platform.
+
+3. **Dogfooding.** ComputeSDK is a sandbox execution platform. Using it to build and run its own benchmarks is the strongest possible proof of the product.
+
+4. **The scale test is the exception, not the rule.** The existing `benchmarks/src/scale` Dockerfile exists because scale testing needs specific system-level access (provider SDKs, API keys, `/proc` access for metrics). Simple `bench()` micro-benchmarks just need Node.js and `npm install`. The default should optimize for the common case.
+
+**Opt-in path: pre-built Docker image.**
+
+```
+bench --platform --image ghcr.io/computesdk/scale-coordinator:latest
+```
+
+For workloads that need system-level dependencies, custom runtimes, or specific provider SDKs, users can provide a pre-built image. The platform launches worker containers from that image. The image's entrypoint should be `bench-worker` (or a user-specified command that calls `runWorker`).
+
+This mirrors the existing `benchmarks/src/scale` flow: build the image in CI, push to a registry, point the CLI at it.
+
+### Platform build flow (ship-files path)
+
+```
+CLI                          Platform API                    Sandbox
+ |                               |                              |
+ |  POST /benchmarks/:slug       |                              |
+ |  POST /runs (totalTasks)      |                              |
+ |  POST /runs/:id/artifact      |                              |
+ |    (upload bench files zip)   |                              |
+ |  POST /runs/:id/build         |                              |
+ |                               |  create build sandbox        |
+ |                               |  -> install deps             |
+ |                               |  -> compile TS               |
+ |                               |  <- build ready              |
+ |                               |  spawn worker sandboxes      |
+ |                               |    from build output         |
+ |                               |                              |
+ |  GET /runs/:id/progress       |                              |
+ |  <--- progress updates ------+                              |
+ |                               |                              |
+ |  GET /runs/:id/results        |                              |
+ |  <--- final summary ---------+                              |
+```
+
+The `POST /runs/:id/build` endpoint is new. It tells the platform to take the uploaded artifact (bench files + package.json), build it in a sandbox, and spawn workers from the result. This keeps the build logic on the platform side, where it can be cached, shared across workers, and reproduced.
+
+### What about the existing scale coordinator?
+
+The existing `computesdk/benchmarks/src/scale` flow (build Docker image, push, `start.ts` launches VMs) continues to work for scale testing. The CLI's `--platform --image` path is the integration point: the scale coordinator image is built in CI, and `bench --platform --image <scale-image>` launches it through the platform API instead of the custom `start.ts` script.
+
+Over time, `start.ts` can be replaced by `bench --platform --image` + a `benchmarks/scale.bench.ts` file that uses `defineTask`/`defineStep`, unifying the scale test under the same CLI.
+
+## CLI Surface
+
+### Commands
+
+```
+bench [run] [files...]     Run benchmarks (default subcommand)
+bench list [files...]      List discovered benchmarks without running
+bench --platform [files..] Run on the ComputeSDK platform
+```
+
+### Flags
+
+Local flags:
+```
+-i, --iterations <n>     Iterations per benchmark (default 100)
+-w, --warmup <n>         Warmup iterations (default 5)
+-r, --reporter <fmt>     Reporter: default | json
+--bail                   Stop on first failure
+--cwd <path>             Working directory
+```
+
+Platform flags:
+```
+--platform               Run on the ComputeSDK platform
+--total <n>              Replications per benchmark function (default 100)
+--workers <n>            Worker sandboxes to spawn (default 1)
+--concurrency <n>        Parallel task slots per worker (default 1)
+--participant <slug>     Participant identifier (default bench-cli)
+--slug <slug>            Benchmark slug (default derived from filename)
+--run-name <name>        Run display name (default derived from filename)
+--image <image>          Pre-built Docker image (skips platform build)
+--api-key <key>          Platform API key (default env COMPUTESDK_ADMIN_API_KEY)
+--base-url <url>         Platform base URL
+--poll-interval <ms>     Progress poll interval (default 1000)
+--timeout <seconds>      Wall-clock timeout (default 0 = unlimited)
+```
+
+General:
+```
+-h, --help               Show help
+-V, --version            Print version
+```
+
+### `bench list` output
+
+```
+benchmarks/strings.bench.ts  (3)
+  • string operations > concatenation
+  • string operations > template literal
+  • string operations > Array#join
+
+benchmarks/sandbox.bench.ts  (1)
+  • sandbox.lifecycle [5 steps: create, exec.initial, sandbox.live, exec.final, destroy]
+
+4 benchmark(s) across 2 file(s).
+```
+
+Both `bench()` and `defineTask()` entries are listed. Steps are shown for `defineTask` entries so users can see the structure.
+
+## SDK Changes (`@computesdk/bench`)
+
+### What stays
+
+- `BenchmarkClient` interface and `createBenchmarkClient()` — HTTP plumbing, unchanged
+- `BenchmarkReporter` class — claim/flush/heartbeat mechanics, unchanged
+- `runWorker()` / `runBenchmarkWorker()` — the concurrent worker execution engine, unchanged
+- `TaskResultRecord`, `TaskStepRecord`, `BenchmarkAssignment` — platform types, unchanged
+
+### What changes
+
+- `defineBench()` and `defineWorker()` are removed from the public exports. They become internal functions used by the CLI/worker layer.
+- `defineTask()` and `defineStep()` remain public. They are the advanced authoring primitives.
+- The worker execution layer gains a new function: `runBenchWorker(options)` — like `runWorker()` but accepts bench entries (`BenchmarkEntry[]`) instead of a `DefinedTask`. Each `bench()` entry is internally translated to a single-step task. `defineTask()` entries pass through with their full step graph.
+
+### New: `runBenchWorker`
+
+```ts
+interface RunBenchWorkerOptions {
+  benchmarkSlug: string;
+  runId: string;
+  participantSlug: string;
+  entries: readonly BenchmarkEntry[];  // bench() and defineTask() entries
+  total: number;                       // replications per entry
+  concurrency?: number;
+  batchSize?: number;
+  apiKey?: string;
+  baseUrl?: string;
+  onResult?: (record: TaskResultRecord) => void;
+}
+
+async function runBenchWorker(options: RunBenchWorkerOptions): Promise<RunWorkerResult>;
+```
+
+Internally:
+- Each `bench()` entry becomes a task with a single step (`fn` is the step function).
+- Each `defineTask()` entry becomes a task with its steps.
+- Task index -> entry mapping: `benchIdx = Math.floor(taskIndex / total)`, `repIdx = taskIndex % total`.
+- The existing `mapPool(taskIndices, concurrency, ...)` provides parallelism.
+- Results include rich metrics in `TaskResultRecord.data` (hz, meanMs, p50, stdev, rme for `bench()` entries; per-step latencies for `defineTask()` entries).
+
+This is the function the CLI calls in `--platform` mode. It replaces the current `runRemoteWorker()` in `bench-cli/src/remote-worker.ts`.
+
+## Package Structure
+
+### `@computesdk/bench` (SDK)
+
+- `createBenchmarkClient`, `BenchmarkClient`, `BenchmarkReporter` — platform plumbing
+- `runWorker`, `runBenchmarkWorker` — low-level worker execution
+- `runBenchWorker` — new, bench-entry-aware worker execution
+- `defineTask`, `defineStep` — advanced authoring primitives
+- Types: `TaskResultRecord`, `TaskStepRecord`, `BenchmarkAssignment`, `RunProgress`, etc.
+- NOT exported: `defineBench`, `defineWorker` (internal)
+
+### `@computesdk/bench-cli` (CLI)
+
+- `bench`, `describe` — simple authoring primitives
+- `defineTask`, `defineStep` — re-exported from `@computesdk/bench` (advanced authoring)
+- `runCommand`, `listCommand` — CLI commands
+- `discoverBenchFiles`, `loadBenchFile` — file discovery and loading
+- `runBenchmarks`, `runSingleBenchmark` — local execution
+- `createReporter`, `DefaultReporter`, `JsonReporter` — output
+- `runCli` — CLI entry point
+- Types: `BenchmarkEntry`, `BenchmarkResult`, `BenchOptions`, etc.
+
+The CLI re-exports `defineTask`/`defineStep` from the SDK so users can import everything from one package. It does NOT re-export `defineBench`/`defineWorker`/`createBenchmarkClient`/`BenchmarkReporter` — those are internal.
+
+## Reporter
+
+### Local TUI
+
+```
+ bench  running 2 file(s)
+  benchmarks/strings.bench.ts
+  benchmarks/sandbox.bench.ts
+
+  ✓ concatenation  12.4M ops/sec  (0.08 µs / iter)
+  ✓ template literal  8.2M ops/sec  (0.12 µs / iter)
+  ✓ Array#join  3.1M ops/sec  (0.32 µs / iter)
+  ✓ sandbox.lifecycle  [create: 420ms, exec.initial: 12ms, live: 90.0s, exec.final: 8ms, destroy: 180ms]
+
+ ✓ 4 benchmark(s) passed in 92.1s across 2 file(s)
+```
+
+`bench()` entries show ops/sec. `defineTask()` entries show per-step latencies.
+
+### Platform TUI
+
+```
+ bench  planning  sandbox-latency on bench-cli
+  file:        benchmarks/sandbox.bench.ts
+  benchmarks:  3
+  total/bench: 500
+  totalTasks:  1500
+  workers:     4
+  concurrency: 10
+
+ bench  run run-76 started. building on platform...
+
+ progress  status=in_progress  workers=4/4  tasks=750/1500  errors=2
+```
+
+### JSON output (`--reporter json`)
+
+```json
+{
+  "summaries": [
+    {
+      "file": "benchmarks/strings.bench.ts",
+      "results": [
+        {
+          "id": "string operations / concatenation",
+          "name": "concatenation",
+          "iterations": 100,
+          "hz": 12400000,
+          "meanMs": 0.00008,
+          "p50Ms": 0.00008,
+          "stdevMs": 0.00001,
+          "rme": 0.012,
+          "status": "success"
+        }
+      ],
+      "totalMs": 12.4,
+      "pass": 3,
+      "failed": 0
+    },
+    {
+      "file": "benchmarks/sandbox.bench.ts",
+      "results": [
+        {
+          "id": "sandbox.lifecycle",
+          "name": "sandbox.lifecycle",
+          "steps": [
+            { "name": "create", "latencyMs": 420, "status": "success" },
+            { "name": "exec.initial", "latencyMs": 12, "status": "success" },
+            { "name": "sandbox.live", "latencyMs": 90000, "status": "success" },
+            { "name": "exec.final", "latencyMs": 8, "status": "success" },
+            { "name": "destroy", "latencyMs": 180, "status": "success" }
+          ],
+          "status": "success",
+          "pass": 1,
+          "failed": 0
+        }
+      ],
+      "totalMs": 90620,
+      "pass": 1,
+      "failed": 0
+    }
+  ]
+}
+```
+
+## Migration Path
+
+### Phase 1: Ship the local runner (from PR #636, trimmed)
+
+- Keep: `bench()`, `describe()`, DSL, discovery, loader, local runner, reporter
+- Remove: `--remote` mode, `remote.ts`, `remote-worker.ts`, `remote-worker-entry.ts`, `bench-worker` binary
+- Remove: all `@computesdk/bench` re-exports from `index.ts`
+- Remove: `commander` dependency
+- Fix: changeset bumps to `patch`
+- This is a clean, shippable local benchmark runner
+
+### Phase 2: Add `defineTask`/`defineStep` to the CLI
+
+- Re-export `defineTask`/`defineStep` from `@computesdk/bench`
+- Extend the local runner to handle `defineTask` entries (execute steps, record per-step latency)
+- Extend the reporter to show per-step results
+- Extend `bench list` to show steps
+
+### Phase 3: Add `runBenchWorker` to the SDK
+
+- Implement `runBenchWorker()` in `@computesdk/bench`
+- Translates `bench()` entries to single-step tasks
+- Passes `defineTask()` entries through with full step graph
+- Uses existing `mapPool` for concurrency, existing heartbeat/flush infrastructure
+
+### Phase 4: Add `--platform` mode to the CLI
+
+- CLI ships files to platform (new `POST /runs/:id/build` endpoint)
+- Platform builds in sandbox, spawns worker sandboxes
+- Worker sandboxes call `runBenchWorker()` with the loaded entries
+- CLI polls progress, prints TUI
+- Add `--image` flag for pre-built Docker image path
+
+### Phase 5: Migrate scale tests
+
+- Replace `benchmarks/src/scale/sdk-coordinator.ts` with a `scale.bench.ts` file using `defineTask`/`defineStep`
+- Replace `start.ts` with `bench --platform --image`
+- The scale coordinator's step graph (worker.ready -> create -> exec.initial -> sandbox.live -> exec.final -> destroy) maps directly to `defineStep` calls
+
+## Open Questions
+
+1. **Platform build endpoint.** Does the platform API already have a way to upload and build source files in a sandbox, or does `POST /runs/:id/build` need to be added? The existing `createWorkerArtifact` / `uploadWorkerArtifact` endpoints upload artifacts, but there is no "build from source" endpoint.
+
+2. **Worker sandbox image.** When the platform builds bench files and spawns workers, what base image do the worker sandboxes use? A Node.js image with the bench CLI pre-installed? Or does the build step produce a self-contained bundle?
+
+3. **Secrets management.** Scale tests need provider API keys (E2B, Modal, etc.) inside the worker sandbox. How do secrets flow from the user's environment to the platform to the worker sandbox? The existing flow uses env vars set in the Docker image or VM startup script. The ship-files path needs a `--env` or `--secret` flag.
+
+4. **Multiple files in `--platform` mode.** Local mode can run multiple files. Should `--platform` mode also support multiple files (ship a zip, build all, run all), or should it be limited to one file per run for simplicity?
+
+5. **Step readiness barriers.** The scale coordinator uses `waitForStepReady` to coordinate across workers (e.g., "all workers reach create phase before any starts exec"). Should the CLI expose this as a `defineStep` option, or should it be implicit? The current SDK already supports `readiness: 'poll'` on `DefineStepOptions`.

--- a/docs/design/bench-cli-unified.md
+++ b/docs/design/bench-cli-unified.md
@@ -138,36 +138,61 @@ Renamed from `--remote` to `--platform` to accurately describe what it does: shi
 
 The first-party benchmark runner platform is a hosted service that owns the entire benchmark lifecycle: receive work, run workers, aggregate, report. It has its own compute infrastructure (VMs/containers) for running benchmarks. It is not a ComputeSDK sandbox — ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark platform is a separate product with its own compute capacity, purpose-built for running `*.bench.ts` workloads.
 
-The initial release uses the Docker image path (the same pattern as `benchmarks/src/scale`): the user builds a Docker image containing the bench files + deps, the platform launches worker VMs from that image, each VM runs a coordinator that claims work and executes entries. A future release will add ship-files capability so users can skip the Docker build step.
+The initial release uses the Docker image path (the same pattern as `benchmarks/src/scale`): the user builds a Docker image containing the bench files + deps, the platform launches worker VMs from that image via Namespace ComputeService, each VM runs a coordinator that claims work and executes entries. A future release will add ship-files capability so users can skip the Docker build step.
 
 1. CLI discovers and loads bench files (same as local) — or the Docker image contains them.
-2. CLI creates a benchmark run on the platform, plans workers, and provides the image reference.
-3. Platform launches worker VMs from the image.
-4. Each worker VM loads the bench files, claims a task range from the platform, and executes entries through the SDK's `runWorker()`:
+2. CLI creates a benchmark run on the ComputeSDK platform, plans workers.
+3. CLI launches worker VMs via Namespace `ComputeService.CreateInstance` — one instance per worker, each running a container from the image with env vars for the ComputeSDK platform connection (slug, run ID, participant, API key).
+4. Each worker VM loads the bench files, claims a task range from the ComputeSDK platform, and executes entries through the SDK's `runWorker()`:
    - Real concurrency via `mapPool(taskIndices, concurrency, ...)`
-   - Automatic heartbeats
-   - Batched result flushing
+   - Automatic heartbeats to the ComputeSDK platform
+   - Batched result flushing to the ComputeSDK platform
    - Step-level concurrency barriers (`waitForStepReady`)
-5. CLI polls progress and prints a TUI until all workers finish.
-6. Platform aggregates results; CLI prints final summary.
+5. CLI polls ComputeSDK platform for progress (`getRunProgress`), streams worker logs via Namespace `ObservabilityService.StreamInstanceLogs`, prints TUI.
+6. When all workers finish, CLI destroys instances via Namespace `ComputeService.DestroyInstance`.
+7. CLI fetches final results from ComputeSDK platform, prints summary.
 
 The key change: the CLI does NOT fork local processes. The platform runs workers on its own compute. The SDK's `runWorker()` is the single execution path for remote work. The CLI replaces `start.ts` from the scale test repo.
 
 ### The first-party benchmark runner platform
 
-The `--platform` mode assumes a first-party benchmark runner platform — a hosted service that owns the entire benchmark lifecycle:
+The `--platform` mode uses two layers:
 
-1. **Receive** bench files + `package.json` from the CLI
-2. **Build** the project (install deps, compile TS) on its own compute
-3. **Run** worker VMs from the build output, each claiming tasks and executing entries
-4. **Aggregate** results across workers
-5. **Report** progress and final summary back to the CLI
+1. **ComputeSDK platform** (`platform.computesdk.com`) — benchmark coordination: create runs, plan workers, task claiming, result aggregation, progress tracking, historical runs. This is the existing API (`BenchmarkClient`, `BenchmarkReporter`).
 
-This is a separate product from ComputeSDK itself. ComputeSDK is a framework that connects to external sandbox providers (E2B, Modal, Vercel, etc.). The benchmark runner platform is a first-party service with its own compute infrastructure, purpose-built for running `*.bench.ts` workloads at scale.
+2. **Namespace** (`namespaceapis.com`) — compute infrastructure: build images, launch worker VMs, stream logs, collect metrics, destroy VMs. Namespace provides three services the CLI uses:
+   - `ImageService` — build Docker images from blueprints ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.image.v1beta))
+   - `ComputeService` — create/monitor/destroy micro-VM instances with containers ([docs](https://buf.build/namespace/cloud/docs/main%3Anamespace.cloud.compute.v1beta))
+   - `ObservabilityService` — stream/fetch instance logs
 
-The existing `platform.computesdk.com` API (benchmark/run/worker coordination, result aggregation, artifact storage) is the foundation. The first-party runner adds build capability and managed worker execution on top of that coordination layer.
+This is a clean separation: Namespace = compute, ComputeSDK platform = coordination. The CLI is the orchestrator that talks to both.
 
-The scale test infrastructure in `computesdk/benchmarks/src/scale` is the prototype: `start.ts` creates runs, launches VMs, and each VM runs a coordinator that claims work. The first-party platform productizes this flow — the CLI replaces `start.ts`, and the platform handles VM launch and coordination internally.
+ComputeSDK itself is a framework that connects to external sandbox providers (E2B, Modal, etc.). The benchmark runner is a separate system that uses Namespace for its compute — it does not use ComputeSDK sandboxes.
+
+The scale test infrastructure in `computesdk/benchmarks/src/scale` is the prototype: `start.ts` creates runs, launches Namespace VMs, and each VM runs a coordinator that claims work. The CLI replaces `start.ts` — it creates the run on the ComputeSDK platform, builds the image via Namespace ImageService, launches worker VMs via Namespace ComputeService, and polls the ComputeSDK platform for progress.
+
+### Architecture
+
+```
+                    CLI (bench --platform)
+                   /                      \
+          ComputeSDK Platform             Namespace
+     (coordination layer)             (compute layer)
+          /          \                /           \
+   create run    aggregate       ImageService    ComputeService
+   plan workers  results         (build image)   (launch VMs)
+   poll progress historical      StorageService   ObservabilityService
+                 runs             (cache volumes)  (stream logs)
+                      \              /
+                       \            /
+                   Worker VM (Namespace instance)
+                   - runs bench-worker container
+                   - claims tasks from ComputeSDK platform
+                   - executes entries via runBenchWorker()
+                   - reports results to ComputeSDK platform
+```
+
+The worker VM is the bridge between the two layers: it runs on Namespace compute but talks to the ComputeSDK platform API for task claiming and result reporting. This is exactly what the scale test coordinator does today — it runs in a Namespace VM and calls `createBenchmarkClient()` + `runBenchmarkWorker()` to claim and report work.
 
 ## Remote Execution: Ship Files vs Docker Image
 
@@ -221,31 +246,49 @@ For benchmarks that just need Node.js + a few system packages, the CLI can use N
 ### Build flow (Mode 2: CLI builds via Namespace)
 
 ```
-CLI                     Namespace ImageService          Namespace Instances
- |                               |                              |
- |  CreateBlueprint(spec)        |                              |
- |  Build(blueprint)             |                              |
- |                               |  async build                 |
- |  FetchBlueprint()             |                              |
- |  <--- STATE_BUILDING --------+                              |
- |  FetchBlueprint()             |                              |
- |  <--- STATE_READY ------------+                              |
- |  (got image_ref)              |                              |
- |                               |                              |
- |  (create run on platform,     |                              |
- |   plan workers, launch VMs    |                              |
- |   from image_ref)             |                              |
- |                               |  launch worker VMs           |
- |                               |    from image_ref            |
- |                               |                              |
- |  GET /runs/:id/progress       |                              |
- |  <--- progress updates ------+                              |
- |                               |                              |
- |  GET /runs/:id/results        |                              |
- |  <--- final summary ---------+                              |
+CLI                Namespace ImageService        Namespace ComputeService      ComputeSDK Platform
+ |                         |                            |                            |
+ |  CreateBlueprint(spec)  |                            |                            |
+ |  Build(blueprint)       |                            |                            |
+ |                         |  async build               |                            |
+ |  FetchBlueprint()       |                            |                            |
+ |  <--- STATE_READY ------+                            |                            |
+ |  (got image_ref)        |                            |                            |
+ |                         |                            |                            |
+ |  (create run, plan workers) ------------------------>|                            |
+ |                         |                            |  POST /benchmarks/:slug    |
+ |                         |                            |  POST /runs                |
+ |                         |                            |  POST /planWorkers         |
+ |                         |                            |                            |
+ |  CreateInstance(image_ref, env: {SLUG, RUN_ID, ...}) |                            |
+ |                         |                            |  launch worker VMs         |
+ |                         |                            |    from image_ref          |
+ |                         |                            |                            |
+ |                         |                            |  each worker VM:           |
+ |                         |                            |    claimWorker() --------->|
+ |                         |                            |    runBenchWorker()        |
+ |                         |                            |    sendTaskResults() ----->|
+ |                         |                            |    completeWorker() ------>|
+ |                         |                            |                            |
+ |  StreamInstanceLogs()   |                            |                            |
+ |  <--- live logs --------+----------------------------+                            |
+ |                         |                            |                            |
+ |  getRunProgress() ----------------------------------------------------------------->|
+ |  <--- progress updates -------------------------------------------------------------|
+ |                         |                            |                            |
+ |  DestroyInstance()      |                            |                            |
+ |                         |                            |  destroy worker VMs        |
+ |                         |                            |                            |
+ |  getRunResults() ------------------------------------------------------------------>|
+ |  <--- final summary ----------------------------------------------------------------|
 ```
 
-No `POST /runs/:id/build` endpoint needed on the ComputeSDK platform — the build happens directly through Namespace's `ImageService` API. The ComputeSDK platform only needs to know the `image_ref` to launch workers. Blueprint management (create, build, poll, cache) is handled by Namespace.
+No `POST /runs/:id/build` endpoint needed on the ComputeSDK platform. The CLI orchestrates directly:
+- Namespace ImageService for building
+- Namespace ComputeService for launching/monitoring/destroying worker VMs
+- ComputeSDK platform for benchmark coordination (runs, task claims, results)
+
+The worker VM is the bridge: it runs on Namespace but talks to the ComputeSDK platform for task claiming and result reporting. This is the same pattern as `benchmarks/src/scale/sdk-coordinator.ts` — it runs in a Namespace VM and calls `createBenchmarkClient()` + `runBenchmarkWorker()`.
 
 ### Blueprint caching strategy
 


### PR DESCRIPTION
## Summary

Design doc for unifying the bench CLI and SDK, prompted by the review of #636.

## Key decisions proposed

1. **Two authoring primitives, one file.** `bench()`/`describe()` for micro-benchmarks (ops/sec), `defineTask()`/`defineStep()` for multi-phase workloads (per-step latency). Both coexist in the same `*.bench.ts` files.

2. **One execution path.** The SDK's `runWorker()` (with real concurrency, heartbeats, flushing) becomes the single execution engine. The CLI does not reimplement worker logic. New `runBenchWorker()` accepts bench entries and translates `bench()` calls to single-step tasks.

3. **Ship files to the platform by default, Docker image as opt-in.** `--platform` (renamed from `--remote`) ships bench files + package.json to the platform. The platform builds in a ComputeSDK sandbox and spawns worker sandboxes. `--image` flag for scale tests that need pre-built Docker images.

4. **`defineBench`/`defineWorker` removed from public API.** Users never call them. The CLI handles worker creation internally.

## Doc location

`docs/design/bench-cli-unified.md`

## Open questions

The doc lists 5 open questions (platform build endpoint, worker sandbox image, secrets management, multiple files in platform mode, step readiness barriers). These need discussion before implementation.

## Related

- #636 (the PR that prompted this design)
- `computesdk/benchmarks/src/scale/sdk-coordinator.ts` (reference implementation for the step-based pattern)