### PR TITLE
chore(blaxel): update @blaxel/core to 0.3.3 and handle paginated list()

### DIFF
--- a/.changeset/blaxel-core-0-3-3.md
+++ b/.changeset/blaxel-core-0-3-3.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/blaxel": patch
+---
+
+Update @blaxel/core to 0.3.3 and adapt sandbox/snapshot listing to the new cursor-paginated list() API (auto-paginates through all pages).

--- a/packages/blaxel/package.json
+++ b/packages/blaxel/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@blaxel/core": "^0.2.89",
+    "@blaxel/core": "^0.3.3",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/blaxel/src/index.ts
+++ b/packages/blaxel/src/index.ts
@@ -155,7 +155,7 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 
 			list: async (config: BlaxelConfig) => {
 				initializeBlaxel(config);
-				const sandboxList = await SandboxInstance.list();
+				const sandboxList = await listAllSandboxes();
 				return sandboxList.map(sandbox => ({
 					sandbox,
 					sandboxId: sandbox.metadata?.name || 'blaxel-unknown'
@@ -398,7 +398,7 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 
 			list: async (config: BlaxelConfig) => {
 				initializeBlaxel(config);
-				const sandboxList = await SandboxInstance.list();
+				const sandboxList = await listAllSandboxes();
 				return sandboxList.map(sandbox => ({
 					id: sandbox.metadata?.name || 'blaxel-unknown',
 					provider: 'blaxel',
@@ -442,6 +442,18 @@ export const blaxel = defineProvider<SandboxInstance, BlaxelConfig, any, any>({
 		}
 	}
 });
+
+/**
+ * Collect all sandboxes across pages — since @blaxel/core 0.3.x, list()
+ * returns a cursor-paginated, auto-paging async iterable instead of an array.
+ */
+async function listAllSandboxes(): Promise<SandboxInstance[]> {
+	const sandboxes: SandboxInstance[] = [];
+	for await (const sandbox of await SandboxInstance.list()) {
+		sandboxes.push(sandbox);
+	}
+	return sandboxes;
+}
 
 /**
  * Parse TTL value from Blaxel's format to milliseconds

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,8 +347,8 @@ importers:
   packages/blaxel:
     dependencies:
       '@blaxel/core':
-        specifier: ^0.2.89
-        version: 0.2.91(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^0.3.3
+        version: 0.3.3(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2497,8 +2497,8 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
 
-  '@blaxel/core@0.2.91':
-    resolution: {integrity: sha512-xtwuH9hpb5x+jmEF8rTUgJdQdEdn1lkr9OlTqjcGwkDRsaviqJzN5UfhN3zR2iG7yaUYfRwOLcMOEJVofWaOqg==}
+  '@blaxel/core@0.3.3':
+    resolution: {integrity: sha512-GOc7ILVMP2eJT/QleeoI0W5ylp60m6aWItUAHQ+DxX8GdPZNVKm5l5pYeLGCouFJfH08qgSzrOrNancymyYv6A==}
     engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.1':
@@ -6527,10 +6527,6 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.11.10:
-    resolution: {integrity: sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==}
-    engines: {node: '>=16.9.0'}
-
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
@@ -9649,19 +9645,19 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@blaxel/core@0.2.91(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@blaxel/core@0.3.3(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@hey-api/client-fetch': 0.10.2(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
       archiver: 7.0.1
-      axios: 1.13.5
+      axios: 1.18.1
       dockerfile-ast: 0.7.1
       dotenv: 16.6.1
       form-data: 4.0.5
       jwt-decode: 4.0.0
       toml: 3.0.0
       uuid: 11.1.0
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yaml: 2.8.2
       zod: 3.25.76
     transitivePeerDependencies:
@@ -10576,9 +10572,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@hono/node-server@1.19.9(hono@4.11.10)':
+  '@hono/node-server@1.19.9(hono@4.12.27)':
     dependencies:
-      hono: 4.11.10
+      hono: 4.12.27
 
   '@hopx-ai/sdk@0.5.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
@@ -10920,7 +10916,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.10)
+      '@hono/node-server': 1.19.9(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -10930,7 +10926,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.11.10
+      hono: 4.12.27
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -10942,7 +10938,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.10)
+      '@hono/node-server': 1.19.9(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -10952,7 +10948,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.11.10
+      hono: 4.12.27
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -14206,8 +14202,6 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.11.10: {}
-
   hono@4.12.27: {}
 
   hpagent@1.2.0: {}
@@ -15461,7 +15455,7 @@ snapshots:
 
   pyodide@0.27.7(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
## What

Updates the Blaxel provider's `@blaxel/core` dependency from `^0.2.89` to `^0.3.3`.

## Why

Since `@blaxel/core` 0.3.x, `SandboxInstance.list()` returns a cursor-paginated `PaginatedList` (async iterable) instead of a plain array. Without adaptation, `sandbox.list` and `snapshot.list` break at compile time and would silently return only the first page at runtime.

## Changes

- Bump `@blaxel/core` to `^0.3.3` in `packages/blaxel`.
- Add a `listAllSandboxes()` helper that iterates the paginated list and collects all sandboxes across pages; both `sandbox.list` and `snapshot.list` use it.
- Changeset added (patch, per repo policy).

## Verification

- `pnpm build` passes.
- `pnpm --filter @computesdk/blaxel run typecheck` passes.
- `pnpm --filter @computesdk/blaxel run test` passes (15 tests).
- Root `pnpm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)