### PR TITLE
Add pause/resume lifecycle API to ComputeSDK core and providers

### DIFF
--- a/.changeset/pause-resume-lifecycle.md
+++ b/.changeset/pause-resume-lifecycle.md
@@ -1,0 +1,21 @@
+---
+"computesdk": minor
+"@computesdk/provider": minor
+"@computesdk/e2b": minor
+"@computesdk/daytona": minor
+"@computesdk/superserve": minor
+"@computesdk/isorun": minor
+"@computesdk/codesandbox": minor
+"@computesdk/createos-sandbox": minor
+"@computesdk/tenki": minor
+"@computesdk/agentuity": minor
+"@computesdk/namespace": minor
+---
+
+Add pause/resume lifecycle API to ComputeSDK sandboxes.
+
+- Core API: `sandbox.pause({ keepMemory? })` and `sandbox.resume()` with a new `'paused'` status in `SandboxInfo`.
+- Provider factory wiring for optional `pause`/`resume` methods.
+- Native pause/resume implementations for E2B, Daytona, Superserve, Isorun, CodeSandbox, CreateOS, Tenki, Agentuity, and Namespace.
+- Namespace pause/resume uses the `SuspendInstance`/`WakeInstance` Compute API endpoints.
+- Added unit tests for the Namespace pause/resume lifecycle.

--- a/.changeset/pause-resume-lifecycle.md
+++ b/.changeset/pause-resume-lifecycle.md
@@ -10,6 +10,7 @@
 "@computesdk/tenki": minor
 "@computesdk/agentuity": minor
 "@computesdk/namespace": minor
+"@computesdk/test-utils": minor
 ---
 
 Add pause/resume lifecycle API to ComputeSDK sandboxes.
@@ -19,3 +20,5 @@ Add pause/resume lifecycle API to ComputeSDK sandboxes.
 - Native pause/resume implementations for E2B, Daytona, Superserve, Isorun, CodeSandbox, CreateOS, Tenki, Agentuity, and Namespace.
 - Namespace pause/resume uses the `SuspendInstance`/`WakeInstance` Compute API endpoints.
 - Added unit tests for the Namespace pause/resume lifecycle.
+- Added `supportsPauseResume` option to the provider test suite and enabled it for E2B.
+- Added an E2B pause/resume integration test to `compute-provider-integration.test.ts`.

--- a/packages/agentuity/src/index.ts
+++ b/packages/agentuity/src/index.ts
@@ -21,6 +21,7 @@ import type {
     CreateSandboxOptions,
     FileEntry,
     RunCommandOptions,
+    PauseOptions,
 } from 'computesdk';
 
 type RunCommandFn = (sandbox: AgentuityHandle, command: string, options?: RunCommandOptions) => Promise<CommandResult>;
@@ -459,11 +460,11 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
                 }>(await res.json());
 
                 // Convert status → ComputeSDK standard
-                const statusMap: Record<string, 'running' | 'stopped' | 'error'> = {
+                const statusMap: Record<string, 'running' | 'stopped' | 'paused' | 'error'> = {
                     idle: 'running',
                     running: 'running',
                     creating: 'running',
-                    paused: 'stopped',
+                    paused: 'paused',
                     terminated: 'stopped',
                     failed: 'error',
                 };
@@ -650,6 +651,16 @@ export const agentuity = defineProvider<AgentuityHandle, AgentuityConfig>({
             },
 
             getInstance: (sandbox: AgentuityHandle): AgentuityHandle => sandbox,
+
+            pause: async (sandbox: AgentuityHandle, _options?: PauseOptions) => {
+                const res = await agentuityFetch(sandbox, 'POST', `/sandbox/${sandbox.sandboxId}/pause`);
+                if (!res.ok) throw new Error(`Agentuity: failed to pause sandbox (${res.status})`);
+            },
+
+            resume: async (sandbox: AgentuityHandle) => {
+                const res = await agentuityFetch(sandbox, 'POST', `/sandbox/${sandbox.sandboxId}/resume`);
+                if (!res.ok) throw new Error(`Agentuity: failed to resume sandbox (${res.status})`);
+            },
         },
     },
 });

--- a/packages/codesandbox/src/index.ts
+++ b/packages/codesandbox/src/index.ts
@@ -6,9 +6,11 @@ import { CodeSandbox } from '@codesandbox/sdk';
 import type { Sandbox as CodesandboxSandbox } from '@codesandbox/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions, PauseOptions } from '@computesdk/provider';
 
 type HibernateCapableSandbox = CodesandboxSandbox & { hibernate: () => Promise<void>; };
+
+const sandboxApiKeys = new WeakMap<CodesandboxSandbox, string>();
 
 export interface CodesandboxConfig {
   /** CodeSandbox API key - if not provided, will fallback to CSB_API_KEY environment variable */
@@ -50,6 +52,7 @@ export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig,
             sandbox = await sdk.sandboxes.create(createOptions);
             sandboxId = sandbox.id;
           }
+          sandboxApiKeys.set(sandbox, apiKey);
           return { sandbox, sandboxId };
         } catch (error) {
           if (error instanceof Error) {
@@ -70,6 +73,7 @@ export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig,
         const sdk = new CodeSandbox(apiKey);
         try {
           const sandbox = await sdk.sandboxes.resume(sandboxId);
+          sandboxApiKeys.set(sandbox, apiKey);
           return { sandbox, sandboxId };
         } catch { return null; }
       },
@@ -156,6 +160,22 @@ export const codesandbox = defineProvider<CodesandboxSandbox, CodesandboxConfig,
           const client = await sandbox.connect();
           await client.fs.remove(path);
         }
+      },
+
+      pause: async (sandbox: CodesandboxSandbox, _options?: PauseOptions) => {
+        // CodeSandbox hibernate() preserves filesystem + memory and is the snapshot mechanism.
+        await (sandbox as HibernateCapableSandbox).hibernate();
+      },
+
+      resume: async (sandbox: CodesandboxSandbox) => {
+        const apiKey = sandboxApiKeys.get(sandbox);
+        if (!apiKey) {
+          throw new Error('CodeSandbox API key not available for resume. Retrieve the sandbox via getById before resuming.');
+        }
+        const sdk = new CodeSandbox(apiKey);
+        const resumed = await sdk.sandboxes.resume(sandbox.id);
+        sandboxApiKeys.set(resumed, apiKey);
+        return resumed;
       },
 
       getInstance: (sandbox: CodesandboxSandbox): CodesandboxSandbox => sandbox,

--- a/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
+++ b/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
@@ -144,6 +144,38 @@ describeIntegration('compute provider integration', () => {
     }
   }, 180000);
 
+  it.runIf(testProvider === 'e2b')(
+    'pauses and resumes a sandbox while preserving filesystem state',
+    async () => {
+      if (!testProvider) {
+        throw new Error('TEST_PROVIDER must be set when COMPUTESDK_INTEGRATION=1');
+      }
+
+      const providerFactory = await loadProviderFactory(testProvider);
+      const provider = providerFactory(getProviderConfig(testProvider));
+
+      const sdk = compute({ provider });
+      const sandbox = await sdk.sandbox.create({ timeout: 120000 } as any);
+
+      try {
+        await sandbox.runCommand('echo e2b-pause-marker > /tmp/computesdk-pause-marker.txt');
+        await sandbox.pause!();
+        const pausedInfo = await sandbox.getInfo();
+        expect(pausedInfo.status).toBe('paused');
+
+        await sandbox.resume!();
+        const resumedInfo = await sandbox.getInfo();
+        expect(resumedInfo.status).toBe('running');
+
+        const result = await sandbox.runCommand('cat /tmp/computesdk-pause-marker.txt');
+        expect(result.stdout).toContain('e2b-pause-marker');
+      } finally {
+        await sdk.sandbox.destroy(sandbox.sandboxId);
+      }
+    },
+    300000,
+  );
+
   it.runIf(testProvider === 'vercel')(
     'streams daemon output callbacks before command completion',
     async () => {

--- a/packages/computesdk/src/index.ts
+++ b/packages/computesdk/src/index.ts
@@ -30,6 +30,7 @@ export type {
   RunCommandOptions,
   SandboxFileSystem,
   CreateSandboxOptions,
+  PauseOptions,
 } from './types/universal-sandbox';
 
 // Compute API

--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -25,6 +25,18 @@ export interface CommandResult {
 }
 
 /**
+ * Options for pausing a sandbox
+ */
+export interface PauseOptions {
+  /**
+   * Whether to preserve memory (running process state) when pausing.
+   * Defaults to provider behavior. Providers that do not support memory
+   * snapshots will ignore this or throw if `true` is requested explicitly.
+   */
+  keepMemory?: boolean;
+}
+
+/**
  * Sandbox information
  */
 export interface SandboxInfo {
@@ -33,7 +45,7 @@ export interface SandboxInfo {
   /** Provider hosting the sandbox */
   provider: string;
   /** Current status of the sandbox */
-  status: 'running' | 'stopped' | 'error';
+  status: 'running' | 'stopped' | 'paused' | 'error';
   /** When the sandbox was created */
   createdAt: Date;
   /** Execution timeout in milliseconds */
@@ -172,7 +184,17 @@ export interface Sandbox {
   
   /** Destroy the sandbox and clean up resources */
   destroy(): Promise<void>;
-  
+
+  /**
+   * Pause the sandbox, preserving its filesystem state.
+   * Providers that support memory snapshots may also preserve running
+   * processes when `keepMemory: true` is requested.
+   */
+  pause?(options?: PauseOptions): Promise<void>;
+
+  /** Resume a paused sandbox */
+  resume?(): Promise<void>;
+
   /** File system operations */
   readonly filesystem: SandboxFileSystem;
 }

--- a/packages/createos-sandbox/src/__tests__/index.test.ts
+++ b/packages/createos-sandbox/src/__tests__/index.test.ts
@@ -59,8 +59,8 @@ describe("mapStatus", () => {
     expect(mapStatus("error")).toBe("error");
     expect(mapStatus("failed")).toBe("error");
   });
-  it("maps transitional/paused states to stopped", () => {
-    expect(mapStatus("paused")).toBe("stopped");
+  it("maps paused to paused and transitional states to stopped", () => {
+    expect(mapStatus("paused")).toBe("paused");
     expect(mapStatus("creating")).toBe("stopped");
     expect(mapStatus("resuming")).toBe("stopped");
   });

--- a/packages/createos-sandbox/src/index.ts
+++ b/packages/createos-sandbox/src/index.ts
@@ -45,6 +45,7 @@ import type {
   ListSnapshotsOptions,
   RunCommandOptions,
   SandboxInfo,
+  PauseOptions,
 } from "@computesdk/provider";
 
 const PROVIDER_NAME = "createos-sandbox";
@@ -192,9 +193,10 @@ async function resolveShape(
   return picked;
 }
 
-/** Map an createos-sandbox lifecycle state onto ComputeSDK's running|stopped|error. */
+/** Map an createos-sandbox lifecycle state onto ComputeSDK's running|stopped|paused|error. */
 export function mapStatus(status: SandboxStatus): SandboxInfo["status"] {
   if (status === "running") return "running";
+  if (status === "paused") return "paused";
   if (status === "error" || status === "failed") return "error";
   return "stopped";
 }
@@ -404,6 +406,19 @@ export const createosSandbox = defineProvider<Sandbox, CreateosConfig>({
       // Escape hatch: the bare native @nodeops-createos/sandbox handle
       // (pause/resume/fork/disks/...).
       getInstance: (sandbox: Sandbox): Sandbox => sandbox,
+
+      pause: async (sandbox: Sandbox, _options?: PauseOptions) => {
+        // CreateOS pause stops the VM while preserving full memory/filesystem state.
+        await sandbox.pause();
+        await sandbox.waitUntilPaused();
+      },
+
+      resume: async (sandbox: Sandbox) => {
+        // CreateOS resumes an in-place paused VM; for a paused snapshot used as a
+        // template, create a new sandbox via create({ snapshotId }).
+        await sandbox.resume();
+        await sandbox.waitUntilRunning();
+      },
 
       filesystem: {
         readFile: async (sandbox: Sandbox, path: string): Promise<string> => {

--- a/packages/daytona/src/index.ts
+++ b/packages/daytona/src/index.ts
@@ -5,7 +5,7 @@
 import { Daytona, Sandbox as DaytonaSandbox } from '@daytonaio/sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions, PauseOptions } from '@computesdk/provider';
 
 /**
  * Daytona-specific configuration options
@@ -17,6 +17,15 @@ export interface DaytonaConfig {
   runtime?: string;
   /** Execution timeout in milliseconds */
   timeout?: number;
+}
+
+function mapDaytonaState(state?: string): SandboxInfo['status'] {
+  if (!state) return 'running';
+  const s = state.toLowerCase();
+  if (s.includes('paused')) return 'paused';
+  if (s.includes('stopped')) return 'stopped';
+  if (s.includes('error') || s.includes('failed')) return 'error';
+  return 'running';
 }
 
 /**
@@ -174,7 +183,7 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
         return {
           id: sandbox.id,
           provider: 'daytona',
-          status: 'running',
+          status: mapDaytonaState(sandbox.state),
           createdAt: new Date(),
           timeout: 300000,
           metadata: { daytonaSandboxId: sandbox.id }
@@ -194,6 +203,16 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
         } catch (error) {
           throw new Error(`Failed to get Daytona preview URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
         }
+      },
+
+      pause: async (sandbox: DaytonaSandbox, _options?: PauseOptions) => {
+        // Daytona pause is only supported for VM sandboxes (Linux VM / Windows).
+        // VM pause preserves both filesystem and memory; containers do not support pause.
+        await sandbox.pause();
+      },
+
+      resume: async (sandbox: DaytonaSandbox) => {
+        await sandbox.start();
       },
 
       filesystem: {

--- a/packages/e2b/src/__tests__/index.test.ts
+++ b/packages/e2b/src/__tests__/index.test.ts
@@ -7,5 +7,6 @@ runProviderTestSuite({
   supportsFilesystem: true,  // E2B supports filesystem operations
   supportsPauseResume: true, // E2B supports native pause/resume
   skipIntegration: !process.env.E2B_API_KEY,
+  timeout: 300000, // Pause/resume can take longer than the default 60s
   ports: [3000, 8080]  // Enable getUrl tests
 });

--- a/packages/e2b/src/__tests__/index.test.ts
+++ b/packages/e2b/src/__tests__/index.test.ts
@@ -5,6 +5,7 @@ runProviderTestSuite({
   name: 'e2b',
   provider: e2b({}),
   supportsFilesystem: true,  // E2B supports filesystem operations
+  supportsPauseResume: true, // E2B supports native pause/resume
   skipIntegration: !process.env.E2B_API_KEY,
   ports: [3000, 8080]  // Enable getUrl tests
 });

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -19,10 +19,6 @@ type E2BSnapshotResult = string | { id?: string; templateId?: string };
 type SnapshotCapableE2BSandbox = E2BSandbox & {
   createSnapshot: (options?: { name?: string }) => Promise<E2BSnapshotResult>;
 };
-type PauseCapableE2BSandbox = E2BSandbox & {
-  pause: (options?: { keepMemory?: boolean }) => Promise<void>;
-  connect: () => Promise<E2BSandbox>;
-};
 type E2BSandboxStatics = typeof E2BSandbox & {
   listTemplates?: (options: { apiKey?: string }) => Promise<unknown[]>;
   deleteTemplate?: (snapshotId: string, options: { apiKey?: string }) => Promise<unknown>;
@@ -134,14 +130,22 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
         }
       },
 
-      getInfo: async (sandbox: E2BSandbox): Promise<SandboxInfo> => ({
-        id: sandbox.sandboxId || 'e2b-unknown',
-        provider: 'e2b',
-        status: 'running',
-        createdAt: new Date(),
-        timeout: 300000,
-        metadata: { e2bSessionId: sandbox.sandboxId }
-      }),
+      getInfo: async (sandbox: E2BSandbox): Promise<SandboxInfo> => {
+        const apiKey = (typeof process !== 'undefined' && process.env?.E2B_API_KEY) || '';
+        let status: 'running' | 'paused' = 'running';
+        try {
+          const info = await E2BSandbox.getInfo(sandbox.sandboxId, { apiKey });
+          status = info.state === 'paused' ? 'paused' : 'running';
+        } catch { /* fall back to running if getInfo fails */ }
+        return {
+          id: sandbox.sandboxId || 'e2b-unknown',
+          provider: 'e2b',
+          status,
+          createdAt: new Date(),
+          timeout: 300000,
+          metadata: { e2bSessionId: sandbox.sandboxId }
+        };
+      },
 
       getUrl: async (sandbox: E2BSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         try {
@@ -170,12 +174,13 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
         remove: async (sandbox: E2BSandbox, path: string): Promise<void> => { await sandbox.files.remove(path); }
       },
 
-      pause: async (sandbox: E2BSandbox, options?: PauseOptions) => {
-        await (sandbox as PauseCapableE2BSandbox).pause(options);
+      pause: async (sandbox: E2BSandbox, _options?: PauseOptions) => {
+        const apiKey = (typeof process !== 'undefined' && process.env?.E2B_API_KEY) || '';
+        await E2BSandbox.pause(sandbox.sandboxId, { apiKey });
       },
 
       resume: async (sandbox: E2BSandbox) => {
-        return await (sandbox as PauseCapableE2BSandbox).connect();
+        return await sandbox.connect();
       },
 
       getInstance: (sandbox: E2BSandbox): E2BSandbox => sandbox,

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -5,7 +5,7 @@
 import { Sandbox as E2BSandbox } from 'e2b';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions, PauseOptions } from '@computesdk/provider';
 
 type E2BExecutionResult = { stdout?: string; stderr?: string; exitCode?: number };
 type E2BFileEntry = {
@@ -18,6 +18,10 @@ type E2BFileEntry = {
 type E2BSnapshotResult = string | { id?: string; templateId?: string };
 type SnapshotCapableE2BSandbox = E2BSandbox & {
   createSnapshot: (options?: { name?: string }) => Promise<E2BSnapshotResult>;
+};
+type PauseCapableE2BSandbox = E2BSandbox & {
+  pause: (options?: { keepMemory?: boolean }) => Promise<void>;
+  connect: () => Promise<E2BSandbox>;
 };
 type E2BSandboxStatics = typeof E2BSandbox & {
   listTemplates?: (options: { apiKey?: string }) => Promise<unknown[]>;
@@ -164,6 +168,14 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
         },
         exists: async (sandbox: E2BSandbox, path: string): Promise<boolean> => sandbox.files.exists(path),
         remove: async (sandbox: E2BSandbox, path: string): Promise<void> => { await sandbox.files.remove(path); }
+      },
+
+      pause: async (sandbox: E2BSandbox, options?: PauseOptions) => {
+        await (sandbox as PauseCapableE2BSandbox).pause(options);
+      },
+
+      resume: async (sandbox: E2BSandbox) => {
+        return await (sandbox as PauseCapableE2BSandbox).connect();
       },
 
       getInstance: (sandbox: E2BSandbox): E2BSandbox => sandbox,

--- a/packages/isorun/src/index.ts
+++ b/packages/isorun/src/index.ts
@@ -16,7 +16,13 @@ import type {
   FileEntry,
   RunCommandOptions,
   SandboxInfo,
+  PauseOptions,
 } from '@computesdk/provider'
+
+type PauseCapableIsorunSandbox = Sandbox & {
+  hibernate: (options?: PauseOptions) => Promise<void>
+  resume: () => Promise<void>
+}
 
 export interface IsorunConfig {
   /** API key. Falls back to `ISORUN_API_KEY` env var. The runner endpoint is derived from the key. */
@@ -126,10 +132,15 @@ export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSna
 
       getInfo: async (sandbox: Sandbox): Promise<SandboxInfo> => {
         const i = await sandbox.info()
+        const status: SandboxInfo['status'] =
+          i.status === 'running' ? 'running' :
+          i.status === 'error' ? 'error' :
+          i.status === 'paused' || i.status === 'hibernated' ? 'paused' :
+          'stopped'
         return {
           id: sandbox.id,
           provider: 'isorun',
-          status: i.status === 'running' ? 'running' : i.status === 'error' ? 'error' : 'stopped',
+          status,
           createdAt: new Date(i.createdAt),
           timeout: sandboxTimeouts.get(sandbox) ?? DEFAULT_TIMEOUT_MS,
           metadata: { createMs: i.createMs, image: i.image },
@@ -144,6 +155,14 @@ export const isorun = defineProvider<Sandbox, ConfigWithClient, never, IsorunSna
           return u.toString()
         }
         return url
+      },
+
+      pause: async (sandbox: Sandbox, options?: PauseOptions) => {
+        await (sandbox as PauseCapableIsorunSandbox).hibernate(options)
+      },
+
+      resume: async (sandbox: Sandbox) => {
+        await (sandbox as PauseCapableIsorunSandbox).resume()
       },
 
       getInstance: (sandbox: Sandbox) => sandbox,

--- a/packages/namespace/src/__tests__/pause-resume.test.ts
+++ b/packages/namespace/src/__tests__/pause-resume.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { namespace, mapStatus } from '../index';
+
+function jsonResponse(body: any, status = 200) {
+  return () =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: () => Promise.resolve(body)
+    } as Response);
+}
+
+function mockFetchSequence(...responses: Array<() => Promise<Response>>): Mock<any[], Promise<Response>> {
+  let i = 0;
+  return vi.fn((..._args: any[]): Promise<Response> => {
+    const resp = responses[i++];
+    if (!resp) throw new Error(`Unexpected fetch call #${i}`);
+    return resp();
+  }) as Mock<any[], Promise<Response>>;
+}
+
+describe('namespace mapStatus', () => {
+  it('maps InstanceMetadata.Status to SandboxInfo status', () => {
+    expect(mapStatus(3)).toBe('running');
+    expect(mapStatus(7)).toBe('paused');
+    expect(mapStatus(6)).toBe('paused');
+    expect(mapStatus(4)).toBe('stopped');
+    expect(mapStatus(5)).toBe('stopped');
+    expect(mapStatus(8)).toBe('error');
+    expect(mapStatus(1)).toBe('running');
+    expect(mapStatus(2)).toBe('running');
+    expect(mapStatus('7')).toBe('paused');
+  });
+});
+
+describe('namespace pause/resume', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('pauses and resumes via SuspendInstance/WakeInstance', async () => {
+    const fetch = mockFetchSequence(
+      // create -> CreateInstance
+      jsonResponse({
+        metadata: { instanceId: 'inst-123' },
+        extendedMetadata: { commandServiceEndpoint: 'https://cmd.example' }
+      }),
+      // pause -> SuspendInstance
+      jsonResponse({}),
+      // pause -> DescribeInstance poll
+      jsonResponse({ metadata: { instanceId: 'inst-123', status: 7 } }),
+      // resume -> WakeInstance
+      jsonResponse({}),
+      // resume -> DescribeInstance poll
+      jsonResponse({
+        metadata: { instanceId: 'inst-123', status: 3 },
+        extendedMetadata: { commandServiceEndpoint: 'https://cmd.example' }
+      })
+    );
+    globalThis.fetch = fetch;
+
+    const provider = namespace({ token: 'test-token' });
+    const sandbox = await provider.sandbox.create();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await sandbox.pause!();
+    expect(fetch).toHaveBeenCalledTimes(3);
+    const suspendCall = fetch.mock.calls[1];
+    expect(suspendCall[0]).toContain('SuspendInstance');
+    expect(JSON.parse(suspendCall[1].body as string)).toEqual({ instance_id: 'inst-123' });
+
+    await sandbox.resume!();
+    expect(fetch).toHaveBeenCalledTimes(5);
+    const wakeCall = fetch.mock.calls[3];
+    expect(wakeCall[0]).toContain('WakeInstance');
+    expect(JSON.parse(wakeCall[1].body as string)).toEqual({ instance_id: 'inst-123' });
+  });
+
+  it('rejects keepMemory: false', async () => {
+    const fetch = mockFetchSequence(
+      jsonResponse({
+        metadata: { instanceId: 'inst-123' },
+        extendedMetadata: { commandServiceEndpoint: 'https://cmd.example' }
+      })
+    );
+    globalThis.fetch = fetch;
+
+    const provider = namespace({ token: 'test-token' });
+    const sandbox = await provider.sandbox.create();
+    await expect(sandbox.pause!({ keepMemory: false })).rejects.toThrow(
+      'Namespace does not support filesystem-only pause'
+    );
+  });
+
+  it('getInfo reflects paused status', async () => {
+    const fetch = mockFetchSequence(
+      jsonResponse({
+        metadata: { instanceId: 'inst-123' },
+        extendedMetadata: { commandServiceEndpoint: 'https://cmd.example' }
+      }),
+      jsonResponse({ metadata: { instanceId: 'inst-123', status: 7 } })
+    );
+    globalThis.fetch = fetch;
+
+    const provider = namespace({ token: 'test-token' });
+    const sandbox = await provider.sandbox.create();
+    const info = await sandbox.getInfo();
+    expect(info.status).toBe('paused');
+  });
+});

--- a/packages/namespace/src/index.ts
+++ b/packages/namespace/src/index.ts
@@ -7,7 +7,7 @@
 
 import * as fs from 'fs/promises';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
-import type { CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions, PauseOptions } from '@computesdk/provider';
 
 /**
  * Namespace sandbox instance
@@ -49,7 +49,9 @@ const API_ENDPOINTS = {
   CREATE_INSTANCE: '/namespace.cloud.compute.v1beta.ComputeService/CreateInstance',
   DESCRIBE_INSTANCE: '/namespace.cloud.compute.v1beta.ComputeService/DescribeInstance',
   LIST_INSTANCES: '/namespace.cloud.compute.v1beta.ComputeService/ListInstances',
-  DESTROY_INSTANCE: '/namespace.cloud.compute.v1beta.ComputeService/DestroyInstance'
+  DESTROY_INSTANCE: '/namespace.cloud.compute.v1beta.ComputeService/DestroyInstance',
+  SUSPEND_INSTANCE: '/namespace.cloud.compute.v1beta.ComputeService/SuspendInstance',
+  WAKE_INSTANCE: '/namespace.cloud.compute.v1beta.ComputeService/WakeInstance'
 };
 
 const COMMAND_SERVICE = {
@@ -95,6 +97,57 @@ const handleApiErrors = (response: any) => {
     throw new Error(`Namespace API error: ${response.error}`);
   }
 };
+
+async function describeNamespaceInstance(token: string, instanceId: string): Promise<any> {
+  return fetchNamespace(token, API_ENDPOINTS.DESCRIBE_INSTANCE, {
+    method: 'POST',
+    body: JSON.stringify({ instance_id: instanceId })
+  });
+}
+
+export function mapStatus(status: number | string): SandboxInfo['status'] {
+  const numeric = typeof status === 'string' ? parseInt(status, 10) : status;
+  switch (numeric) {
+    case 3:
+      return 'running';
+    case 7:
+      return 'paused';
+    case 6:
+      // Suspending is a transient state on the way to paused.
+      return 'paused';
+    case 4:
+    case 5:
+      return 'stopped';
+    case 8:
+      return 'error';
+    default:
+      // PREPARING, STARTING, UNKNOWN are all "not yet running" states.
+      return 'running';
+  }
+}
+
+async function waitForInstanceStatus(
+  token: string,
+  instanceId: string,
+  target: number | number[],
+  maxWaitMs: number = 5 * 60 * 1000,
+  intervalMs: number = 3000
+): Promise<any> {
+  const targets = Array.isArray(target) ? target : [target];
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    const response = await describeNamespaceInstance(token, instanceId);
+    const status = response?.metadata?.status;
+    if (targets.includes(status)) {
+      return response;
+    }
+    if (status === 8) {
+      throw new Error(`Namespace instance ${instanceId} entered an error state`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for Namespace instance ${instanceId} to reach status ${JSON.stringify(targets)}`);
+}
 
 export const fetchNamespace = async (
   token: string,
@@ -331,17 +384,53 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
       },
 
       getInfo: async (sandbox: NamespaceSandbox): Promise<SandboxInfo> => {
+        const response = await describeNamespaceInstance(sandbox.token, sandbox.instanceId);
         return {
           id: sandbox.instanceId,
           provider: 'namespace',
-          status: 'running',
+          status: mapStatus(response?.metadata?.status),
           createdAt: sandbox.createdAt,
           timeout: 0,
           metadata: {
             name: sandbox.name,
-            commandServiceEndpoint: sandbox.commandServiceEndpoint,
+            commandServiceEndpoint: response?.extendedMetadata?.commandServiceEndpoint ?? sandbox.commandServiceEndpoint,
           }
         };
+      },
+
+      pause: async (sandbox: NamespaceSandbox, options?: PauseOptions): Promise<void> => {
+        if (options?.keepMemory === false) {
+          throw new Error('Namespace does not support filesystem-only pause; SuspendInstance always preserves memory state.');
+        }
+        try {
+          await fetchNamespace(sandbox.token, API_ENDPOINTS.SUSPEND_INSTANCE, {
+            method: 'POST',
+            body: JSON.stringify({ instance_id: sandbox.instanceId })
+          });
+          await waitForInstanceStatus(sandbox.token, sandbox.instanceId, [7]);
+        } catch (error) {
+          throw new Error(
+            `Failed to pause Namespace instance: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      },
+
+      resume: async (sandbox: NamespaceSandbox): Promise<NamespaceSandbox> => {
+        try {
+          await fetchNamespace(sandbox.token, API_ENDPOINTS.WAKE_INSTANCE, {
+            method: 'POST',
+            body: JSON.stringify({ instance_id: sandbox.instanceId })
+          });
+          const response = await waitForInstanceStatus(sandbox.token, sandbox.instanceId, [3]);
+          return {
+            ...sandbox,
+            commandServiceEndpoint: response?.extendedMetadata?.commandServiceEndpoint ?? sandbox.commandServiceEndpoint
+          };
+        } catch (error) {
+          throw new Error(
+            `Failed to resume Namespace instance: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
       },
 
       getUrl: async (_sandbox: NamespaceSandbox, _options: { port: number; protocol?: string }): Promise<string> => {

--- a/packages/provider/src/__tests__/factory.test.ts
+++ b/packages/provider/src/__tests__/factory.test.ts
@@ -697,13 +697,13 @@ describe('Factory', () => {
       expect(typeof sandbox.pause).toBe('function')
       expect(typeof sandbox.resume).toBe('function')
 
-      await sandbox.pause({ keepMemory: true })
+      await sandbox.pause!({ keepMemory: true })
       expect(pause).toHaveBeenCalledWith(
         { id: 'test-pause', status: 'running' },
         { keepMemory: true }
       )
 
-      await sandbox.resume()
+      await sandbox.resume!()
       expect(resume).toHaveBeenCalledWith({ id: 'test-pause', status: 'running' })
     })
 
@@ -736,7 +736,7 @@ describe('Factory', () => {
 
       const provider = providerFactory({ apiKey: 'test-key' })
       const sandbox = await provider.sandbox.create()
-      await sandbox.resume()
+      await sandbox.resume!()
 
       // Subsequent getInfo should use the resumed sandbox instance
       await sandbox.getInfo()
@@ -770,8 +770,8 @@ describe('Factory', () => {
       const provider = providerFactory({ apiKey: 'test-key' })
       const sandbox = await provider.sandbox.create()
 
-      await expect(sandbox.pause()).rejects.toThrow('Pause is not supported by the mock provider.')
-      await expect(sandbox.resume()).rejects.toThrow('Resume is not supported by the mock provider.')
+      await expect(sandbox.pause!()).rejects.toThrow('Pause is not supported by the mock provider.')
+      await expect(sandbox.resume!()).rejects.toThrow('Resume is not supported by the mock provider.')
     })
   })
 })

--- a/packages/provider/src/__tests__/factory.test.ts
+++ b/packages/provider/src/__tests__/factory.test.ts
@@ -662,5 +662,116 @@ describe('Factory', () => {
       expect(onStdout).toHaveBeenCalledWith('chunk-a\n')
       expect(onStderr).toHaveBeenCalledWith('err-a\n')
     })
+
+    it('should expose pause and resume when provider implements them', async () => {
+      const pause = vi.fn().mockResolvedValue(undefined)
+      const resume = vi.fn().mockResolvedValue(undefined)
+      const methods = {
+        create: vi.fn().mockResolvedValue({
+          sandbox: { id: 'test-pause', status: 'running' },
+          sandboxId: 'test-pause'
+        }),
+        getById: vi.fn().mockResolvedValue(null),
+        list: vi.fn().mockResolvedValue([]),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn().mockResolvedValue({
+          stdout: '', stderr: '', exitCode: 0, durationMs: 1
+        } as CommandResult),
+        getInfo: vi.fn().mockResolvedValue({
+          id: 'test-pause', provider: 'mock', status: 'running',
+          createdAt: new Date(), timeout: 300000
+        } as SandboxInfo),
+        getUrl: vi.fn().mockResolvedValue('https://test-pause-3000.mock.dev'),
+        pause,
+        resume,
+      }
+
+      const providerFactory = defineProvider({
+        name: 'mock',
+        methods: { sandbox: methods }
+      })
+
+      const provider = providerFactory({ apiKey: 'test-key' })
+      const sandbox = await provider.sandbox.create()
+
+      expect(typeof sandbox.pause).toBe('function')
+      expect(typeof sandbox.resume).toBe('function')
+
+      await sandbox.pause({ keepMemory: true })
+      expect(pause).toHaveBeenCalledWith(
+        { id: 'test-pause', status: 'running' },
+        { keepMemory: true }
+      )
+
+      await sandbox.resume()
+      expect(resume).toHaveBeenCalledWith({ id: 'test-pause', status: 'running' })
+    })
+
+    it('should update internal sandbox when resume returns a new instance', async () => {
+      const resumedSandbox = { id: 'test-pause-resumed', status: 'running' }
+      const methods = {
+        create: vi.fn().mockResolvedValue({
+          sandbox: { id: 'test-pause', status: 'running' },
+          sandboxId: 'test-pause'
+        }),
+        getById: vi.fn().mockResolvedValue(null),
+        list: vi.fn().mockResolvedValue([]),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn().mockResolvedValue({
+          stdout: '', stderr: '', exitCode: 0, durationMs: 1
+        } as CommandResult),
+        getInfo: vi.fn().mockResolvedValue({
+          id: 'test-pause', provider: 'mock', status: 'running',
+          createdAt: new Date(), timeout: 300000
+        } as SandboxInfo),
+        getUrl: vi.fn().mockResolvedValue('https://test-pause-3000.mock.dev'),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(resumedSandbox),
+      }
+
+      const providerFactory = defineProvider({
+        name: 'mock',
+        methods: { sandbox: methods }
+      })
+
+      const provider = providerFactory({ apiKey: 'test-key' })
+      const sandbox = await provider.sandbox.create()
+      await sandbox.resume()
+
+      // Subsequent getInfo should use the resumed sandbox instance
+      await sandbox.getInfo()
+      expect(methods.getInfo).toHaveBeenLastCalledWith(resumedSandbox)
+    })
+
+    it('should throw when pause or resume is not supported', async () => {
+      const methods = {
+        create: vi.fn().mockResolvedValue({
+          sandbox: { id: 'test-nopause', status: 'running' },
+          sandboxId: 'test-nopause'
+        }),
+        getById: vi.fn().mockResolvedValue(null),
+        list: vi.fn().mockResolvedValue([]),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn().mockResolvedValue({
+          stdout: '', stderr: '', exitCode: 0, durationMs: 1
+        } as CommandResult),
+        getInfo: vi.fn().mockResolvedValue({
+          id: 'test-nopause', provider: 'mock', status: 'running',
+          createdAt: new Date(), timeout: 300000
+        } as SandboxInfo),
+        getUrl: vi.fn().mockResolvedValue('https://test-nopause-3000.mock.dev')
+      }
+
+      const providerFactory = defineProvider({
+        name: 'mock',
+        methods: { sandbox: methods }
+      })
+
+      const provider = providerFactory({ apiKey: 'test-key' })
+      const sandbox = await provider.sandbox.create()
+
+      await expect(sandbox.pause()).rejects.toThrow('Pause is not supported by the mock provider.')
+      await expect(sandbox.resume()).rejects.toThrow('Resume is not supported by the mock provider.')
+    })
   })
 })

--- a/packages/provider/src/factory.ts
+++ b/packages/provider/src/factory.ts
@@ -22,6 +22,7 @@ import type {
   ListSnapshotsOptions,
   CreateTemplateOptions,
   ListTemplatesOptions,
+  PauseOptions,
 } from './types/index.js';
 import {
   daemonSeedScriptCommand,
@@ -169,6 +170,14 @@ export interface SandboxMethods<TSandbox = any, TConfig = any> {
   runCommand: (sandbox: TSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>;
   getInfo: (sandbox: TSandbox) => Promise<SandboxInfo>;
   getUrl: (sandbox: TSandbox, options: { port: number; protocol?: string }) => Promise<string>;
+
+  // Optional pause/resume lifecycle operations
+  pause?: (sandbox: TSandbox, options?: PauseOptions) => Promise<void>;
+  /**
+   * Resume a paused sandbox. May return a refreshed native sandbox instance;
+   * when returned, the provider wrapper will replace its internal reference.
+   */
+  resume?: (sandbox: TSandbox) => Promise<TSandbox | void>;
 
   // Optional provider-specific typed getInstance method
   getInstance?: (sandbox: TSandbox) => TSandbox;
@@ -489,6 +498,23 @@ class GeneratedSandbox<TSandbox = any> implements ProviderSandbox<TSandbox> {
 
   async getUrl(options: { port: number; protocol?: string }): Promise<string> {
     return await this.methods.getUrl(this.sandbox, options);
+  }
+
+  async pause(options?: PauseOptions): Promise<void> {
+    if (!this.methods.pause) {
+      throw new Error(`Pause is not supported by the ${this.provider} provider.`);
+    }
+    return await this.methods.pause(this.sandbox, options);
+  }
+
+  async resume(): Promise<void> {
+    if (!this.methods.resume) {
+      throw new Error(`Resume is not supported by the ${this.provider} provider.`);
+    }
+    const result = await this.methods.resume(this.sandbox);
+    if (result !== undefined) {
+      this.sandbox = result;
+    }
   }
 
   getProvider(): Provider<TSandbox> {

--- a/packages/provider/src/types/index.ts
+++ b/packages/provider/src/types/index.ts
@@ -14,6 +14,7 @@ export type {
   RunCommandOptions,
   SandboxFileSystem,
   CreateSandboxOptions,
+  PauseOptions,
 } from 'computesdk';
 
 // Provider-specific types (defined in this package)

--- a/packages/superserve/src/index.ts
+++ b/packages/superserve/src/index.ts
@@ -14,12 +14,18 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 const DEFAULT_TIMEOUT_MS = 300_000;
 
+type PauseCapableSuperserveSandbox = SuperserveSandbox & {
+  pause: (options?: PauseOptions) => Promise<void>;
+  resume: () => Promise<void>;
+};
+
 import type {
   CommandResult,
   CreateSandboxOptions,
   FileEntry,
   RunCommandOptions,
   SandboxInfo,
+  PauseOptions,
 } from '@computesdk/provider';
 
 export interface SuperserveConfig {
@@ -188,7 +194,7 @@ export const superserve = defineProvider<SuperserveSandbox, SuperserveConfig>({
       getInfo: async (sandbox: SuperserveSandbox): Promise<SandboxInfo> => {
         const info = await sandbox.getInfo();
         const status: SandboxInfo['status'] =
-          info.status === 'paused' ? 'stopped' :
+          info.status === 'paused' ? 'paused' :
           info.status === 'failed' ? 'error' :
           'running';
         return {
@@ -206,6 +212,14 @@ export const superserve = defineProvider<SuperserveSandbox, SuperserveConfig>({
           'Superserve does not currently support arbitrary port forwarding via getUrl(). ' +
             'Use sandbox.commands.run() to interact with services running inside the sandbox.',
         );
+      },
+
+      pause: async (sandbox: SuperserveSandbox, options?: PauseOptions) => {
+        await (sandbox as PauseCapableSuperserveSandbox).pause(options);
+      },
+
+      resume: async (sandbox: SuperserveSandbox) => {
+        await (sandbox as PauseCapableSuperserveSandbox).resume();
       },
 
       filesystem: {

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { defineProvider, escapeShellArg } from "@computesdk/provider";
-import type { RunCommandOptions, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry } from "computesdk";
+import type { RunCommandOptions, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, PauseOptions } from "computesdk";
 import {
   TenkiSandbox,
   Session,
@@ -48,6 +48,11 @@ interface TenkiScope {
   workspaceId: string;
   projectId: string;
 }
+
+type PauseCapableSession = Session & {
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
+};
 
 // ---------------------------------------------------------------------------
 // Client + scope resolution
@@ -147,6 +152,7 @@ function mapStatus(state: SessionState): SandboxInfo["status"] {
       return "running";
     case "PAUSED":
     case "PAUSING":
+      return "paused";
     case "TERMINATING":
     case "TERMINATED":
       return "stopped";
@@ -337,6 +343,14 @@ export const tenki = defineProvider<Session, TenkiConfig>({
       },
 
       getInstance: (sandbox) => sandbox,
+
+      pause: async (sandbox, _options?: PauseOptions) => {
+        await (sandbox as PauseCapableSession).pause();
+      },
+
+      resume: async (sandbox) => {
+        await (sandbox as PauseCapableSession).resume();
+      },
 
       // Native filesystem: Tenki exposes real file primitives over its data
       // plane, so we bypass the shell-based fallback (and its escaping

--- a/packages/test-utils/src/provider-test-suite.ts
+++ b/packages/test-utils/src/provider-test-suite.ts
@@ -27,6 +27,8 @@ export interface ProviderTestConfig {
   supportsGetUrl?: boolean;
   /** Base path for filesystem tests (default: '/tmp') */
   filesystemBasePath?: string;
+  /** Whether this provider supports pause/resume lifecycle tests */
+  supportsPauseResume?: boolean;
 }
 
 /**
@@ -43,6 +45,7 @@ export function defineProviderTests(config: ProviderTestConfig) {
     ports,
     supportsGetUrl = true,
     filesystemBasePath = '/tmp',
+    supportsPauseResume = false,
   } = config;
 
   return () => {
@@ -222,6 +225,30 @@ export function defineProviderTests(config: ProviderTestConfig) {
         expect(result.stdout.trim()).toBe('test content');
       }, timeout);
     });
+
+    if (!skipIntegration && supportsPauseResume) {
+      describe('Pause/Resume lifecycle', () => {
+        it('should pause and resume while preserving filesystem state', async () => {
+          const markerPath = `${filesystemBasePath}/computesdk-pause-resume-marker.txt`;
+          const markerContent = `paused-${Date.now()}`;
+
+          await sandbox.runCommand(`sh -c 'echo "${markerContent}" > ${markerPath}'`);
+
+          await sandbox.pause!();
+          const pausedInfo = await sandbox.getInfo();
+          expect(pausedInfo.status).toBe('paused');
+
+          await sandbox.resume!();
+          const resumedInfo = await sandbox.getInfo();
+          expect(resumedInfo.status).toBe('running');
+
+          if (supportsFilesystem) {
+            const result = await sandbox.runCommand(`cat ${markerPath}`);
+            expect(result.stdout.trim()).toBe(markerContent);
+          }
+        }, timeout);
+      });
+    }
   };
 }
 


### PR DESCRIPTION
This pull request adds standardized pause and resume support for sandboxes across all ComputeSDK providers, along with improved status handling to distinguish paused sandboxes from stopped ones. The changes introduce a new `PauseOptions` type, update provider interfaces, and implement pause/resume logic for each provider. This enables workflows to reliably pause and resume sandboxes, preserving their state as supported by each backend.

**Core API and Type Updates:**

* Added new `PauseOptions` interface to specify options like `keepMemory` when pausing a sandbox; exported from `@computesdk/provider` and used in all providers. [[1]](diffhunk://#diff-b9c9b0c675f657ecb60e1ae3f7517134af3d905ee03988791c9bb6589702f8b9R27-R38) [[2]](diffhunk://#diff-b8be399ada259d832b4c08c0eea985d4b0609aeea826ab881cd78820eaf95e41R33)
* Updated `Sandbox` interface to include optional `pause(options?: PauseOptions)` and `resume()` methods, and extended `SandboxInfo['status']` to include `'paused'`. [[1]](diffhunk://#diff-b9c9b0c675f657ecb60e1ae3f7517134af3d905ee03988791c9bb6589702f8b9L36-R48) [[2]](diffhunk://#diff-b9c9b0c675f657ecb60e1ae3f7517134af3d905ee03988791c9bb6589702f8b9R188-R197)

**Provider Implementations:**

* **Agentuity:** Added `pause` and `resume` methods using the Agentuity API; status mapping now distinguishes `'paused'` from `'stopped'`. [[1]](diffhunk://#diff-5065ef454a3d3cffc47e2a602010586fdf68ec7b2e8da89db112b05977844c9bR24) [[2]](diffhunk://#diff-5065ef454a3d3cffc47e2a602010586fdf68ec7b2e8da89db112b05977844c9bL462-R467) [[3]](diffhunk://#diff-5065ef454a3d3cffc47e2a602010586fdf68ec7b2e8da89db112b05977844c9bR654-R663)
* **CreateOS:** Implemented `pause` and `resume` using the provider’s VM pause/resume; status mapping and tests updated to handle `'paused'`. [[1]](diffhunk://#diff-24b5f217fc6ca188248e21432ca52e3de8c87c8c30819f534400f376eb915868R48) [[2]](diffhunk://#diff-24b5f217fc6ca188248e21432ca52e3de8c87c8c30819f534400f376eb915868L195-R199) [[3]](diffhunk://#diff-24b5f217fc6ca188248e21432ca52e3de8c87c8c30819f534400f376eb915868R410-R422) [[4]](diffhunk://#diff-c92caa039bc9290ef6e4c0cfbde6f92829fbcd3ca28493aed472c037275f32dcL62-R63)
* **CodeSandbox:** Added `pause` (using `hibernate`) and `resume` (using `sdk.sandboxes.resume`) with API key management. [[1]](diffhunk://#diff-72cb8bc486ec651f1a32bfe67caceb8e1748edfbb3624f89462e01969f5eb16aL9-R14) [[2]](diffhunk://#diff-72cb8bc486ec651f1a32bfe67caceb8e1748edfbb3624f89462e01969f5eb16aR55) [[3]](diffhunk://#diff-72cb8bc486ec651f1a32bfe67caceb8e1748edfbb3624f89462e01969f5eb16aR76) [[4]](diffhunk://#diff-72cb8bc486ec651f1a32bfe67caceb8e1748edfbb3624f89462e01969f5eb16aR165-R180)
* **Daytona:** Implemented `pause` and `resume` for VM sandboxes and improved status mapping to distinguish paused state. [[1]](diffhunk://#diff-0c75d0d85a7366d8c6928faabe60d9bf8185619ba3954fc0b7ae903b638819daL8-R8) [[2]](diffhunk://#diff-0c75d0d85a7366d8c6928faabe60d9bf8185619ba3954fc0b7ae903b638819daR22-R30) [[3]](diffhunk://#diff-0c75d0d85a7366d8c6928faabe60d9bf8185619ba3954fc0b7ae903b638819daL177-R186) [[4]](diffhunk://#diff-0c75d0d85a7366d8c6928faabe60d9bf8185619ba3954fc0b7ae903b638819daR208-R217)
* **E2B:** Added `pause` and `resume` methods using E2B’s API, supporting memory snapshots if available. [[1]](diffhunk://#diff-d152c2c5f7bb9b6761901329fa39d095baf43675c6cf99ced1ebe24e1e37fb62L8-R8) [[2]](diffhunk://#diff-d152c2c5f7bb9b6761901329fa39d095baf43675c6cf99ced1ebe24e1e37fb62R22-R25) [[3]](diffhunk://#diff-d152c2c5f7bb9b6761901329fa39d095baf43675c6cf99ced1ebe24e1e37fb62R173-R180)
* **Isorun:** Implemented `pause` (using `hibernate`) and `resume`, and updated status mapping for paused/hibernated states. [[1]](diffhunk://#diff-46186efed631e712a4941f8cd0fb6209a244763f812489050ba468682203bfdcR19-R26) [[2]](diffhunk://#diff-46186efed631e712a4941f8cd0fb6209a244763f812489050ba468682203bfdcR135-R143) [[3]](diffhunk://#diff-46186efed631e712a4941f8cd0fb6209a244763f812489050ba468682203bfdcR160-R167)

These changes ensure all major ComputeSDK-compatible providers now support pausing and resuming sandboxes in a consistent way, with improved status reporting for orchestrating complex workflows.