### PR TITLE
feat(northflank): add ephemeralStorageSize option

### DIFF
--- a/.changeset/northflank-storage.md
+++ b/.changeset/northflank-storage.md
@@ -1,5 +1,5 @@
 ---
-'@computesdk/northflank': minor
+'@computesdk/northflank': patch
 ---
 
 Add `ephemeralStorageSize` option to configure ephemeral storage per container (in MB). Passes through to `deployment.storage.ephemeralStorage.storageSize` in the Northflank API. Works at both the provider config level and per-sandbox via `create()`.

--- a/.changeset/northflank-storage.md
+++ b/.changeset/northflank-storage.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/northflank': minor
+---
+
+Add `ephemeralStorageSize` option to configure ephemeral storage per container (in MB). Passes through to `deployment.storage.ephemeralStorage.storageSize` in the Northflank API. Works at both the provider config level and per-sandbox via `create()`.

--- a/packages/northflank/README.md
+++ b/packages/northflank/README.md
@@ -66,6 +66,8 @@ interface NorthflankConfig {
   timeout?: number;
   /** Deploy from a Northflank build service instead of an external image */
   internalDeployment?: { id: string; branch?: string; buildSHA?: string };
+  /** Ephemeral storage per container in MB (e.g. 5120 for 5 GiB) */
+  ephemeralStorageSize?: number;
 }
 ```
 
@@ -100,6 +102,7 @@ await compute.sandbox.create({
   timeout: 180000,                      // overrides config.timeout
   envs: { LOG_LEVEL: 'debug' },         // merged into runtimeEnvironment
   name: 'my-sandbox',                   // service name (auto-prefixed)
+  ephemeralStorageSize: 5120,           // 5 GiB ephemeral storage per container
 });
 ```
 

--- a/packages/northflank/src/index.ts
+++ b/packages/northflank/src/index.ts
@@ -78,6 +78,8 @@ interface NorthflankCreateOptions extends CreateSandboxOptions {
   ports?: NorthflankPortInput[];
   deploymentPlan?: string;
   internalDeployment?: NorthflankInternalDeployment;
+  /** Ephemeral storage per container in MB — overrides config.ephemeralStorageSize */
+  ephemeralStorageSize?: number;
 }
 
 function readCreateOptions(options?: CreateSandboxOptions): NorthflankCreateOptions {
@@ -189,6 +191,11 @@ const createNorthflankProvider = defineProvider<NorthflankSandboxHandle, Northfl
           const explicitImage = opts.image ?? config.image;
           const imagePath = explicitImage ?? imageForRuntime(runtime);
           deployment.external = { imagePath };
+        }
+
+        const ephemeralStorageSize = opts.ephemeralStorageSize ?? config.ephemeralStorageSize;
+        if (ephemeralStorageSize != null) {
+          deployment.storage = { ephemeralStorage: { storageSize: ephemeralStorageSize } };
         }
 
         const data: Parameters<typeof client.create.service.deployment>[0]['data'] = {

--- a/packages/northflank/src/utils.ts
+++ b/packages/northflank/src/utils.ts
@@ -51,6 +51,8 @@ export interface NorthflankConfig {
   timeout?: number;
   /** Deploy from a Northflank build service instead of an external image */
   internalDeployment?: NorthflankInternalDeployment;
+  /** Ephemeral storage per container in MB (e.g. 5120 for 5 GiB). Maps to `deployment.storage.ephemeralStorage.storageSize` in the Northflank API. */
+  ephemeralStorageSize?: number;
 }
 
 export function prefix(config: NorthflankConfig): string {


### PR DESCRIPTION
Add `ephemeralStorageSize` (in MB) to `NorthflankConfig` and per-sandbox `create()` options. Maps to `deployment.storage.ephemeralStorage.storageSize` in the Northflank API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->