### PR TITLE
fix(sandbox0): support long-running foreground commands

### DIFF
--- a/.changeset/calm-contexts-wait.md
+++ b/.changeset/calm-contexts-wait.md
@@ -1,0 +1,6 @@
+---
+"@computesdk/sandbox0": patch
+---
+
+Run foreground commands through asynchronous Sandbox0 Contexts so long-running
+commands are not limited by a synchronous gateway request.

--- a/docs/providers/sandbox0.md
+++ b/docs/providers/sandbox0.md
@@ -100,11 +100,16 @@ Per-create `templateId`, `snapshotId`, `memory`, `envs`, `ttl`, `hardTtl`, and `
 | `getById` | ✅ | Returns `null` for a missing sandbox. |
 | `list` | ✅ | Paginates through sandboxes visible to the team token. |
 | `destroy` | ✅ | Idempotent, with bounded retry for throttling and server failures. |
-| `runCommand` | ✅ | Uses `sh -lc`; supports `cwd`, env, timeout, and background mode. |
+| `runCommand` | ✅ | Uses `sh -lc`; foreground calls follow an asynchronous Context through WebSocket with API polling fallback. Supports `cwd`, env, timeout, and background mode. |
 | `getInfo` | ✅ | Uses lifecycle metadata already returned by Sandbox0 without adding a post-create request. |
 | `getUrl` | ✅ | Returns the URL of an existing public Sandbox0 service for the requested port. |
 | `filesystem` | ✅ | Native read, write, mkdir, list, stat, and delete operations. |
 
 For automated workloads, set `hardTtl` as a safety net in addition to calling `destroy`.
+
+Foreground commands use the requested timeout as both a local deadline and the
+Sandbox0 Context TTL. If the WebSocket disconnects before a terminal event, the
+provider continues through the Context API. A timeout also triggers a
+best-effort Context deletion.
 
 Use `sandbox.getInstance()` for Sandbox0-specific pause/resume, services, snapshots, volumes, and observability APIs.

--- a/packages/sandbox0/README.md
+++ b/packages/sandbox0/README.md
@@ -78,6 +78,12 @@ Per-create `templateId`, `snapshotId`, `memory`, `envs`, `ttl`, `hardTtl`, and `
 | Restore from snapshot | Yes, with `snapshotId` at create time |
 | Snapshot management | Use the native Sandbox0 SDK |
 
+Foreground `runCommand` calls start an asynchronous Sandbox0 Context, follow
+its WebSocket terminal event, and read the final result from the Context API.
+If the WebSocket disconnects, the provider polls the Context until it exits.
+The command `timeout` is also applied as the Context TTL, and a timed-out call
+attempts to delete the Context.
+
 `destroy` is idempotent and retries short-lived throttling or server failures. Setting `hardTtl` is still recommended for automated workloads so a failed client cannot leave a sandbox indefinitely.
 
 For Sandbox0-specific capabilities such as pause/resume, services, snapshots, volumes, and observability, call `sandbox.getInstance()` to access the native `sandbox0` SDK handle.

--- a/packages/sandbox0/src/__tests__/unit.test.ts
+++ b/packages/sandbox0/src/__tests__/unit.test.ts
@@ -45,16 +45,39 @@ vi.mock('sandbox0', () => {
 });
 
 function makeSandbox() {
+  const contextStream = {
+    id: 'ctx_123',
+    outputs: vi.fn(async function* () {
+      yield { source: 'stdout', data: 'ok\n' };
+    }),
+    wait: vi.fn().mockResolvedValue({
+      contextId: 'ctx_123',
+      exitCode: 0,
+      state: 'exited',
+    }),
+    close: vi.fn(),
+  };
   return {
     id: 'sb_123',
     status: 'running',
     template: 'default',
     clusterId: 'cluster_1',
     cmd: vi.fn().mockResolvedValue({
+      contextId: 'ctx_123',
+      stdout: 'ok\n',
+      stderr: '',
+      exitCode: undefined,
+    }),
+    connectWsContext: vi.fn().mockResolvedValue(contextStream),
+    getContext: vi.fn().mockResolvedValue({
+      id: 'ctx_123',
+      running: false,
       stdout: 'ok\n',
       stderr: '',
       exitCode: 0,
+      state: 'exited',
     }),
+    deleteContext: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn().mockResolvedValue(new TextEncoder().encode('file-content')),
     writeFile: vi.fn().mockResolvedValue(undefined),
     mkdir: vi.fn().mockResolvedValue(undefined),
@@ -196,17 +219,110 @@ describe('sandbox0 provider', () => {
 
     expect(nativeSandbox.cmd).toHaveBeenCalledWith('printf "$VALUE"', {
       command: ['sh', '-lc', 'printf "$VALUE"'],
-      wait: true,
+      wait: false,
       cwd: '/workspace',
       envVars: { VALUE: 'hello' },
       ttlSec: 5,
     });
+    expect(nativeSandbox.connectWsContext).toHaveBeenCalledWith('ctx_123');
+    expect(nativeSandbox.getContext).toHaveBeenCalledWith('ctx_123');
     expect(result).toMatchObject({ stdout: 'ok\n', stderr: '', exitCode: 0 });
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });
 
+  it('falls back to streamed output and preserves a non-zero exit code', async () => {
+    nativeSandbox.connectWsContext.mockResolvedValueOnce({
+      id: 'ctx_123',
+      outputs: vi.fn(async function* () {
+        yield { source: 'stdout', data: 'out\n' };
+        yield { source: 'stderr', data: 'err\n' };
+      }),
+      wait: vi.fn().mockResolvedValue({
+        contextId: 'ctx_123',
+        exitCode: 7,
+        state: 'crashed',
+      }),
+      close: vi.fn(),
+    });
+    nativeSandbox.getContext.mockResolvedValueOnce({
+      id: 'ctx_123',
+      running: false,
+      exitCode: 7,
+      state: 'crashed',
+    });
+    const sandbox = await sandbox0({ token: 's0_test' }).sandbox.create();
+
+    const result = await sandbox.runCommand('echo out; echo err >&2; exit 7');
+
+    expect(result).toMatchObject({
+      stdout: 'out\n',
+      stderr: 'err\n',
+      exitCode: 7,
+    });
+  });
+
+  it('polls the Context API if the WebSocket closes before a terminal event', async () => {
+    vi.useFakeTimers();
+    try {
+      nativeSandbox.connectWsContext.mockResolvedValueOnce({
+        id: 'ctx_123',
+        outputs: vi.fn(async function* () {}),
+        wait: vi.fn().mockResolvedValue({ contextId: 'ctx_123' }),
+        close: vi.fn(),
+      });
+      nativeSandbox.getContext
+        .mockResolvedValueOnce({ id: 'ctx_123', running: true })
+        .mockResolvedValueOnce({
+          id: 'ctx_123',
+          running: false,
+          stdout: 'done\n',
+          stderr: '',
+          exitCode: 0,
+          state: 'exited',
+        });
+      const sandbox = await sandbox0({ token: 's0_test' }).sandbox.create();
+
+      const pending = sandbox.runCommand('sleep 1; echo done', { timeout: 1_000 });
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(pending).resolves.toMatchObject({
+        stdout: 'done\n',
+        exitCode: 0,
+      });
+      expect(nativeSandbox.getContext).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('deletes the Context when a foreground command times out', async () => {
+    vi.useFakeTimers();
+    try {
+      nativeSandbox.connectWsContext.mockResolvedValueOnce({
+        id: 'ctx_123',
+        outputs: vi.fn(async function* () {}),
+        wait: vi.fn().mockReturnValue(new Promise(() => undefined)),
+        close: vi.fn(),
+      });
+      const sandbox = await sandbox0({ token: 's0_test' }).sandbox.create();
+
+      const pending = sandbox.runCommand('sleep 30', { timeout: 50 });
+      const rejection = expect(pending).rejects.toMatchObject({
+        name: 'TimeoutError',
+        message: 'Sandbox0 command timed out after 50ms.',
+      });
+      await vi.advanceTimersByTimeAsync(50);
+
+      await rejection;
+      expect(nativeSandbox.deleteContext).toHaveBeenCalledWith('ctx_123');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('starts background commands without waiting for an exit code', async () => {
     nativeSandbox.cmd.mockResolvedValueOnce({
+      contextId: 'ctx_123',
       stdout: '',
       stderr: '',
       exitCode: undefined,
@@ -223,6 +339,9 @@ describe('sandbox0 provider', () => {
       expect.objectContaining({ wait: false, ttlSec: 2 }),
     );
     expect(result.exitCode).toBe(0);
+    expect(nativeSandbox.connectWsContext).not.toHaveBeenCalled();
+    expect(nativeSandbox.getContext).not.toHaveBeenCalled();
+    expect(nativeSandbox.deleteContext).not.toHaveBeenCalled();
   });
 
   it('gets and paginates team sandboxes', async () => {

--- a/packages/sandbox0/src/__tests__/unit.test.ts
+++ b/packages/sandbox0/src/__tests__/unit.test.ts
@@ -230,7 +230,7 @@ describe('sandbox0 provider', () => {
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  it('falls back to streamed output and preserves a non-zero exit code', async () => {
+  it('uses the streamed result if the final Context lookup fails', async () => {
     nativeSandbox.connectWsContext.mockResolvedValueOnce({
       id: 'ctx_123',
       outputs: vi.fn(async function* () {
@@ -244,12 +244,9 @@ describe('sandbox0 provider', () => {
       }),
       close: vi.fn(),
     });
-    nativeSandbox.getContext.mockResolvedValueOnce({
-      id: 'ctx_123',
-      running: false,
-      exitCode: 7,
-      state: 'crashed',
-    });
+    nativeSandbox.getContext.mockRejectedValueOnce(
+      new APIError({ statusCode: 503, message: 'unavailable' }),
+    );
     const sandbox = await sandbox0({ token: 's0_test' }).sandbox.create();
 
     const result = await sandbox.runCommand('echo out; echo err >&2; exit 7');
@@ -259,6 +256,8 @@ describe('sandbox0 provider', () => {
       stderr: 'err\n',
       exitCode: 7,
     });
+    expect(nativeSandbox.getContext).toHaveBeenCalledWith('ctx_123');
+    expect(nativeSandbox.deleteContext).not.toHaveBeenCalled();
   });
 
   it('polls the Context API if the WebSocket closes before a terminal event', async () => {

--- a/packages/sandbox0/src/index.ts
+++ b/packages/sandbox0/src/index.ts
@@ -232,6 +232,117 @@ function commandTimeoutSeconds(value: number | undefined): number | undefined {
   return Math.max(1, Math.ceil(value / 1_000));
 }
 
+type Sandbox0Context = Awaited<ReturnType<Sandbox0Sandbox['getContext']>>;
+type Sandbox0ContextStream = Awaited<ReturnType<Sandbox0Sandbox['connectWsContext']>>;
+type Sandbox0StreamDone = Awaited<ReturnType<Sandbox0ContextStream['wait']>>;
+
+interface CapturedCommandOutput {
+  stdout: string;
+  stderr: string;
+}
+
+const commandPollIntervalMs = 100;
+
+class Sandbox0CommandTimeoutError extends Error {
+  constructor(timeout: number) {
+    super(`Sandbox0 command timed out after ${timeout}ms.`);
+    this.name = 'TimeoutError';
+  }
+}
+
+async function withinCommandDeadline<T>(
+  operation: Promise<T>,
+  deadline: number | undefined,
+  timeout: number | undefined,
+): Promise<T> {
+  if (deadline === undefined || timeout === undefined) return operation;
+
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new Sandbox0CommandTimeoutError(timeout);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Sandbox0CommandTimeoutError(timeout)),
+          remaining,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function captureContextOutput(
+  stream: Sandbox0ContextStream,
+  output: CapturedCommandOutput,
+): Promise<void> {
+  for await (const chunk of stream.outputs()) {
+    if (chunk.source === 'stderr') {
+      output.stderr += chunk.data;
+    } else {
+      output.stdout += chunk.data;
+    }
+  }
+}
+
+async function observeCommandCompletion(
+  sandbox: Sandbox0Sandbox,
+  contextId: string,
+  deadline: number | undefined,
+  timeout: number | undefined,
+): Promise<{
+  context: Sandbox0Context;
+  terminal?: Sandbox0StreamDone;
+  output: CapturedCommandOutput;
+}> {
+  const output: CapturedCommandOutput = { stdout: '', stderr: '' };
+  let terminal: Sandbox0StreamDone | undefined;
+  let stream: Sandbox0ContextStream | undefined;
+
+  try {
+    stream = await withinCommandDeadline(
+      sandbox.connectWsContext(contextId),
+      deadline,
+      timeout,
+    );
+    const outputTask = captureContextOutput(stream, output).catch(() => undefined);
+    terminal = await withinCommandDeadline(stream.wait(), deadline, timeout);
+    await outputTask;
+  } catch (error) {
+    if (error instanceof Sandbox0CommandTimeoutError) throw error;
+    // A dropped WebSocket must not lose the command. Fall back to the Context API.
+  } finally {
+    stream?.close();
+  }
+
+  let context = await withinCommandDeadline(
+    sandbox.getContext(contextId),
+    deadline,
+    timeout,
+  );
+  while (context.running && terminal?.exitCode === undefined) {
+    const delay = deadline === undefined
+      ? commandPollIntervalMs
+      : Math.min(commandPollIntervalMs, Math.max(1, deadline - Date.now()));
+    await sleep(delay);
+    context = await withinCommandDeadline(
+      sandbox.getContext(contextId),
+      deadline,
+      timeout,
+    );
+  }
+
+  return { context, terminal, output };
+}
+
+function deleteContextBestEffort(sandbox: Sandbox0Sandbox, contextId: string): void {
+  void sandbox.deleteContext(contextId).catch(() => undefined);
+}
+
 async function createSandbox(config: Sandbox0Config, options?: CreateSandboxOptions) {
   throwIfAborted(options?.signal);
   const client = createClient(config);
@@ -320,19 +431,43 @@ const _provider = defineProvider<Sandbox0Sandbox, Sandbox0Config>({
       ): Promise<CommandResult> => {
         const startedAt = Date.now();
         const timeout = options?.timeout ?? observations.get(sandbox)?.commandTimeout;
-        const result = await sandbox.cmd(command, {
+        const ttlSec = commandTimeoutSeconds(timeout);
+        const deadline = timeout !== undefined && timeout > 0
+          ? startedAt + timeout
+          : undefined;
+        const started = await sandbox.cmd(command, {
           command: ['sh', '-lc', command],
-          wait: !options?.background,
+          wait: false,
           cwd: options?.cwd,
           envVars: options?.env,
-          ttlSec: commandTimeoutSeconds(timeout),
+          ttlSec,
         });
-        return {
-          stdout: result.stdout || '',
-          stderr: result.stderr || '',
-          exitCode: result.exitCode ?? (options?.background ? 0 : 1),
-          durationMs: Date.now() - startedAt,
-        };
+        if (options?.background) {
+          return {
+            stdout: started.stdout || '',
+            stderr: started.stderr || '',
+            exitCode: 0,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+
+        try {
+          const completed = await observeCommandCompletion(
+            sandbox,
+            started.contextId,
+            deadline,
+            timeout,
+          );
+          return {
+            stdout: completed.context.stdout ?? completed.output.stdout,
+            stderr: completed.context.stderr ?? completed.output.stderr,
+            exitCode: completed.context.exitCode ?? completed.terminal?.exitCode ?? 1,
+            durationMs: Date.now() - startedAt,
+          };
+        } catch (error) {
+          deleteContextBestEffort(sandbox, started.contextId);
+          throw error;
+        }
       },
 
       getInfo: async (sandbox): Promise<SandboxInfo> => {

--- a/packages/sandbox0/src/index.ts
+++ b/packages/sandbox0/src/index.ts
@@ -295,7 +295,7 @@ async function observeCommandCompletion(
   deadline: number | undefined,
   timeout: number | undefined,
 ): Promise<{
-  context: Sandbox0Context;
+  context?: Sandbox0Context;
   terminal?: Sandbox0StreamDone;
   output: CapturedCommandOutput;
 }> {
@@ -319,21 +319,32 @@ async function observeCommandCompletion(
     stream?.close();
   }
 
-  let context = await withinCommandDeadline(
-    sandbox.getContext(contextId),
-    deadline,
-    timeout,
-  );
-  while (context.running && terminal?.exitCode === undefined) {
-    const delay = deadline === undefined
-      ? commandPollIntervalMs
-      : Math.min(commandPollIntervalMs, Math.max(1, deadline - Date.now()));
-    await sleep(delay);
+  let context: Sandbox0Context | undefined;
+  try {
     context = await withinCommandDeadline(
       sandbox.getContext(contextId),
       deadline,
       timeout,
     );
+    while (context.running && terminal?.exitCode === undefined) {
+      const delay = deadline === undefined
+        ? commandPollIntervalMs
+        : Math.min(commandPollIntervalMs, Math.max(1, deadline - Date.now()));
+      await sleep(delay);
+      context = await withinCommandDeadline(
+        sandbox.getContext(contextId),
+        deadline,
+        timeout,
+      );
+    }
+  } catch (error) {
+    // Preserve a completed WebSocket result if the final Context snapshot is unavailable.
+    if (
+      error instanceof Sandbox0CommandTimeoutError
+      || terminal?.exitCode === undefined
+    ) {
+      throw error;
+    }
   }
 
   return { context, terminal, output };
@@ -459,9 +470,9 @@ const _provider = defineProvider<Sandbox0Sandbox, Sandbox0Config>({
             timeout,
           );
           return {
-            stdout: completed.context.stdout ?? completed.output.stdout,
-            stderr: completed.context.stderr ?? completed.output.stderr,
-            exitCode: completed.context.exitCode ?? completed.terminal?.exitCode ?? 1,
+            stdout: completed.context?.stdout ?? completed.output.stdout,
+            stderr: completed.context?.stderr ?? completed.output.stderr,
+            exitCode: completed.context?.exitCode ?? completed.terminal?.exitCode ?? 1,
             durationMs: Date.now() - startedAt,
           };
         } catch (error) {


### PR DESCRIPTION
## Summary

- start foreground commands through the asynchronous Sandbox0 Context API instead of holding the synchronous command request open
- follow Context output and terminal events over WebSocket, with Context polling as a disconnect fallback
- preserve streamed output when the final Context lookup is unavailable
- apply ComputeSDK command timeouts to Context TTLs and best-effort cleanup
- document the long-running command behavior

## Why

The synchronous Sandbox0 command endpoint is intended for bounded requests and can be terminated by an HTTP gateway before workloads such as the DAX install/typecheck complete. The command itself may continue, but ComputeSDK loses the result. The Context API separates command lifetime from the original HTTP request.

## Validation

- `pnpm --filter @computesdk/sandbox0 test` (28/28)
- `pnpm --filter @computesdk/sandbox0 typecheck`
- `pnpm --filter @computesdk/sandbox0 lint`
- `pnpm --filter @computesdk/sandbox0 build`
- live provider integration suite against Sandbox0: 14/14
- live 70-second foreground command: exit 0, output preserved, 71.5s duration
- official ComputeSDK DAX benchmark with the local provider build: 7/7 phases, 153.09s total, 4 CPU / 16 GiB, no gateway timeout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->