### PR TITLE
fix: forward timeout to createos-sandbox exec requests

### DIFF
--- a/.changeset/forward-exec-timeout.md
+++ b/.changeset/forward-exec-timeout.md
@@ -1,0 +1,7 @@
+---
+"@computesdk/createos-sandbox": patch
+---
+
+Forward timeout to createos-sandbox exec requests
+
+The `runCommand` method now passes `options.timeout` as `timeoutMs` to the underlying `@nodeops-createos/sandbox` exec call. Previously the timeout was ignored and the SDK used a hardcoded 60s default, causing long-running commands (e.g. dax benchmark) to time out.

--- a/packages/createos-sandbox/src/index.ts
+++ b/packages/createos-sandbox/src/index.ts
@@ -386,10 +386,11 @@ export const createosSandbox = defineProvider<Sandbox, CreateosConfig>({
         // `sh -c` (not `bash -lc`): POSIX-portable so bare rootfses without
         // bash still run. buildScript only emits POSIX constructs. Transport /
         // auth errors propagate; a command that ran reports its own exit code.
+        const execOpts = options?.timeout ? { timeoutMs: options.timeout } : undefined;
         const { result, exec_ms } = await sandbox.runCommand("sh", [
           "-c",
           buildScript(command, options),
-        ]);
+        ], execOpts);
         const stderr = result.error ? `${result.stderr}${result.error}` : result.stderr;
         return {
           stdout: result.stdout,


### PR DESCRIPTION
## Summary

- Forward `options.timeout` from `RunCommandOptions` to the underlying `@nodeops-createos/sandbox` exec call as `timeoutMs`
- Previously the timeout was ignored and the SDK used a hardcoded 60s default, causing long-running commands (e.g. dax benchmark ~120s) to time out with `CreateosSandboxTimeoutError`

## Changes

`packages/createos-sandbox/src/index.ts` — `runCommand` method now passes `{ timeoutMs: options.timeout }` to `sandbox.runCommand()` when a timeout is specified.

## Test plan

- [x] Verified locally: dax benchmark completes successfully with 600s timeout (previously timed out at 60s)
- [x] No change when timeout is not specified (undefined → default behavior)