### PR TITLE
Update beam SDK version

### DIFF
--- a/.changeset/fast-beam-inline-exec.md
+++ b/.changeset/fast-beam-inline-exec.md
@@ -1,5 +1,0 @@
----
-"@computesdk/beam": patch
----
-
-Use Beam's inline command completion path to avoid status and output polling during sandbox commands.

--- a/.changeset/fast-beam-inline-exec.md
+++ b/.changeset/fast-beam-inline-exec.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/beam": patch
+---
+
+Use Beam's inline command completion path to avoid status and output polling during sandbox commands.

--- a/packages/beam/package.json
+++ b/packages/beam/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@beamcloud/beam-js": "^1.0.12",
+    "@beamcloud/beam-js": "^1.0.13",
     "computesdk": "workspace:*",
     "@computesdk/provider": "workspace:*"
   },

--- a/packages/beam/package.json
+++ b/packages/beam/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@beamcloud/beam-js": "1.0.0-rc.30",
+    "@beamcloud/beam-js": "^1.0.12",
     "computesdk": "workspace:*",
     "@computesdk/provider": "workspace:*"
   },

--- a/packages/beam/src/index.ts
+++ b/packages/beam/src/index.ts
@@ -202,7 +202,10 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
           if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
           if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
 
-          const proc = await sandbox.exec(['sh', '-c', fullCommand]);
+          const proc = await sandbox.exec(
+            ['sh', '-c', fullCommand],
+            { wait: true } as Parameters<SandboxInstance['exec']>[1],
+          );
           await proc.wait();
           const [stdoutStr, stderrStr] = await Promise.all([proc.stdout.read(), proc.stderr.read()]);
           return { stdout: stdoutStr || '', stderr: stderrStr || '', exitCode: proc.exitCode || 0, durationMs: Date.now() - startTime };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,8 +323,8 @@ importers:
   packages/beam:
     dependencies:
       '@beamcloud/beam-js':
-        specifier: 1.0.0-rc.30
-        version: 1.0.0-rc.30(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
+        specifier: ^1.0.12
+        version: 1.0.12(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2548,8 +2548,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.0-rc.30':
-    resolution: {integrity: sha512-lIs9Y5yD9xK1ZpUqAY1VQEBwoxJmnaghd9aB9+DvuBcjEEoU7y7XpU42h6Jh37DKt20uYjqCWXHTauVPHFcI2Q==}
+  '@beamcloud/beam-js@1.0.12':
+    resolution: {integrity: sha512-y1tIvqphJNvwKjSqOikkJ+viUtCpbjXWZT5sG7+QbLgUd10QQshXf7cbMe/xtWc55nqzvFDfB5wQI5Gmh1XU5g==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -5416,9 +5416,6 @@ packages:
 
   axios@1.11.0:
     resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
-
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
@@ -9728,18 +9725,19 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.0-rc.30(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.12(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
     dependencies:
       archiver: 7.0.1
-      axios: 1.13.5
+      axios: 1.18.1
       commander: 12.1.0
       ignore: 7.0.5
       strip-ansi: 7.2.0
       typescript: 5.8.3
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
+      - supports-color
       - utf-8-validate
 
   '@blaxel/core@0.3.3(@hey-api/openapi-ts@0.83.1(magicast@0.3.5)(typescript@5.8.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
@@ -12869,14 +12867,6 @@ snapshots:
   aws4fetch@1.0.20: {}
 
   axios@1.11.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,8 +323,8 @@ importers:
   packages/beam:
     dependencies:
       '@beamcloud/beam-js':
-        specifier: ^1.0.12
-        version: 1.0.12(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
+        specifier: ^1.0.13
+        version: 1.0.13(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2548,8 +2548,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.12':
-    resolution: {integrity: sha512-y1tIvqphJNvwKjSqOikkJ+viUtCpbjXWZT5sG7+QbLgUd10QQshXf7cbMe/xtWc55nqzvFDfB5wQI5Gmh1XU5g==}
+  '@beamcloud/beam-js@1.0.13':
+    resolution: {integrity: sha512-y2DDUKNr2lK8mQbeSkeo1W6RMhTeLeZRyED8FfxjowLxYEj2QN3kgXxn2/v93OY1OCRW4mRYSe0+cHhpe65iqQ==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -9725,7 +9725,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.12(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.13(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
     dependencies:
       archiver: 7.0.1
       axios: 1.18.1


### PR DESCRIPTION
## What changed

- Request Beam inline command completion for `runCommand`.
- Require the published `@beamcloud/beam-js@^1.0.13` release.

## Why

Beam JS 1.0.13 can return short command results with the exec response, removing status and output-fetch round trips while preserving fallback polling for longer-running commands.

## Package validation

- `pnpm install --filter @computesdk/beam`
- 15/15 adapter tests
- `pnpm --filter @computesdk/beam run typecheck`
- `pnpm --filter @computesdk/beam run build`
- installed dependency reports Beam JS 1.0.13
- exact latest upstream benchmark dependency tree verified