### PR TITLE
Add Arker provider

### DIFF
--- a/.changeset/add-arker-provider.md
+++ b/.changeset/add-arker-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/arker": patch
+---
+
+Add Arker provider — sandboxed VMs with persistent filesystems, forked from golden images.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | Provider | Environment Variables | Use Cases |
 |----------|----------------------|-----------|
 | **Archil** | `ARCHIL_API_KEY` | Disk-attached command execution |
+| **Arker** | `ARKER_API_KEY` | Sandboxed VMs with persistent filesystems, forked from golden images |
 | **Beam** | `BEAM_TOKEN`, `BEAM_WORKSPACE_ID` | Serverless cloud sandboxes |
 | **Blaxel** | `BL_API_KEY`, `BL_WORKSPACE` | Agent sandboxes with custom images |
 | **Cloud Run** | `CLOUD_RUN_SANDBOX_URL`, `CLOUD_RUN_SANDBOX_SECRET` | Google Cloud Run sandboxes |

--- a/docs/providers/arker.md
+++ b/docs/providers/arker.md
@@ -1,3 +1,27 @@
+---
+description: >-
+  Set up the Arker provider for ComputeSDK, configure your API key, and create
+  sandboxed VMs to run commands with a persistent filesystem.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
 # Arker
 
 Arker provider for ComputeSDK — sandboxed VMs with persistent per-VM filesystems.
@@ -59,6 +83,6 @@ interface ArkerConfig {
 
 ### Notes
 
-- **Creation is fork-only.** Direct VM creation is disabled; `create()` forks a golden source image (`ubuntu-small` by default). Pick a different golden via `source` in config or `templateId` in create options.
+- **Creation is fork-only.** Direct VM creation is disabled; `create()` forks a source VM — a golden/template by name (`templateId` or `source`, `ubuntu-small` by default) or a specific VM by id (`snapshotId`). The `sandboxId` returned by `create()` can be passed back as a `snapshotId` to branch from that sandbox's state; there is no separate snapshot store. `snapshotId` wins if both are given.
 - **`getUrl` is not supported** and throws. VMs forked with network reachability enabled get a stable per-VM hostname — see the [Arker SDK](https://github.com/ArkerHQ/arker-sdk) fork network options.
 - **Automatic retries.** The underlying `@arker-ai/sdk` retries transient failures (HTTP 429/502/503/504 and transient backend errors).

--- a/docs/providers/arker.md
+++ b/docs/providers/arker.md
@@ -1,0 +1,64 @@
+# Arker
+
+Arker provider for ComputeSDK — sandboxed VMs with persistent per-VM filesystems.
+
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/arker
+```
+
+Add your Arker credentials to a `.env` file:
+
+```bash
+ARKER_API_KEY=your_arker_api_key
+```
+
+> **Note:** Arker API keys start with `ark_` — get one from [arker.ai](https://arker.ai). By default the provider targets the `aws-us-east-1` region; select another region with `ARKER_REGION`.
+
+
+## Usage
+
+```typescript
+import { arker } from '@computesdk/arker';
+
+const compute = arker({
+  apiKey: process.env.ARKER_API_KEY,
+});
+
+// Create sandbox (forks the `ubuntu-small` golden by default)
+const sandbox = await compute.sandbox.create();
+
+// Run a command
+const result = await sandbox.runCommand('echo "Hello from Arker!"');
+console.log(result.stdout); // "Hello from Arker!"
+
+// Clean up
+await sandbox.destroy();
+```
+
+### Configuration Options
+
+```typescript
+interface ArkerConfig {
+  /** Arker API key (starts with `ark_`). Falls back to ARKER_API_KEY. */
+  apiKey?: string;
+  /** Region, e.g. `aws-us-east-1`. Falls back to ARKER_REGION, then the us-east-1 default. */
+  region?: string;
+  /** Golden source VM to fork on create(). Falls back to ARKER_SOURCE, then `ubuntu-small`. */
+  source?: string;
+}
+```
+
+### Supported Operations
+
+- **Sandbox lifecycle** — `create` (fork from a golden image), `getById`, `list`, `destroy`
+- **Command execution** — `runCommand` with `cwd`, `env`, `timeout`, and `background` options; Node.js and Python are preinstalled on the default `ubuntu-small` golden
+- **Filesystem** — `readFile`, `writeFile`, `mkdir`, `readdir`, `exists`, `remove` (persistent per-VM filesystem)
+
+### Notes
+
+- **Creation is fork-only.** Direct VM creation is disabled; `create()` forks a golden source image (`ubuntu-small` by default). Pick a different golden via `source` in config or `templateId` in create options.
+- **`getUrl` is not supported** and throws. VMs forked with network reachability enabled get a stable per-VM hostname — see the [Arker SDK](https://github.com/ArkerHQ/arker-sdk) fork network options.
+- **Automatic retries.** The underlying `@arker-ai/sdk` retries transient failures (HTTP 429/502/503/504 and transient backend errors).

--- a/packages/arker/README.md
+++ b/packages/arker/README.md
@@ -50,17 +50,23 @@ const sandbox = await sdk.sandbox.create();
 
 ## How sandboxes are created
 
-Arker disables direct VM creation — every sandbox is **forked from a golden source image**. `create()` forks `ubuntu-small` (Node.js + Python preinstalled) by default. Choose a different golden via `source` in config or `templateId` in create options:
+Arker disables direct VM creation — every sandbox is **forked from a source VM**. `create()` forks the `ubuntu-small` golden (Node.js + Python preinstalled) by default. The source can be chosen two ways:
+
+- **By name** — a golden/template, via `source` in config or `templateId` in create options.
+- **By id** — a specific existing VM, via `snapshotId` in create options. The `sandboxId` returned by `create()` is itself a valid source, so this branches a sandbox from its current state (Arker's equivalent of a snapshot restore). If both are given, `snapshotId` wins.
 
 ```typescript
 // Default: forks the `ubuntu-small` golden
 const sandbox = await sdk.sandbox.create();
 
 // Pick a golden globally for this provider
-const py = arker({ apiKey, source: 'ubuntu-py-repl' });
+const heavy = arker({ apiKey, source: 'ubuntu-full' });
 
-// Or per sandbox
-const sandbox = await sdk.sandbox.create({ templateId: 'ubuntu-js-repl' });
+// ...or per sandbox, by name
+const other = await sdk.sandbox.create({ templateId: 'ubuntu-full' });
+
+// Fork an existing sandbox by id — branches from its current state
+const forked = await sdk.sandbox.create({ snapshotId: sandbox.sandboxId });
 ```
 
 ## Configuration
@@ -140,7 +146,7 @@ await sandbox.destroy();
 
 ## Limitations
 
-- **Creation is fork-only** — direct VM creation is disabled; `create()` forks a golden source.
+- **Creation is fork-only** — direct VM creation is disabled; `create()` forks a golden by name (`templateId`/`source`) or an existing VM by id (`snapshotId`). There's no separate snapshot store, but any `sandboxId` can be re-forked as a `snapshotId`.
 - **`getUrl` is not supported** — Arker does not expose per-port URLs; `getUrl` throws. VMs forked with network reachability enabled get a stable per-VM hostname — see the [Arker SDK](https://github.com/ArkerHQ/arker-sdk) fork network options.
 - **`getInfo` status** — always reports `running`; idle sandboxes resume automatically on their next command.
 

--- a/packages/arker/README.md
+++ b/packages/arker/README.md
@@ -1,0 +1,155 @@
+# @computesdk/arker
+
+Arker provider for ComputeSDK — run code in [Arker](https://arker.ai) sandboxed VMs with persistent per-VM filesystems.
+
+## Installation
+
+```bash
+npm install @computesdk/arker
+```
+
+## Setup
+
+1. Get your Arker API key (starts with `ark_`) from [arker.ai](https://arker.ai).
+2. Set the environment variable:
+
+```bash
+export ARKER_API_KEY=ark_live_your_api_key_here
+```
+
+By default the provider targets the `aws-us-east-1` region. Select another region with `region` / `ARKER_REGION`.
+
+## Quick Start
+
+Configure `compute` with the Arker provider and create a sandbox:
+
+```typescript
+import { compute } from 'computesdk';
+import { arker } from '@computesdk/arker';
+
+compute.setConfig({
+  provider: arker({ apiKey: process.env.ARKER_API_KEY }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('node -v');
+console.log(result.stdout); // v18.x
+
+await sandbox.destroy();
+```
+
+Or call the provider factory directly when you only need one provider:
+
+```typescript
+import { arker } from '@computesdk/arker';
+
+const sdk = arker({ apiKey: process.env.ARKER_API_KEY });
+const sandbox = await sdk.sandbox.create();
+```
+
+## How sandboxes are created
+
+Arker disables direct VM creation — every sandbox is **forked from a golden source image**. `create()` forks `ubuntu-small` (Node.js + Python preinstalled) by default. Choose a different golden via `source` in config or `templateId` in create options:
+
+```typescript
+// Default: forks the `ubuntu-small` golden
+const sandbox = await sdk.sandbox.create();
+
+// Pick a golden globally for this provider
+const py = arker({ apiKey, source: 'ubuntu-py-repl' });
+
+// Or per sandbox
+const sandbox = await sdk.sandbox.create({ templateId: 'ubuntu-js-repl' });
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+export ARKER_API_KEY=ark_live_your_api_key_here
+export ARKER_REGION=aws-us-east-1     # optional, this is the default
+export ARKER_SOURCE=ubuntu-small      # optional default golden
+```
+
+### Configuration Options
+
+```typescript
+interface ArkerConfig {
+  /** Arker API key (starts with `ark_`). Falls back to ARKER_API_KEY. */
+  apiKey?: string;
+  /** Region, e.g. `aws-us-east-1`. Falls back to ARKER_REGION, then the us-east-1 default. */
+  region?: string;
+  /** Golden source VM to fork on create(). Falls back to ARKER_SOURCE, then `ubuntu-small`. */
+  source?: string;
+}
+```
+
+## API Reference
+
+### Command Execution
+
+```typescript
+// Shell command
+const result = await sandbox.runCommand('echo hello');
+
+// Run a script via heredoc
+const result = await sandbox.runCommand(`python3 - <<'PY'
+print("Hello from Python")
+PY`);
+
+// With environment and working directory
+const result = await sandbox.runCommand('npm test', {
+  cwd: '/app',
+  env: { CI: '1' },
+});
+```
+
+`runCommand` returns `{ stdout, stderr, exitCode, durationMs }`.
+
+### Filesystem Operations
+
+Filesystem operations run as shell commands in the VM and work over arbitrary paths.
+
+```typescript
+await sandbox.filesystem.writeFile('/tmp/hello.txt', 'hi');
+const content = await sandbox.filesystem.readFile('/tmp/hello.txt');
+await sandbox.filesystem.mkdir('/tmp/data');
+const entries = await sandbox.filesystem.readdir('/tmp');
+const exists = await sandbox.filesystem.exists('/tmp/hello.txt');
+await sandbox.filesystem.remove('/tmp/hello.txt');
+```
+
+### Sandbox Management
+
+```typescript
+const sandbox = await sdk.sandbox.create();
+const info = await sandbox.getInfo();      // { id, provider, status, createdAt, ... }
+const all = await sdk.sandbox.list();      // VMs visible to the API key
+const existing = await sdk.sandbox.getById(sandbox.sandboxId);
+await sandbox.destroy();
+```
+
+## Features
+
+- ✅ **Command Execution** — full shell, Node.js & Python preinstalled (`ubuntu-small`)
+- ✅ **Filesystem Operations** — persistent per-VM filesystem (read/write/list/mkdir/exists/remove)
+- ✅ **Fast cold start** — forking the default golden boots a sandbox in well under a second
+- ✅ **Automatic retries** — the underlying `@arker-ai/sdk` retries transient failures (HTTP 429/502/503/504 and transient backend errors)
+
+## Limitations
+
+- **Creation is fork-only** — direct VM creation is disabled; `create()` forks a golden source.
+- **`getUrl` is not supported** — Arker does not expose per-port URLs; `getUrl` throws. VMs forked with network reachability enabled get a stable per-VM hostname — see the [Arker SDK](https://github.com/ArkerHQ/arker-sdk) fork network options.
+- **`getInfo` status** — always reports `running`; idle sandboxes resume automatically on their next command.
+
+## Support
+
+- [Arker](https://arker.ai)
+- [Arker SDK](https://github.com/ArkerHQ/arker-sdk)
+- [ComputeSDK Issues](https://github.com/computesdk/computesdk/issues)
+
+## License
+
+MIT

--- a/packages/arker/package.json
+++ b/packages/arker/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@arker-ai/sdk": "^0.8.2",
+    "@arker-ai/sdk": "^0.8.3",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/arker/package.json
+++ b/packages/arker/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@computesdk/arker",
+  "version": "0.1.0",
+  "description": "Arker provider for ComputeSDK - sandboxed VMs with persistent filesystems, forked from golden images",
+  "author": "Arker",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@arker-ai/sdk": "^0.8.2",
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "arker",
+    "sandbox",
+    "code-execution",
+    "firecracker",
+    "microvm",
+    "python",
+    "javascript",
+    "cloud",
+    "compute",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/arker"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/arker/src/__tests__/index.test.ts
+++ b/packages/arker/src/__tests__/index.test.ts
@@ -1,0 +1,10 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { arker } from '../index';
+
+runProviderTestSuite({
+  name: 'arker',
+  provider: arker({}),
+  supportsFilesystem: true,   // Arker VMs are full OS environments with persistent filesystems
+  supportsGetUrl: false,      // ports are exposed via run-time tunnel requests, not a static URL
+  skipIntegration: !process.env.ARKER_API_KEY,
+});

--- a/packages/arker/src/index.ts
+++ b/packages/arker/src/index.ts
@@ -128,10 +128,17 @@ export const arker = defineProvider<VM, ArkerConfig>({
 
         let fullCommand = command;
         if (options?.env && Object.keys(options.env).length > 0) {
-          const envPrefix = Object.entries(options.env)
-            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+          const assignments = Object.entries(options.env)
+            .map(([k, v]) => {
+              // A shell `NAME=value` prefix can't quote the name, so reject any
+              // name that isn't a valid identifier.
+              if (!/^[A-Za-z_]\w*$/.test(k)) {
+                throw new Error(`Arker runCommand: invalid environment variable name: ${JSON.stringify(k)}`);
+              }
+              return `${k}="${escapeShellArg(String(v))}"`;
+            })
             .join(' ');
-          fullCommand = `${envPrefix} ${fullCommand}`;
+          fullCommand = `${assignments} ${fullCommand}`;
         }
         if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
         // Wrap in `sh -c` so any cwd/env prefix detaches with the command;

--- a/packages/arker/src/index.ts
+++ b/packages/arker/src/index.ts
@@ -8,7 +8,7 @@
 import { Arker, ArkerError, VM } from '@arker-ai/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { ForkOptions, RunOptions } from '@arker-ai/sdk';
+import type { RunOptions } from '@arker-ai/sdk';
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
 /** Region used when none is configured. */
@@ -37,7 +37,7 @@ const env = (key: string): string | undefined => {
  */
 function makeClient(config: ArkerConfig): Arker {
   return new Arker({
-    apiKey: config.apiKey,
+    apiKey: config.apiKey ?? env('ARKER_API_KEY'),
     region: config.region ?? env('ARKER_REGION') ?? DEFAULT_REGION,
   });
 }
@@ -85,12 +85,12 @@ export const arker = defineProvider<VM, ArkerConfig>({
 
       create: async (config: ArkerConfig, options?: CreateSandboxOptions) => {
         const client = makeClient(config);
-        const source = options?.templateId || options?.snapshotId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE;
+        const name = options?.name ?? null;
+        
+        const vm = options?.snapshotId
+          ? await client.fork({ sourceVmId: options.snapshotId, name })
+          : await client.fork(options?.templateId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE, { name });
 
-        const forkOpts: Partial<ForkOptions> = {};
-        if (options?.name) forkOpts.name = options.name;
-
-        const vm = await client.fork(source, forkOpts);
         return { sandbox: vm, sandboxId: vm.id };
       },
 

--- a/packages/arker/src/index.ts
+++ b/packages/arker/src/index.ts
@@ -1,0 +1,240 @@
+/**
+ * Arker Provider - Factory-based Implementation
+ *
+ * Arker (https://arker.ai) runs sandboxed VMs with persistent per-VM
+ * filesystems.
+ */
+
+import { Arker, ArkerError, VM } from '@arker-ai/sdk';
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+
+import type { ForkOptions, RunOptions } from '@arker-ai/sdk';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+
+/** Region used when none is configured. */
+const DEFAULT_REGION = 'aws-us-east-1';
+/** Golden forked when none is requested — small Ubuntu VM with node + python. */
+const DEFAULT_SOURCE = 'ubuntu-small';
+
+export interface ArkerConfig {
+  /** Arker API key (starts with `ark_`). Falls back to the ARKER_API_KEY environment variable. */
+  apiKey?: string;
+  /** Region, e.g. `aws-us-east-1`. Falls back to ARKER_REGION, then the us-east-1 default. */
+  region?: string;
+  /** Golden source VM to fork on create(). Falls back to ARKER_SOURCE, then `ubuntu-small`. */
+  source?: string;
+}
+
+const env = (key: string): string | undefined => {
+  const value = typeof process !== 'undefined' ? process.env?.[key] : undefined;
+  return value && value.trim() ? value.trim() : undefined;
+};
+
+/**
+ * Build an Arker SDK client. Region precedence: config, then ARKER_REGION,
+ * then the us-east-1 default — the SDK itself requires a region, so an
+ * unconfigured caller gets a working default instead of a thrown error.
+ */
+function makeClient(config: ArkerConfig): Arker {
+  return new Arker({
+    apiKey: config.apiKey,
+    region: config.region ?? env('ARKER_REGION') ?? DEFAULT_REGION,
+  });
+}
+
+const decoder = new TextDecoder();
+
+/** Single-quote a string for `sh -c`, escaping any embedded single quotes. */
+const singleQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+
+/** Decode a run-status output field per its declared encoding. */
+const decodeOutput = (value: string, encoding: string): string =>
+  encoding === 'base64' ? Buffer.from(value, 'base64').toString('utf8') : value;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * A run that outlives its synchronous window (default 30s) converts to a
+ * background run; poll it to completion. The platform imposes no inner
+ * timeout on the command itself, so an unbounded command is the caller's.
+ */
+async function pollRunToCompletion(sandbox: VM, runId: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  let delayMs = 500;
+  for (;;) {
+    const run = await sandbox.getRun(runId);
+    if (run.state === 'completed') {
+      if (run.exit_code == null) throw new Error(`Arker run ${runId} completed without an exit code.`);
+      return {
+        stdout: decodeOutput(run.stdout, run.stdout_encoding),
+        stderr: decodeOutput(run.stderr, run.stderr_encoding),
+        exitCode: run.exit_code,
+      };
+    }
+    if (run.state === 'failed') throw new Error(`Arker run ${runId} failed: ${run.fail_reason ?? 'unknown reason'}`);
+    if (run.state === 'cancelled') throw new Error(`Arker run ${runId} was cancelled.`);
+    await sleep(delayMs);
+    delayMs = Math.min(delayMs * 2, 2000);
+  }
+}
+
+export const arker = defineProvider<VM, ArkerConfig>({
+  name: 'arker',
+  methods: {
+    sandbox: {
+      // --- Collection operations ---
+
+      create: async (config: ArkerConfig, options?: CreateSandboxOptions) => {
+        const client = makeClient(config);
+        const source = options?.templateId || options?.snapshotId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE;
+
+        const forkOpts: Partial<ForkOptions> = {};
+        if (options?.name) forkOpts.name = options.name;
+
+        const vm = await client.fork(source, forkOpts);
+        return { sandbox: vm, sandboxId: vm.id };
+      },
+
+      getById: async (config: ArkerConfig, sandboxId: string) => {
+        const client = makeClient(config);
+        try {
+          const vm = await client.getVm(sandboxId);
+          return { sandbox: vm, sandboxId };
+        } catch (err) {
+          if (err instanceof ArkerError && err.status === 404) return null;
+          throw err;
+        }
+      },
+
+      list: async (config: ArkerConfig) => {
+        const client = makeClient(config);
+        const { vms } = await client.listVms();
+        return vms.map((vm) => ({ sandbox: vm, sandboxId: vm.id }));
+      },
+
+      destroy: async (config: ArkerConfig, sandboxId: string) => {
+        const client = makeClient(config);
+        try {
+          await client.vm(sandboxId).delete();
+        } catch (err) {
+          if (err instanceof ArkerError && err.status === 404) return;
+          throw err;
+        }
+      },
+
+      // --- Instance operations ---
+
+      runCommand: async (sandbox: VM, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
+        const startTime = Date.now();
+
+        let fullCommand = command;
+        if (options?.env && Object.keys(options.env).length > 0) {
+          const envPrefix = Object.entries(options.env)
+            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+            .join(' ');
+          fullCommand = `${envPrefix} ${fullCommand}`;
+        }
+        if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+        // Wrap in `sh -c` so any cwd/env prefix detaches with the command;
+        // a bare `nohup cd … && …` would run only `cd` under nohup.
+        if (options?.background) fullCommand = `nohup sh -c ${singleQuote(fullCommand)} > /dev/null 2>&1 &`;
+
+        const runOptions: RunOptions = {};
+        if (options?.timeout) runOptions.timeout = options.timeout;
+
+        const result = await sandbox.run(fullCommand, runOptions);
+        if (result.type === 'completed') {
+          return {
+            stdout: decoder.decode(result.stdout),
+            stderr: decoder.decode(result.stderr),
+            exitCode: result.exitCode,
+            durationMs: Date.now() - startTime,
+          };
+        }
+        // The run outlived its synchronous window and converted to background.
+        // With an explicit timeout the window *was* the caller's deadline —
+        // cancel and report the timeout; otherwise poll to completion.
+        if (options?.timeout) {
+          await sandbox.cancelRun(result.runId).catch(() => {});
+          throw new Error(`Arker command timed out after ${options.timeout}ms and was cancelled (run ${result.runId}).`);
+        }
+        const polled = await pollRunToCompletion(sandbox, result.runId);
+        return { ...polled, durationMs: Date.now() - startTime };
+      },
+
+      getInfo: async (sandbox: VM): Promise<SandboxInfo> => ({
+        id: sandbox.id,
+        provider: 'arker',
+        status: 'running',
+        createdAt: sandbox.created_at ? new Date(sandbox.created_at) : new Date(),
+        timeout: 0,
+      }),
+
+      getUrl: async (_sandbox: VM, options: { port: number; protocol?: string }): Promise<string> => {
+        throw new Error(
+          `Arker does not expose per-port URLs (requested port ${options.port}). ` +
+            `VMs forked with network reachability enabled get a stable per-VM hostname ` +
+            `(see the @arker-ai/sdk fork network options and vm.network.hostname).`
+        );
+      },
+
+      getInstance: (sandbox: VM): VM => sandbox,
+
+      // --- Filesystem (over runCommand; works anywhere in the VM) ---
+
+      filesystem: {
+        readFile: async (sandbox, path, runCommand): Promise<string> => {
+          const result = await runCommand(sandbox, `cat "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Arker readFile failed for ${path}: ${result.stderr || `exit ${result.exitCode}`}`);
+          return result.stdout;
+        },
+        writeFile: async (sandbox, path, content, runCommand): Promise<void> => {
+          // base64 round-trip so arbitrary content needs no shell escaping
+          const b64 = Buffer.from(content, 'utf8').toString('base64');
+          const result = await runCommand(sandbox, `printf '%s' "${b64}" | base64 -d > "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Arker writeFile failed for ${path}: ${result.stderr || `exit ${result.exitCode}`}`);
+        },
+        mkdir: async (sandbox, path, runCommand): Promise<void> => {
+          const result = await runCommand(sandbox, `mkdir -p "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Arker mkdir failed for ${path}: ${result.stderr || `exit ${result.exitCode}`}`);
+        },
+        readdir: async (sandbox, path, runCommand): Promise<FileEntry[]> => {
+          const result = await runCommand(sandbox, `ls -la "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Arker readdir failed for ${path}: ${result.stderr || `exit ${result.exitCode}`}`);
+
+          const entries: FileEntry[] = [];
+          for (const line of result.stdout.split('\n')) {
+            const parts = line.trim().split(/\s+/);
+            // Skip the "total" line, malformed rows, and . / ..
+            if (parts.length < 9 || !/^[-dl]/.test(parts[0])) continue;
+            let name = parts.slice(8).join(' ');
+            if (parts[0].startsWith('l')) name = name.split(' -> ')[0]; // symlink arrow
+            if (name === '.' || name === '..') continue;
+            // ls prints "Mmm dd HH:MM" for recent files (no year) and "Mmm dd YYYY" otherwise.
+            const [month, day, timeOrYear] = parts.slice(5, 8);
+            const dateStr = timeOrYear.includes(':')
+              ? `${month} ${day} ${new Date().getFullYear()} ${timeOrYear}`
+              : `${month} ${day} ${timeOrYear}`;
+            const modified = new Date(dateStr);
+            entries.push({
+              name,
+              type: parts[0].startsWith('d') ? 'directory' : 'file',
+              size: Number(parts[4]) || 0,
+              modified: isNaN(modified.getTime()) ? new Date(0) : modified,
+            });
+          }
+          return entries;
+        },
+        exists: async (sandbox, path, runCommand): Promise<boolean> => {
+          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          return result.exitCode === 0;
+        },
+        remove: async (sandbox, path, runCommand): Promise<void> => {
+          const result = await runCommand(sandbox, `rm -rf "${escapeShellArg(path)}"`);
+          if (result.exitCode !== 0) throw new Error(`Arker remove failed for ${path}: ${result.stderr || `exit ${result.exitCode}`}`);
+        },
+      },
+    },
+  },
+});
+
+export type { VM as ArkerSandbox } from '@arker-ai/sdk';

--- a/packages/arker/tsconfig.json
+++ b/packages/arker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/arker/tsup.config.ts
+++ b/packages/arker/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/arker/vitest.config.ts
+++ b/packages/arker/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
   packages/arker:
     dependencies:
       '@arker-ai/sdk':
-        specifier: ^0.8.2
-        version: 0.8.2(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+        specifier: ^0.8.3
+        version: 0.8.3(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2267,8 +2267,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@arker-ai/sdk@0.8.2':
-    resolution: {integrity: sha512-qMFBUcyRqXPzu83KZwVwsRul/WB4iZIvIIhk9SGgH4Fh/mkbrjEFKjyy83+9nbljZsTpp/koj8q7sjd2HpY3hQ==}
+  '@arker-ai/sdk@0.8.3':
+    resolution: {integrity: sha512-QZpfH3kWyozf/VdoXZzD+qX1O45ZiYMZQhy143jfgAnpfakPj9lrP94yxGvkD5cuISxRb26ZNbLeamsfES32kQ==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -9066,7 +9066,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@arker-ai/sdk@0.8.2(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+  '@arker-ai/sdk@0.8.3(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/arker:
+    dependencies:
+      '@arker-ai/sdk':
+        specifier: ^0.8.2
+        version: 0.8.2(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/beam:
     dependencies:
       '@beamcloud/beam-js':
@@ -2230,6 +2267,25 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@arker-ai/sdk@0.8.2':
+    resolution: {integrity: sha512-qMFBUcyRqXPzu83KZwVwsRul/WB4iZIvIIhk9SGgH4Fh/mkbrjEFKjyy83+9nbljZsTpp/koj8q7sjd2HpY3hQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@computesdk/daytona': ^1.7.30
+      '@computesdk/e2b': ^1.7.51
+      '@computesdk/modal': ^1.9.3
+      computesdk: ^4.1.3
+    peerDependenciesMeta:
+      '@computesdk/daytona':
+        optional: true
+      '@computesdk/e2b':
+        optional: true
+      '@computesdk/modal':
+        optional: true
+      computesdk:
+        optional: true
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -2736,6 +2792,21 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@computesdk/cmd@0.4.1':
+    resolution: {integrity: sha512-hhcYrwMnOpRSwWma3gkUeAVsDFG56nURwSaQx8vCepv0IuUv39bK4mMkgszolnUQrVjBDdW7b3lV+l5B2S8fRA==}
+
+  '@computesdk/daytona@1.7.32':
+    resolution: {integrity: sha512-kAaUAp/cjkMhbfdiP0CMB5oH3wxYFNe4YrJ7ptOVfVx55pZq83T59Axk7D2CZMiUNuwB8RVEhclMbGKeVIhaVg==}
+
+  '@computesdk/e2b@1.7.52':
+    resolution: {integrity: sha512-B0PJZRu7GdxGCPPVhHk4NrdlqOV4kjP2C8OkDFk2as2wD2L3lnV4Zfm0vDuhw2bGrTzY6J4oTphs/40W9uAwSA==}
+
+  '@computesdk/modal@1.9.4':
+    resolution: {integrity: sha512-MTxwhw+Ol/UaOJBpTfQmg1vo8s9rIhWZeCzcfG6LndwuQoq4CVWwjO+fGT9lB7wVBaddtbWaks3R7PI9GH+meg==}
+
+  '@computesdk/provider@2.1.4':
+    resolution: {integrity: sha512-abTZS8kpif4QpLZ7Jzo6hmlje2b3YB4VRC8hVkrb/tKXwt0QcU7Nao7tM1phRru0HxVrfHycb/vZtdJSlNFGeA==}
 
   '@connectrpc/connect-node@2.1.2':
     resolution: {integrity: sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==}
@@ -5746,6 +5817,9 @@ packages:
     resolution: {integrity: sha512-jpKJjBTretQACTGLNuvnozP1JdP2ZLrjdGdBgk/tz1VfXlUcBhhSZW6vEsuThmeot/yjvSrPQKEgfF3X2Lpi8Q==}
     hasBin: true
 
+  computesdk@4.1.4:
+    resolution: {integrity: sha512-PRBMwJ2yRTMvVc+8mC8wM2EKI96kco1Dk9/kSAOsABlv7YP+h9v5qbqVIQQ6xKr46KL81MLpIOKf0dVZbIEafg==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -5833,6 +5907,11 @@ packages:
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
+
+  daemond@0.1.4:
+    resolution: {integrity: sha512-xiLScBiwYGGPmxfcAb24aH+FkmR/ZSd+PxOvigGpKda6OsDjE2Gj6/4oAX2N3hMWoL4atti1hYyF9dLV3FFM0A==}
+    engines: {node: '>=18.0.0'}
+    os: [linux, darwin]
 
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
@@ -8987,6 +9066,18 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
+  '@arker-ai/sdk@0.8.2(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      '@computesdk/daytona': 1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@computesdk/e2b': 1.7.52
+      '@computesdk/modal': 1.9.4
+      computesdk: link:packages/computesdk
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -9963,6 +10054,42 @@ snapshots:
       - supports-color
 
   '@colors/colors@1.5.0':
+    optional: true
+
+  '@computesdk/cmd@0.4.1':
+    optional: true
+
+  '@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@computesdk/provider': 2.1.4
+      '@daytonaio/sdk': 0.192.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      computesdk: 4.1.4
+    transitivePeerDependencies:
+      - aws-crt
+      - debug
+      - supports-color
+      - ws
+    optional: true
+
+  '@computesdk/e2b@1.7.52':
+    dependencies:
+      '@computesdk/provider': 2.1.4
+      computesdk: 4.1.4
+      e2b: 2.30.1
+    optional: true
+
+  '@computesdk/modal@1.9.4':
+    dependencies:
+      '@computesdk/provider': 2.1.4
+      computesdk: 4.1.4
+      modal: 0.7.6
+    optional: true
+
+  '@computesdk/provider@2.1.4':
+    dependencies:
+      '@computesdk/cmd': 0.4.1
+      computesdk: 4.1.4
+      daemond: 0.1.4
     optional: true
 
   '@connectrpc/connect-node@2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))':
@@ -13221,6 +13348,12 @@ snapshots:
       amdefine: 1.0.1
       commander: 2.8.1
 
+  computesdk@4.1.4:
+    dependencies:
+      '@computesdk/cmd': 0.4.1
+      daemond: 0.1.4
+    optional: true
+
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
@@ -13320,6 +13453,9 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
+    optional: true
+
+  daemond@0.1.4:
     optional: true
 
   data-uri-to-buffer@2.0.2: {}


### PR DESCRIPTION
## Provider: `@computesdk/arker`

**What is it?** [Arker](https://arker.ai) runs sandboxed VMs with persistent per-VM filesystems; every sandbox is forked from a golden image (default `ubuntu-small`, Node.js + Python preinstalled) and cold-starts in well under a second.

**Underlying SDK / API:** [`@arker-ai/sdk`](https://www.npmjs.com/package/@arker-ai/sdk) 

**Credentials:** `ARKER_API_KEY` (from [arker.ai](https://arker.ai)); optional `ARKER_REGION` (defaults to `aws-us-east-1`) and `ARKER_SOURCE` (default golden).

### Capabilities

| Capability | Supported? | Notes |
|---|---|---|
| `runCommand` (required) | ✅ | `env`/`cwd`/`background`/`timeout`; runs outliving the sync window are polled to completion |
| Filesystem | ✅ | shell-based; read/write/mkdir/readdir/exists/remove |
| `getUrl` (port exposure) | ❌ | throws with guidance — Arker exposes a per-VM hostname via its SDK, not per-port URLs |
| `list` | ✅ | first page (100) |
| Templates | ❌ | no template management; `create({ templateId })` selects the golden to fork |
| Snapshots | ❌ | |

### Checklist

- [x] New `packages/arker/` package with `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, `README.md`, and `src/`
- [x] Core sandbox methods implemented: `create`, `getById`, `destroy`, `runCommand`, `getInfo`
- [x] Config validated with env-var fallbacks (`ARKER_API_KEY` / `ARKER_REGION` / `ARKER_SOURCE`)
- [x] Shell interpolation uses `escapeShellArg` wrapped in double quotes
- [x] Tests via `runProviderTestSuite` — 14/14 unit; integration gated on `ARKER_API_KEY` (passes against production)
- [x] `pnpm build` passes
- [x] `pnpm --filter @computesdk/arker run typecheck` passes
- [ ] `pnpm --filter @computesdk/arker run lint` — fails with the pre-existing root `.eslintrc.js` config error (`@typescript-eslint/recommended` missing the `plugin:` prefix); reproduces identically on `packages/e2b`
- [x] Root `README.md` "Supported Providers" table updated
- [x] Docs page added at `docs/providers/arker.md`
- [x] Changeset added (`patch`)

### Notes for reviewers

- **Disclosure:** I work for Arker.
- Snapshots via fork: create({ snapshotId }) branches an existing VM by id; create({ templateId }) forks a golden by name.
- Happy to provide API credentials for the daily benchmarks once merged.