### PR TITLE
Add @computesdk/tilion browser provider

### DIFF
--- a/packages/tilion/CHANGELOG.md
+++ b/packages/tilion/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @computesdk/tilion
+
+## 0.1.0
+
+- Initial Tilion browser provider: session create / getById / list / destroy / getConnectUrl.

--- a/packages/tilion/README.md
+++ b/packages/tilion/README.md
@@ -25,7 +25,7 @@ await t.session.destroy(session.sessionId);
 | option | env | default |
 |---|---|---|
 | `apiKey` | `TILION_API_KEY` | — (required) |
-| `baseUrl` | `TILION_BASE_URL` | `https://tilion-control.fly.dev` |
+| `baseUrl` | `TILION_BASE_URL` | `https://api.tilion.dev` |
 
 `create` returns an authenticated CDP url inline (`connectUrl`), so `connectOverCDP` works with no
 extra round trip. Sessions are non-stealth with direct egress by default.

--- a/packages/tilion/README.md
+++ b/packages/tilion/README.md
@@ -1,0 +1,33 @@
+# @computesdk/tilion
+
+Tilion browser provider for ComputeSDK. Cloud browser sessions via [Tilion](https://tilion.dev) (beta).
+
+```bash
+npm install @computesdk/tilion
+```
+
+```ts
+import { tilion } from '@computesdk/tilion';
+import { chromium } from 'playwright-core';
+
+const t = tilion({ apiKey: process.env.TILION_API_KEY });
+
+const session = await t.session.create();
+const browser = await chromium.connectOverCDP(session.connectUrl);
+const page = browser.contexts()[0].pages()[0];
+await page.goto('https://example.com');
+
+await t.session.destroy(session.sessionId);
+```
+
+## Config
+
+| option | env | default |
+|---|---|---|
+| `apiKey` | `TILION_API_KEY` | — (required) |
+| `baseUrl` | `TILION_BASE_URL` | `https://tilion-control.fly.dev` |
+
+`create` returns an authenticated CDP url inline (`connectUrl`), so `connectOverCDP` works with no
+extra round trip. Sessions are non-stealth with direct egress by default.
+
+Get an API key at [tilion.dev](https://tilion.dev). Beta — reach out if you need one provisioned for testing.

--- a/packages/tilion/package.json
+++ b/packages/tilion/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@computesdk/tilion",
+  "version": "0.1.0",
+  "description": "Tilion browser provider for ComputeSDK - cloud browser sessions powered by Tilion (beta)",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": ["computesdk", "tilion", "browser", "headless", "playwright", "provider"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/tilion"
+  },
+  "homepage": "https://tilion.dev",
+  "bugs": { "url": "https://github.com/computesdk/computesdk/issues" },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/tilion/src/__tests__/index.test.ts
+++ b/packages/tilion/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { runBrowserProviderTestSuite } from '@computesdk/test-utils';
+import { tilion } from '../index';
+
+runBrowserProviderTestSuite({
+  name: 'tilion',
+  provider: tilion({}),
+  skipIntegration: !process.env.TILION_API_KEY,
+});

--- a/packages/tilion/src/index.ts
+++ b/packages/tilion/src/index.ts
@@ -1,0 +1,137 @@
+/**
+ * Tilion Browser Provider - Factory-based Implementation
+ *
+ * Cloud browser sessions via the Tilion platform (https://tilion.dev). Tilion's API returns an
+ * authenticated CDP websocket url inline on create, so `connectOverCDP` works with no extra round
+ * trip. Sessions here are created non-stealth with direct egress, to match how the other providers
+ * are benchmarked.
+ */
+
+import { defineBrowserProvider } from '@computesdk/provider';
+
+import type { CreateBrowserSessionOptions } from '@computesdk/provider';
+
+/**
+ * Shape of a Tilion session as returned by the REST API.
+ */
+interface TilionSession {
+  session_id: string;
+  connect_url?: string;
+  state?: string;
+  region?: string | null;
+}
+
+/**
+ * Tilion-specific configuration options.
+ */
+export interface TilionConfig {
+  /** Tilion API key — falls back to TILION_API_KEY env var. Get one at https://tilion.dev */
+  apiKey?: string;
+  /** Control-plane base URL — falls back to TILION_BASE_URL, then the public endpoint. */
+  baseUrl?: string;
+}
+
+function resolveConfig(config: TilionConfig) {
+  const apiKey =
+    config.apiKey || (typeof process !== 'undefined' && process.env?.TILION_API_KEY) || '';
+  if (!apiKey) {
+    throw new Error(
+      `Missing Tilion API key. Provide 'apiKey' in config or set TILION_API_KEY environment variable. ` +
+        `Get your API key from https://tilion.dev`,
+    );
+  }
+  const baseUrl = (
+    config.baseUrl ||
+    (typeof process !== 'undefined' && process.env?.TILION_BASE_URL) ||
+    'https://tilion-control.fly.dev'
+  ).replace(/\/+$/, '');
+  return { apiKey, baseUrl };
+}
+
+function headers(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' };
+}
+
+/** The API may hand back ws://; the public endpoint terminates TLS, so upgrade to wss://. */
+function fixScheme(baseUrl: string, url: string): string {
+  return baseUrl.startsWith('https') && url.startsWith('ws://') ? 'wss://' + url.slice(5) : url;
+}
+
+function normalize(baseUrl: string, s: TilionSession) {
+  const connectUrl = fixScheme(baseUrl, s.connect_url || '');
+  return { session: s, sessionId: s.session_id, connectUrl };
+}
+
+/**
+ * Create a Tilion browser provider instance.
+ *
+ * @example
+ * ```ts
+ * import { tilion } from '@computesdk/tilion';
+ * import { chromium } from 'playwright-core';
+ *
+ * const t = tilion({ apiKey: 'ph_live_...' });
+ * const s = await t.session.create();
+ * const browser = await chromium.connectOverCDP(s.connectUrl);
+ * const page = browser.contexts()[0].pages()[0];
+ * await page.goto('https://example.com');
+ * ```
+ */
+export const tilion = defineBrowserProvider<TilionSession, TilionConfig>({
+  name: 'tilion',
+  methods: {
+    session: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      create: async (config: TilionConfig, _options?: CreateBrowserSessionOptions) => {
+        const { apiKey, baseUrl } = resolveConfig(config);
+        // Tilion runs non-stealth with direct egress by default; residential egress is an opt-in
+        // premium path not exercised by the benchmark. `stealth`/`proxies` from options are not
+        // mapped here so every provider is compared on the same session shape.
+        const r = await fetch(`${baseUrl}/v1/session`, {
+          method: 'POST',
+          headers: headers(apiKey),
+          body: JSON.stringify({ residential: false }),
+        });
+        if (!r.ok) throw new Error(`tilion create ${r.status}: ${await r.text()}`);
+        const s = (await r.json()) as TilionSession;
+        if (!s.session_id || !s.connect_url) {
+          throw new Error('tilion: response missing session_id or connect_url');
+        }
+        return normalize(baseUrl, s);
+      },
+
+      getById: async (config: TilionConfig, sessionId: string) => {
+        const { apiKey, baseUrl } = resolveConfig(config);
+        const r = await fetch(`${baseUrl}/v1/session/${sessionId}`, { headers: headers(apiKey) });
+        if (!r.ok) return null;
+        return normalize(baseUrl, (await r.json()) as TilionSession);
+      },
+
+      list: async (config: TilionConfig) => {
+        const { apiKey, baseUrl } = resolveConfig(config);
+        const r = await fetch(`${baseUrl}/v1/sessions`, { headers: headers(apiKey) });
+        if (!r.ok) return [];
+        const rows = (await r.json()) as TilionSession[];
+        return rows.map((s) => normalize(baseUrl, s));
+      },
+
+      destroy: async (config: TilionConfig, sessionId: string) => {
+        const { apiKey, baseUrl } = resolveConfig(config);
+        await fetch(`${baseUrl}/v1/session/${sessionId}`, {
+          method: 'DELETE',
+          headers: headers(apiKey),
+        }).catch(() => {});
+      },
+
+      getConnectUrl: async (config: TilionConfig, sessionId: string) => {
+        const { apiKey, baseUrl } = resolveConfig(config);
+        const r = await fetch(`${baseUrl}/v1/session/${sessionId}/connect`, {
+          headers: headers(apiKey),
+        });
+        if (!r.ok) throw new Error(`tilion connect ${r.status}: ${await r.text()}`);
+        const { connect_url } = (await r.json()) as { connect_url: string };
+        return fixScheme(baseUrl, connect_url);
+      },
+    },
+  },
+});

--- a/packages/tilion/src/index.ts
+++ b/packages/tilion/src/index.ts
@@ -43,7 +43,7 @@ function resolveConfig(config: TilionConfig) {
   const baseUrl = (
     config.baseUrl ||
     (typeof process !== 'undefined' && process.env?.TILION_BASE_URL) ||
-    'https://tilion-control.fly.dev'
+    'https://api.tilion.dev'
   ).replace(/\/+$/, '');
   return { apiKey, baseUrl };
 }
@@ -57,9 +57,43 @@ function fixScheme(baseUrl: string, url: string): string {
   return baseUrl.startsWith('https') && url.startsWith('ws://') ? 'wss://' + url.slice(5) : url;
 }
 
-function normalize(baseUrl: string, s: TilionSession) {
-  const connectUrl = fixScheme(baseUrl, s.connect_url || '');
+/** Encode a session id before interpolating it into a request path so it can't alter the route. */
+function enc(sessionId: string): string {
+  return encodeURIComponent(sessionId);
+}
+
+/**
+ * Shape a session that is guaranteed to carry a connect url (create / getById). Throws if the API
+ * omitted it, rather than handing back a present-but-empty connectUrl that would fail a CDP connect.
+ */
+function toSession(baseUrl: string, s: TilionSession) {
+  if (!s.session_id || !s.connect_url) {
+    throw new Error('tilion: response missing session_id or connect_url');
+  }
+  return { session: s, sessionId: s.session_id, connectUrl: fixScheme(baseUrl, s.connect_url) };
+}
+
+/**
+ * Shape a session where the connect url may legitimately be absent (e.g. list entries). Leaves
+ * connectUrl undefined — not "" — so callers don't attempt a CDP connect with an empty url.
+ */
+function toListEntry(baseUrl: string, s: TilionSession) {
+  const connectUrl = s.connect_url ? fixScheme(baseUrl, s.connect_url) : undefined;
   return { session: s, sessionId: s.session_id, connectUrl };
+}
+
+/**
+ * Mint a fresh CDP connect url for a session. Tilion connect tokens are single-use and issued on
+ * demand, so the create response and this endpoint carry a `connect_url` while plain session reads
+ * (getById / list) return `connect_url: null`.
+ */
+async function mintConnectUrl(baseUrl: string, apiKey: string, sessionId: string): Promise<string> {
+  const r = await fetch(`${baseUrl}/v1/session/${enc(sessionId)}/connect`, {
+    headers: headers(apiKey),
+  });
+  if (!r.ok) throw new Error(`tilion connect ${r.status}: ${await r.text()}`);
+  const { connect_url } = (await r.json()) as { connect_url: string };
+  return fixScheme(baseUrl, connect_url);
 }
 
 /**
@@ -93,44 +127,51 @@ export const tilion = defineBrowserProvider<TilionSession, TilionConfig>({
           body: JSON.stringify({ residential: false }),
         });
         if (!r.ok) throw new Error(`tilion create ${r.status}: ${await r.text()}`);
-        const s = (await r.json()) as TilionSession;
-        if (!s.session_id || !s.connect_url) {
-          throw new Error('tilion: response missing session_id or connect_url');
-        }
-        return normalize(baseUrl, s);
+        return toSession(baseUrl, (await r.json()) as TilionSession);
       },
 
       getById: async (config: TilionConfig, sessionId: string) => {
         const { apiKey, baseUrl } = resolveConfig(config);
-        const r = await fetch(`${baseUrl}/v1/session/${sessionId}`, { headers: headers(apiKey) });
-        if (!r.ok) return null;
-        return normalize(baseUrl, (await r.json()) as TilionSession);
+        const r = await fetch(`${baseUrl}/v1/session/${enc(sessionId)}`, {
+          headers: headers(apiKey),
+        });
+        // 404 means no such session — a null return, not an error.
+        if (r.status === 404) return null;
+        if (!r.ok) throw new Error(`tilion getById ${r.status}: ${await r.text()}`);
+        const s = (await r.json()) as TilionSession;
+        // Session reads don't re-issue a connect url; mint a fresh one so callers get a usable
+        // connectUrl (the BrowserSession contract requires it) rather than an empty string.
+        const connectUrl = s.connect_url
+          ? fixScheme(baseUrl, s.connect_url)
+          : await mintConnectUrl(baseUrl, apiKey, s.session_id);
+        return { session: s, sessionId: s.session_id, connectUrl };
       },
 
       list: async (config: TilionConfig) => {
         const { apiKey, baseUrl } = resolveConfig(config);
         const r = await fetch(`${baseUrl}/v1/sessions`, { headers: headers(apiKey) });
-        if (!r.ok) return [];
+        // Surface failures (e.g. auth) rather than masking them as an empty list.
+        if (!r.ok) throw new Error(`tilion list ${r.status}: ${await r.text()}`);
         const rows = (await r.json()) as TilionSession[];
-        return rows.map((s) => normalize(baseUrl, s));
+        return rows.map((s) => toListEntry(baseUrl, s));
       },
 
       destroy: async (config: TilionConfig, sessionId: string) => {
         const { apiKey, baseUrl } = resolveConfig(config);
-        await fetch(`${baseUrl}/v1/session/${sessionId}`, {
+        const r = await fetch(`${baseUrl}/v1/session/${enc(sessionId)}`, {
           method: 'DELETE',
           headers: headers(apiKey),
-        }).catch(() => {});
+        });
+        // Deleting an already-gone session (404) is a no-op; surface any other failure so
+        // callers can detect e.g. invalid credentials or leaked sessions.
+        if (!r.ok && r.status !== 404) {
+          throw new Error(`tilion destroy ${r.status}: ${await r.text()}`);
+        }
       },
 
       getConnectUrl: async (config: TilionConfig, sessionId: string) => {
         const { apiKey, baseUrl } = resolveConfig(config);
-        const r = await fetch(`${baseUrl}/v1/session/${sessionId}/connect`, {
-          headers: headers(apiKey),
-        });
-        if (!r.ok) throw new Error(`tilion connect ${r.status}: ${await r.text()}`);
-        const { connect_url } = (await r.json()) as { connect_url: string };
-        return fixScheme(baseUrl, connect_url);
+        return mintConnectUrl(baseUrl, apiKey, sessionId);
       },
     },
   },

--- a/packages/tilion/tsconfig.json
+++ b/packages/tilion/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tilion/tsup.config.ts
+++ b/packages/tilion/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2068,6 +2068,40 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/tilion:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/upstash:
     dependencies:
       '@computesdk/provider':


### PR DESCRIPTION
Adds **Tilion** ([tilion.dev](https://tilion.dev)) as a browser provider under `packages/tilion`, following the `packages/kernel` layout.

We're in **beta** and would like to be included in the benchmarks — happy to provide an API key for the ongoing daily run (just say where to send it, or grab one at tilion.dev).

### What's here
- `src/index.ts` — `defineBrowserProvider` with the full session lifecycle: `create`, `getById`, `list`, `destroy`, `getConnectUrl`, over Tilion's REST API using `fetch` (no extra SDK dependency). `create` returns an authenticated CDP url inline, so `connectOverCDP` works with no extra round trip. Sessions are created non-stealth with direct egress, to match how the other providers are benchmarked.
- Config resolves `apiKey` from `TILION_API_KEY` and `baseUrl` from `TILION_BASE_URL` (defaults to the public endpoint).
- Shared browser-provider test suite wired via `@computesdk/test-utils`, integration-gated on `TILION_API_KEY`.

### Validation
Typechecks (`tsc --noEmit`) and builds clean (`tsup` → CJS + ESM + DTS).

### Getting a key
You'll need a `TILION_API_KEY` for the daily run. Tell us where to send one and we'll issue a key with credits pre-loaded, scoped for benchmarking — no signup friction. Happy to make any changes you'd like to the package.
