### PR TITLE
changeset for beam sdk update

### DIFF
--- a/.changeset/beam-sdk-update.md
+++ b/.changeset/beam-sdk-update.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/beam': minor
+---
+
+Update `@beamcloud/beam-js` SDK to `^1.0.13` and switch `runCommand` to use Beam's inline command completion (`sandbox.exec(..., { wait: true })`) for synchronous command output.


### PR DESCRIPTION
## Summary

- Add a `minor` changeset for `@computesdk/beam` reflecting the Beam SDK upgrade and inline command completion change from #659.

## Changeset

```
---
'@computesdk/beam': minor
---

Update `@beamcloud/beam-js` SDK to `^1.0.13` and switch `runCommand` to use Beam's inline command completion (`sandbox.exec(..., { wait: true })`) for synchronous command output.
```