### PR TITLE
chore(tenki): bump sandbox sdk to 0.5.4

### DIFF
--- a/.changeset/bright-ravens-fly.md
+++ b/.changeset/bright-ravens-fly.md
@@ -1,0 +1,6 @@
+---
+"@computesdk/tenki": patch
+"@computesdk/workbench": patch
+---
+
+Update `@tenkicloud/sandbox` to 0.5.4 and replace project scope with server-side workspace inference.

--- a/docs/providers/tenki.md
+++ b/docs/providers/tenki.md
@@ -68,9 +68,9 @@ interface TenkiConfig {
   apiKey?: string;
   /** API base URL. Falls back to TENKI_API_URL, then https://api.tenki.cloud. */
   baseUrl?: string;
-  /** Workspace to create sandboxes in. Falls back to TENKI_WORKSPACE_ID, then auto-resolved from the API key. */
+  /** Workspace to create sandboxes in. Falls back to TENKI_WORKSPACE_ID; workspace API keys infer it server-side. */
   workspaceId?: string;
-  /** Project to create sandboxes in. Falls back to TENKI_PROJECT_ID, then auto-resolved from the API key. */
+  /** @deprecated Tenki no longer scopes sandboxes by project. */
   projectId?: string;
   /** Default runCommand timeout in milliseconds. */
   timeout?: number;
@@ -96,6 +96,6 @@ interface TenkiConfig {
 
 ### Notes
 
-* When `workspaceId`/`projectId` are not set, the provider resolves them once from the API key's identity (first workspace with a project). Set them explicitly, or via `TENKI_WORKSPACE_ID` / `TENKI_PROJECT_ID`, to skip the lookup.
+* Workspace API keys infer their workspace server-side. Set `workspaceId`, or `TENKI_WORKSPACE_ID`, only when using trusted service credentials that require explicit scope.
 * Background commands (`{ background: true }`) detach stdio automatically; a bare `&` would hold the exec output stream open.
 * Snapshots and pause/resume exist in the underlying `@tenkicloud/sandbox` SDK but are not yet wired to the provider's snapshot methods. For advanced features (SSH, volumes, tunnels, git, snapshots), use `sandbox.getInstance()` to reach the SDK `Session` directly.

--- a/packages/tenki/README.md
+++ b/packages/tenki/README.md
@@ -68,12 +68,12 @@ const url = await sandbox.getUrl({ port: 3000 });
 |---|---|---|---|
 | `apiKey` | `TENKI_API_KEY` / `TENKI_AUTH_TOKEN` | required | Tenki API key (`tk_...`) |
 | `baseUrl` | `TENKI_API_URL` | `https://api.tenki.cloud` | API endpoint |
-| `workspaceId` | `TENKI_WORKSPACE_ID` | auto-resolved | Workspace for new sandboxes |
-| `projectId` | `TENKI_PROJECT_ID` | auto-resolved | Project for new sandboxes |
+| `workspaceId` | `TENKI_WORKSPACE_ID` | inferred from workspace API key | Explicit workspace for trusted service credentials |
+| `projectId` | - | ignored | Deprecated; Tenki no longer scopes sandboxes by project |
 | `timeout` | - | none | Default `runCommand` timeout (ms) |
 | `cpuCores` / `memoryMb` / `diskSizeGb` | - | Tenki defaults | Default sandbox resources |
 
-When `workspaceId`/`projectId` are not set, the provider resolves them once from the API key's identity (first workspace with a project).
+Workspace API keys infer their workspace server-side. Set `workspaceId`, or `TENKI_WORKSPACE_ID`, only when using trusted service credentials that require explicit scope.
 
 Per-sandbox resource overrides are accepted on `create`:
 

--- a/packages/tenki/package.json
+++ b/packages/tenki/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@tenkicloud/sandbox": "^0.4.0",
+    "@tenkicloud/sandbox": "^0.5.4",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/packages/tenki/src/__tests__/index.test.ts
+++ b/packages/tenki/src/__tests__/index.test.ts
@@ -6,7 +6,6 @@ runProviderTestSuite({
   provider: tenki({
     apiKey: process.env.TENKI_API_KEY,
     workspaceId: process.env.TENKI_WORKSPACE_ID,
-    projectId: process.env.TENKI_PROJECT_ID,
   }),
   supportsFilesystem: true,
   supportsGetUrl: true,

--- a/packages/tenki/src/__tests__/unit.test.ts
+++ b/packages/tenki/src/__tests__/unit.test.ts
@@ -4,7 +4,7 @@
  * filesystem path, and not-found handling. Integration coverage lives in
  * index.test.ts via the standard provider test suite.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 
 const enc = new TextEncoder();
 
@@ -21,7 +21,7 @@ class FakeSession {
   cpuCores = 2;
   memoryMb = 4096;
   diskSizeGb = 10;
-  projectId = 'proj_1';
+  workspaceId = 'ws_1';
   tags: string[] = [];
   timeoutAt = new Date(Date.now() + 3_600_000);
   closed = false;
@@ -102,13 +102,6 @@ const sharedSession = new FakeSession();
 
 class FakeTenkiSandbox {
   constructor(public options: any) {}
-  async whoAmI() {
-    return {
-      ownerType: 'USER',
-      ownerId: 'user_1',
-      workspaces: [{ id: 'ws_1', name: 'WS', projects: [{ id: 'proj_1', name: 'P' }] }],
-    };
-  }
   async createAndWait(opts: any) {
     lastCreateOptions = opts;
     return sharedSession;
@@ -150,11 +143,16 @@ describe('tenki provider (mocked SDK)', () => {
     sharedSession.closed = false;
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('has the right name', () => {
     expect(tenki({ apiKey: 'tk_test' }).name).toBe('tenki');
   });
 
-  it('create resolves scope via whoAmI and maps options', async () => {
+  it('creates with server-inferred scope and maps options', async () => {
+    vi.stubEnv('TENKI_WORKSPACE_ID', '');
     const provider = tenki({ apiKey: 'tk_test', memoryMb: 8192 });
     const sandbox = await provider.sandbox.create({
       envs: { NODE_ENV: 'production' },
@@ -162,18 +160,18 @@ describe('tenki provider (mocked SDK)', () => {
     });
     expect(sandbox.sandboxId).toBe('sbx_123');
     expect(lastCreateOptions).toMatchObject({
-      workspaceId: 'ws_1',
-      projectId: 'proj_1',
       env: { NODE_ENV: 'production' },
       maxDurationMs: 60_000,
       memoryMb: 8192,
     });
+    expect(lastCreateOptions).not.toHaveProperty('workspaceId');
   });
 
-  it('explicit workspace/project skips whoAmI resolution', async () => {
+  it('passes an explicit workspace and ignores legacy project scope', async () => {
     const provider = tenki({ apiKey: 'tk_test', workspaceId: 'ws_x', projectId: 'proj_x' });
     await provider.sandbox.create();
-    expect(lastCreateOptions).toMatchObject({ workspaceId: 'ws_x', projectId: 'proj_x' });
+    expect(lastCreateOptions).toMatchObject({ workspaceId: 'ws_x' });
+    expect(lastCreateOptions).not.toHaveProperty('projectId');
   });
 
   it('runCommand wraps the command in sh -lc', async () => {
@@ -249,6 +247,7 @@ describe('tenki provider (mocked SDK)', () => {
     expect(info.provider).toBe('tenki');
     expect(info.status).toBe('running');
     expect(info.id).toBe('sbx_123');
+    expect(info.metadata?.workspaceId).toBe('ws_1');
     expect(info.createdAt).toBeInstanceOf(Date);
   });
 

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -32,9 +32,9 @@ export interface TenkiConfig {
   apiKey?: string;
   /** API base URL. Falls back to TENKI_API_URL, then https://api.tenki.cloud. */
   baseUrl?: string;
-  /** Workspace to create sandboxes in. Falls back to TENKI_WORKSPACE_ID, then auto-resolved from the API key. */
+  /** Workspace to create sandboxes in. Falls back to TENKI_WORKSPACE_ID; workspace API keys infer it server-side. */
   workspaceId?: string;
-  /** Project to create sandboxes in. Falls back to TENKI_PROJECT_ID, then auto-resolved from the API key. */
+  /** @deprecated Tenki no longer scopes sandboxes by project. */
   projectId?: string;
   /** Default runCommand timeout in milliseconds. */
   timeout?: number;
@@ -44,13 +44,8 @@ export interface TenkiConfig {
   diskSizeGb?: number;
 }
 
-interface TenkiScope {
-  workspaceId: string;
-  projectId: string;
-}
-
 // ---------------------------------------------------------------------------
-// Client + scope resolution
+// Client resolution
 // ---------------------------------------------------------------------------
 
 /**
@@ -59,7 +54,6 @@ interface TenkiScope {
  * call (create/getById/list/destroy).
  */
 const clients = new Map<string, TenkiSandbox>();
-const scopes = new Map<string, TenkiScope>();
 
 function resolveApiKey(config: TenkiConfig): string {
   const apiKey = config.apiKey ?? process.env.TENKI_API_KEY ?? process.env.TENKI_AUTH_TOKEN;
@@ -89,35 +83,6 @@ function getClient(config: TenkiConfig): TenkiSandbox {
     clients.set(key, client);
   }
   return client;
-}
-
-/**
- * Tenki sandboxes are created inside a workspace/project. When neither is
- * configured we resolve the key's identity once via whoAmI() and pick the
- * first workspace that has a project.
- */
-async function resolveScope(config: TenkiConfig, client: TenkiSandbox): Promise<TenkiScope> {
-  const workspaceId = config.workspaceId ?? process.env.TENKI_WORKSPACE_ID;
-  const projectId = config.projectId ?? process.env.TENKI_PROJECT_ID;
-  if (workspaceId && projectId) return { workspaceId, projectId };
-
-  const key = clientKey(config);
-  const cached = scopes.get(key);
-  if (cached) return cached;
-
-  const identity = await client.whoAmI();
-  const workspace = identity.workspaces.find((w) => w.projects.length > 0);
-  const project = workspace?.projects[0];
-  if (!workspace || !project) {
-    throw new Error(
-      "Could not resolve a Tenki workspace/project for this API key.\n" +
-        "Pass them explicitly: tenki({ workspaceId, projectId })\n" +
-        "Or set TENKI_WORKSPACE_ID and TENKI_PROJECT_ID in your environment.",
-    );
-  }
-  const scope = { workspaceId: workspace.id, projectId: project.id };
-  scopes.set(key, scope);
-  return scope;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,11 +121,10 @@ function mapStatus(state: SessionState): SandboxInfo["status"] {
   }
 }
 
-function toCreateOptions(config: TenkiConfig, scope: TenkiScope, options?: CreateSandboxOptions): CreateOptions {
-  const opts: CreateOptions = {
-    workspaceId: scope.workspaceId,
-    projectId: scope.projectId,
-  };
+function toCreateOptions(config: TenkiConfig, options?: CreateSandboxOptions): CreateOptions {
+  const opts: CreateOptions = {};
+  const workspaceId = config.workspaceId ?? process.env.TENKI_WORKSPACE_ID;
+  if (workspaceId) opts.workspaceId = workspaceId;
   if (options?.name) opts.name = options.name;
   if (options?.envs) opts.env = options.envs;
   if (options?.metadata) {
@@ -274,8 +238,7 @@ export const tenki = defineProvider<Session, TenkiConfig>({
     sandbox: {
       create: async (config, options) => {
         const client = getClient(config);
-        const scope = await resolveScope(config, client);
-        const session = await client.createAndWait(toCreateOptions(config, scope, options));
+        const session = await client.createAndWait(toCreateOptions(config, options));
         return { sandbox: rememberSession(session, config), sandboxId: session.id };
       },
 
@@ -326,7 +289,7 @@ export const tenki = defineProvider<Session, TenkiConfig>({
             cpuCores: sandbox.cpuCores,
             memoryMb: sandbox.memoryMb,
             diskSizeGb: sandbox.diskSizeGb,
-            projectId: sandbox.projectId,
+            workspaceId: sandbox.workspaceId,
             tags: sandbox.tags,
           },
         };

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -109,7 +109,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string | reado
     domain: ['LELANTOS_DOMAIN', 'E2B_DOMAIN'],
     apiUrl: ['LELANTOS_API_URL', 'E2B_API_URL'],
   },
-  tenki: { apiKey: 'TENKI_API_KEY', baseUrl: 'TENKI_API_URL', workspaceId: 'TENKI_WORKSPACE_ID', projectId: 'TENKI_PROJECT_ID' },
+  tenki: { apiKey: 'TENKI_API_KEY', baseUrl: 'TENKI_API_URL', workspaceId: 'TENKI_WORKSPACE_ID' },
 };
 
 function getProviderConfigFromEnv(provider: SharedProviderName): Record<string, string> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1957,8 +1957,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@tenkicloud/sandbox':
-        specifier: ^0.4.0
-        version: 0.4.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^0.5.4
+        version: 0.5.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -5080,8 +5080,8 @@ packages:
   '@superserve/sdk@0.7.6':
     resolution: {integrity: sha512-ovJG1hIoOolhMeKUl/j0y8awaexvHFTjYjkk7/HnrN5olpqeHDyLQT++6SJmnL3/94XFd2g2DPvc8VWABlOBqw==}
 
-  '@tenkicloud/sandbox@0.4.0':
-    resolution: {integrity: sha512-p9GiQutfqEhEEAQlEOph/wuP2Vk0kDof4GjhIvnV96TbvzoqPFp1pD6iEjUcJMri6sJsEXBGf0Grsyl+X52GiA==}
+  '@tenkicloud/sandbox@0.5.4':
+    resolution: {integrity: sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==}
     engines: {node: '>=18'}
 
   '@tigrisdata/storage@3.6.0':
@@ -8985,6 +8985,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   x256@0.0.2:
     resolution: {integrity: sha512-ZsIH+sheoF8YG9YG+QKEEIdtqpHRA9FYuD7MqhfyB1kayXU43RUNBFSxBEnF8ywSUxdg+8no4+bPr5qLbyxKgA==}
     engines: {node: '>=0.4.0'}
@@ -12357,12 +12369,12 @@ snapshots:
 
   '@superserve/sdk@0.7.6': {}
 
-  '@tenkicloud/sandbox@0.4.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@tenkicloud/sandbox@0.5.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
       '@connectrpc/connect-node': 2.1.2(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17081,6 +17093,11 @@ snapshots:
       utf-8-validate: 6.0.6
 
   ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## Summary

Update the Tenki provider to `@tenkicloud/sandbox` 0.5.4 and migrate it to workspace-scoped sandbox creation.

## Changes

- Rely on Tenki's server-side workspace inference instead of calling `whoAmI()` to resolve a project.
- Keep `projectId` as a deprecated no-op for source compatibility.
- Report `workspaceId` instead of `projectId` in sandbox metadata.
- Remove `TENKI_PROJECT_ID` from the Workbench provider configuration.
- Update Tenki documentation and tests for the new workspace behavior.

## Validation

- Full monorepo build and lint
- Tenki typecheck and tests: 31 passed
- Workbench typecheck
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->