### PR TITLE
feat: add Sail provider

### DIFF
--- a/.changeset/fresh-sail-provider.md
+++ b/.changeset/fresh-sail-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/sail": patch
+---
+
+Add the Sail sandbox provider with lifecycle, command execution, native filesystem, ingress URL, resource sizing, and cancellation support.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Northflank** | `NORTHFLANK_TOKEN`, `NORTHFLANK_PROJECT_ID` | Cloud sandboxes with preview URLs |
 | **OpenComputer** | `OPENCOMPUTER_API_KEY` | Persistent cloud VMs with checkpoints and preview URLs |
 | **Runloop** | `RUNLOOP_API_KEY` | Code execution, automation |
+| **Sail** | `SAIL_API_KEY` | Fast isolated Firecracker microVM sandboxes |
 | **Sandbox0** | `SANDBOX0_TOKEN` | Fast persistent sandboxes with native filesystem access |
 | **Superserve** | `SUPERSERVE_API_KEY` | Firecracker microVM sandboxes |
 | **Tensorlake** | `TENSORLAKE_API_KEY` | Stateful MicroVM sandboxes |
@@ -289,6 +290,7 @@ npm install @computesdk/lightning        # Lightning AI provider
 npm install @computesdk/modal            # Modal provider
 npm install @computesdk/northflank       # Northflank provider
 npm install @computesdk/runloop          # Runloop provider
+npm install @computesdk/sail             # Sail provider
 npm install @computesdk/sandbox0         # Sandbox0 provider
 npm install @computesdk/superserve       # Superserve provider
 npm install @computesdk/tensorlake       # Tensorlake provider

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Northflank** | `NORTHFLANK_TOKEN`, `NORTHFLANK_PROJECT_ID` | Cloud sandboxes with preview URLs |
 | **OpenComputer** | `OPENCOMPUTER_API_KEY` | Persistent cloud VMs with checkpoints and preview URLs |
 | **Runloop** | `RUNLOOP_API_KEY` | Code execution, automation |
-| **Sail** | `SAIL_API_KEY` | Fast isolated Firecracker microVM sandboxes |
+| **Sail** | `SAIL_API_KEY` | Cost-effective Firecracker microVM sandboxes for long-horizon agents. |
 | **Sandbox0** | `SANDBOX0_TOKEN` | Fast persistent sandboxes with native filesystem access |
 | **Superserve** | `SUPERSERVE_API_KEY` | Firecracker microVM sandboxes |
 | **Tensorlake** | `TENSORLAKE_API_KEY` | Stateful MicroVM sandboxes |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,6 +38,7 @@
   * [Quilt](providers/quilt.md)
   * [Railway](providers/railway.md)
   * [Runloop](providers/runloop.md)
+  * [Sail](providers/sail.md)
   * [Sandbox0](providers/sandbox0.md)
   * [Secure Exec](providers/secure-exec.md)
   * [Sprites](providers/sprites.md)

--- a/docs/providers/sail.md
+++ b/docs/providers/sail.md
@@ -24,8 +24,9 @@ layout:
 
 # Sail
 
-[Sail](https://sailresearch.com) provides isolated Firecracker microVM
-sandboxes for running agent and developer workloads.
+[Sail](https://sailresearch.com) provides maximally-efficient Firecracker microVM
+sandboxes for running agent and developer workloads. They can live forever and bill only for active 
+CPU, memory, and disk usage.
 
 ## Installation & Setup
 

--- a/docs/providers/sail.md
+++ b/docs/providers/sail.md
@@ -1,0 +1,99 @@
+---
+description: >-
+  Sail provider for ComputeSDK - isolated Firecracker microVM sandboxes with
+  fast startup, command execution, and native filesystem access.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# Sail
+
+[Sail](https://sailresearch.com) provides isolated Firecracker microVM
+sandboxes for running agent and developer workloads.
+
+## Installation & Setup
+
+```bash
+npm install computesdk @computesdk/sail
+```
+
+Node.js 22 or newer is required. Create an API key at
+[app.sailresearch.com](https://app.sailresearch.com), then export it:
+
+```bash
+export SAIL_API_KEY=your_sail_api_key
+```
+
+## Usage
+
+```typescript
+import { sail } from '@computesdk/sail';
+
+const compute = sail({ app: 'my-app' });
+
+const sandbox = await compute.sandbox.create();
+const result = await sandbox.runCommand('node --version');
+console.log(result.stdout);
+
+await sandbox.filesystem.writeFile('/tmp/result.txt', result.stdout);
+console.log(await sandbox.filesystem.readFile('/tmp/result.txt'));
+
+await sandbox.destroy();
+```
+
+## Configuration Options
+
+```typescript
+interface SailConfig {
+  apiKey?: string;
+  app?: string;
+  image?: ImageSpec | Image;
+}
+```
+
+`apiKey` falls back to `SAIL_API_KEY`. `app` falls back to `SAIL_APP`, then
+`computesdk`, and is created on first use when missing. `image` defaults to
+Sail's ARM64 Devbox builtin, which includes Node.js and Bun. Pass a different
+image when the workload needs another runtime or architecture.
+
+Create accepts Sailbox `size` values `s`, `m`, and `l`, optional `memoryGib`, a
+name, and an `AbortSignal`. It defaults to `s`; explicit size choices override
+that default. Unsupported universal options are rejected rather than silently
+ignored.
+
+## Supported Operations
+
+| Method | Supported | Notes |
+|---|---|---|
+| `create` | Yes | Defaults to an ARM64 Devbox on `S`. |
+| `getById` | Yes | Returns `null` for missing or terminated Sailboxes. |
+| `list` | Yes | Lists live and actionable Sailboxes for the configured app. |
+| `destroy` | Yes | Terminates the Sailbox. |
+| `runCommand` | Yes | Supports cwd, environment, timeout, and background mode. |
+| `getInfo` | Yes | Maps current Sail lifecycle state to ComputeSDK. |
+| `getUrl` | Yes | Supports public HTTP/HTTPS and TCP listeners. |
+| `filesystem` | Yes | Native read, write, mkdir, list, exists, and remove. |
+| Templates | No | Configure a Sail `Image` on the provider. |
+| Snapshots | No | Use the native Sail SDK for checkpoints. |
+
+`getUrl` preserves existing listener policy and rejects protocol conflicts
+instead of replacing a listener's allowlist.
+
+Use `sandbox.getInstance()` for Sail-specific checkpoint, sleep, resume, SSH,
+listener allowlist, and credential-injection APIs.

--- a/packages/sail/CHANGELOG.md
+++ b/packages/sail/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @computesdk/sail
+
+## 1.0.0
+
+### Patch Changes
+
+- Initial Sail provider for ComputeSDK.

--- a/packages/sail/README.md
+++ b/packages/sail/README.md
@@ -1,0 +1,93 @@
+# @computesdk/sail
+
+[Sail](https://sailresearch.com) provider for ComputeSDK. Sailboxes are
+isolated Firecracker microVM sandboxes with command execution, native
+filesystem operations, and public HTTP or TCP listeners.
+
+## Installation
+
+```bash
+npm install computesdk @computesdk/sail
+```
+
+Node.js 22 or newer is required by the Sail SDK.
+
+## Configuration
+
+Create a Sail API key at [app.sailresearch.com](https://app.sailresearch.com),
+then export it:
+
+```bash
+export SAIL_API_KEY=your_sail_api_key
+```
+
+The provider accepts:
+
+```typescript
+interface SailConfig {
+  apiKey?: string;
+  app?: string;
+  image?: ImageSpec | Image;
+}
+```
+
+- `apiKey` falls back to `SAIL_API_KEY`.
+- `app` owns the created Sailboxes and falls back to `SAIL_APP`, then
+  `computesdk`. It is created on first use when missing.
+- `image` defaults to Sail's ARM64 Devbox builtin, which includes Node.js and
+  Bun. Pass another Sail image when the workload needs a different runtime or
+  architecture.
+- Creates default to an `S` Sailbox. Pass `size: 'm'` or `size: 'l'` to
+  `create()` when the workload needs more compute.
+
+## Usage
+
+```typescript
+import { sail } from '@computesdk/sail';
+
+const compute = sail({ app: 'my-app' });
+
+const sandbox = await compute.sandbox.create();
+const result = await sandbox.runCommand('node --version');
+console.log(result.stdout);
+
+await sandbox.filesystem.writeFile('/tmp/result.txt', result.stdout);
+console.log(await sandbox.filesystem.readFile('/tmp/result.txt'));
+
+await sandbox.destroy();
+```
+
+It can also be registered with ComputeSDK's shared client:
+
+```typescript
+import { compute } from 'computesdk';
+import { sail } from '@computesdk/sail';
+
+compute.setConfig({ provider: sail({ app: 'my-app' }) });
+const sandbox = await compute.sandbox.create();
+```
+
+## Supported Operations
+
+| Operation | Supported | Notes |
+|---|---|---|
+| `create` | Yes | Defaults to an ARM64 Devbox on `S`; supports `name`, `size`, `memoryGib`, and cancellation. |
+| `getById` | Yes | Returns `null` for missing or terminated Sailboxes. |
+| `list` | Yes | Scoped to the configured app. |
+| `destroy` | Yes | Terminates the Sailbox. |
+| `runCommand` | Yes | Supports cwd, environment, timeout, and background mode. |
+| `getInfo` | Yes | Refreshes current lifecycle state. |
+| `getUrl` | Yes | Exposes or reuses HTTP/HTTPS and TCP listeners. |
+| Filesystem | Yes | Native read, write, mkdir, list, exists, and remove. |
+| Templates | No | Configure a Sail `Image` on the provider instead. |
+| Snapshots | No | Use the native Sail SDK for checkpoint operations. |
+
+`getUrl` does not replace an existing listener because doing so would replace
+its allowlist. A listener with a conflicting protocol produces an error.
+
+ComputeSDK's create `timeout` is not supported: it represents a hard sandbox
+lifetime, while Sail's autosleep only sleeps an idle Sailbox. Bound individual
+commands with `runCommand`'s timeout or explicitly call `destroy()`.
+
+Use `sandbox.getInstance()` for Sail-specific checkpoint, sleep, resume, SSH,
+listener allowlist, and credential-injection APIs.

--- a/packages/sail/package.json
+++ b/packages/sail/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@computesdk/sail",
+  "version": "1.0.0",
+  "description": "Sail provider for ComputeSDK - fast, isolated microVM sandboxes with native filesystem access",
+  "author": "Sail Research",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "sail",
+    "sailbox",
+    "sandbox",
+    "microvm",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider"
+  ],
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "@sailresearch/sdk": "^0.5.1",
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/sail"
+  },
+  "homepage": "https://sailresearch.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  }
+}

--- a/packages/sail/src/__tests__/index.test.ts
+++ b/packages/sail/src/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { sail } from '../index';
+
+runProviderTestSuite({
+  name: 'sail',
+  provider: sail({
+    apiKey: process.env.SAIL_API_KEY,
+    app: process.env.SAIL_APP,
+  }),
+  supportsFilesystem: true,
+  // A routable URL requires a process to listen on the requested guest port.
+  // Focused provider tests cover listener creation and protocol handling.
+  supportsGetUrl: false,
+  skipIntegration: !process.env.SAIL_API_KEY,
+  filesystemBasePath: '/tmp',
+  timeout: 120_000,
+});

--- a/packages/sail/src/__tests__/unit.test.ts
+++ b/packages/sail/src/__tests__/unit.test.ts
@@ -100,7 +100,7 @@ vi.mock('@sailresearch/sdk', () => {
   };
 });
 
-import { sail } from '../index';
+let sail: typeof import('../index').sail;
 
 function provider() {
   return sail({ app: 'demo', apiKey: 'key' });
@@ -114,7 +114,7 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   h.state.appMissing = false;
   h.state.createGate = undefined;
   h.state.createArgs = [];
@@ -126,19 +126,21 @@ beforeEach(() => {
   h.state.lsResult = [];
   h.state.notFoundOnGet = false;
   vi.clearAllMocks();
+  vi.resetModules();
+  ({ sail } = await import('../index'));
 });
 
 describe('sail provider', () => {
-  it('creates named Sailboxes and shares one app lookup', async () => {
+  it('creates named Sailboxes and shares one client and app lookup across providers', async () => {
     const sdk = await import('@sailresearch/sdk');
-    const compute = provider();
     const [first, second] = await Promise.all([
-      compute.sandbox.create({ name: 'first', size: 'l', memoryGib: 64 }),
-      compute.sandbox.create(),
+      provider().sandbox.create({ name: 'first', size: 'l', memoryGib: 64 }),
+      provider().sandbox.create(),
     ]);
 
     expect(first.sandboxId).toBe('sb_new');
     expect(second.sandboxId).toBe('sb_new');
+    expect(sdk.Client.fromConfig).toHaveBeenCalledTimes(1);
     expect(sdk.App.find).toHaveBeenCalledTimes(1);
     expect(h.state.createArgs[0]).toMatchObject({
       app: { id: 'app_demo', name: 'demo' },

--- a/packages/sail/src/__tests__/unit.test.ts
+++ b/packages/sail/src/__tests__/unit.test.ts
@@ -1,0 +1,368 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  class NotFoundError extends Error {}
+  const state = {
+    appMissing: false,
+    createGate: undefined as Promise<void> | undefined,
+    createArgs: [] as Array<Record<string, unknown>>,
+    existsResult: true,
+    fileContent: 'hello',
+    getStatus: 'running',
+    hasListener: false,
+    lastBox: {} as any,
+    listStatuses: ['running', 'running', 'running'],
+    lsResult: [] as Array<{
+      name: string;
+      type: string;
+      size: number;
+      modifiedTime: number;
+      mode: number;
+    }>,
+    notFoundOnGet: false,
+    terminate: vi.fn(async () => undefined),
+  };
+  return { NotFoundError, state };
+});
+
+vi.mock('@sailresearch/sdk', () => {
+  const makeBox = (id: string, status: string) => {
+    const box = {
+      sailboxId: id,
+      status,
+      createdAt: new Date('2020-01-02T03:04:05Z'),
+      client: {},
+      run: vi.fn(async () => ({ stdout: 'out', stderr: 'err', exitCode: 0 })),
+      exec: vi.fn(async () => ({})),
+      fs: {
+        read: vi.fn(async () => Buffer.from(h.state.fileContent)),
+        write: vi.fn(async () => undefined),
+        mkdir: vi.fn(async () => undefined),
+        ls: vi.fn(async () => h.state.lsResult),
+        exists: vi.fn(async () => h.state.existsResult),
+        remove: vi.fn(async () => undefined),
+      },
+      expose: vi.fn(async () => ({})),
+      listener: vi.fn(async () => {
+        if (!h.state.hasListener) throw new h.NotFoundError('no listener');
+        return h.state.lastBox.listenerValue;
+      }),
+      waitForListener: vi.fn(async () => h.state.lastBox.listenerValue),
+    };
+    h.state.lastBox = {
+      ...box,
+      listenerValue: {
+        protocol: 'http',
+        endpoint: { kind: 'http', url: 'https://sb.example/8080' },
+      },
+    };
+    return h.state.lastBox;
+  };
+
+  return {
+    Image: { devbox: vi.fn(() => ({ base: 'devbox' })) },
+    NotFoundError: h.NotFoundError,
+    resolveConfig: vi.fn(() => ({
+      mode: undefined,
+      apiKey: 'env-key',
+      apiUrl: 'https://dev.example',
+      sailboxApiUrl: 'https://sb-dev.example',
+      imagebuilderUrl: 'ib-dev:50051',
+      ingressBase: 'ingress-dev.example',
+      ingressScheme: 'path' as const,
+    })),
+    App: {
+      find: vi.fn(async (name: string) => {
+        if (h.state.appMissing) throw new h.NotFoundError('no app');
+        return { id: `app_${name}`, name };
+      }),
+    },
+    Client: {
+      fromEnv: vi.fn(() => ({ terminateSailbox: h.state.terminate })),
+      fromConfig: vi.fn(() => ({ terminateSailbox: h.state.terminate })),
+    },
+    Sailbox: {
+      create: vi.fn(async (options: Record<string, unknown>) => {
+        h.state.createArgs.push(options);
+        await h.state.createGate;
+        return makeBox('sb_new', 'running');
+      }),
+      get: vi.fn(async (id: string) => {
+        if (h.state.notFoundOnGet) throw new h.NotFoundError('missing');
+        return makeBox(id, h.state.getStatus);
+      }),
+      list: vi.fn(async () =>
+        h.state.listStatuses.map((status, index) =>
+          makeBox(`sb_${index + 1}`, status),
+        ),
+      ),
+    },
+  };
+});
+
+import { sail } from '../index';
+
+function provider() {
+  return sail({ app: 'demo', apiKey: 'key' });
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  h.state.appMissing = false;
+  h.state.createGate = undefined;
+  h.state.createArgs = [];
+  h.state.existsResult = true;
+  h.state.fileContent = 'hello';
+  h.state.getStatus = 'running';
+  h.state.hasListener = false;
+  h.state.listStatuses = ['running', 'running', 'running'];
+  h.state.lsResult = [];
+  h.state.notFoundOnGet = false;
+  vi.clearAllMocks();
+});
+
+describe('sail provider', () => {
+  it('creates named Sailboxes and shares one app lookup', async () => {
+    const sdk = await import('@sailresearch/sdk');
+    const compute = provider();
+    const [first, second] = await Promise.all([
+      compute.sandbox.create({ name: 'first', size: 'l', memoryGib: 64 }),
+      compute.sandbox.create(),
+    ]);
+
+    expect(first.sandboxId).toBe('sb_new');
+    expect(second.sandboxId).toBe('sb_new');
+    expect(sdk.App.find).toHaveBeenCalledTimes(1);
+    expect(h.state.createArgs[0]).toMatchObject({
+      app: { id: 'app_demo', name: 'demo' },
+      image: { base: 'devbox' },
+      name: 'first',
+      size: 'l',
+      memoryGib: 64,
+    });
+    expect(h.state.createArgs[1]).toMatchObject({
+      image: { base: 'devbox' },
+      size: 's',
+    });
+    expect(String(h.state.createArgs[1].name)).toMatch(/^csdk-/);
+    expect(sdk.Image.devbox).toHaveBeenCalledTimes(2);
+    expect(sdk.Image.devbox).toHaveBeenCalledWith('arm64');
+  });
+
+  it('retries a failed app lookup', async () => {
+    const sdk = await import('@sailresearch/sdk');
+    const compute = provider();
+    h.state.appMissing = true;
+    await expect(compute.sandbox.create()).rejects.toThrow('no app');
+    h.state.appMissing = false;
+    await expect(compute.sandbox.create()).resolves.toMatchObject({
+      sandboxId: 'sb_new',
+    });
+    expect(sdk.App.find).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves SDK connection settings with an explicit API key', async () => {
+    const sdk = await import('@sailresearch/sdk');
+    await provider().sandbox.create();
+    expect(sdk.Client.fromConfig).toHaveBeenCalledWith({
+      apiKey: 'key',
+      mode: undefined,
+      apiUrl: 'https://dev.example',
+      sailboxApiUrl: 'https://sb-dev.example',
+      imagebuilderUrl: 'ib-dev:50051',
+      ingressUrl: 'ingress-dev.example',
+    });
+  });
+
+  it('fails early when no API key is configured', async () => {
+    const sdk = await import('@sailresearch/sdk');
+    vi.mocked(sdk.resolveConfig).mockReturnValueOnce({
+      mode: undefined,
+      apiKey: undefined,
+      apiUrl: 'https://api.sailresearch.com',
+      sailboxApiUrl: 'https://api.sailresearch.com',
+      imagebuilderUrl: 'api.sailresearch.com:443',
+      ingressBase: 'api.sailresearch.com',
+      ingressScheme: 'subdomain',
+    } as never);
+    await expect(sail({ app: 'demo' }).sandbox.create()).rejects.toThrow(
+      /Missing Sail API key/,
+    );
+  });
+
+  it('rejects unsupported or misleading create options', async () => {
+    const compute = provider();
+    await expect(
+      compute.sandbox.create({ snapshotId: 'snap_1' }),
+    ).rejects.toThrow(/snapshotId/);
+    await expect(
+      compute.sandbox.create({ envs: { A: '1' } }),
+    ).rejects.toThrow(/envs/);
+    await expect(compute.sandbox.create({ timeout: 5_000 })).rejects.toThrow(
+      /hard sandbox lifetime/,
+    );
+    await expect(
+      compute.sandbox.create({ size: 'extra-large' }),
+    ).rejects.toThrow(/use s, m, or l/);
+    expect(h.state.createArgs).toHaveLength(0);
+  });
+
+  it('cleans up a Sailbox that finishes creating after cancellation', async () => {
+    const gate = deferred();
+    h.state.createGate = gate.promise;
+    const controller = new AbortController();
+    const creation = provider().sandbox.create({ signal: controller.signal });
+    await vi.waitFor(() => expect(h.state.createArgs).toHaveLength(1));
+    controller.abort(new Error('caller stopped'));
+
+    await expect(creation).rejects.toMatchObject({ name: 'AbortError' });
+    gate.resolve();
+    await vi.waitFor(() =>
+      expect(h.state.terminate).toHaveBeenCalledWith('sb_new'),
+    );
+  });
+
+  it('maps command options and background execution', async () => {
+    const sandbox = await provider().sandbox.create();
+    const result = await sandbox.runCommand('echo hi', {
+      cwd: '/work',
+      env: { A: '1' },
+      timeout: 5_000,
+    });
+    expect(result).toMatchObject({ stdout: 'out', stderr: 'err', exitCode: 0 });
+    expect(h.state.lastBox.run).toHaveBeenCalledWith('echo hi', {
+      cwd: '/work',
+      env: { A: '1' },
+      background: undefined,
+      timeoutSeconds: 5,
+    });
+
+    const background = await sandbox.runCommand('sleep 60', {
+      background: true,
+    });
+    expect(background).toMatchObject({ stdout: '', stderr: '', exitCode: 0 });
+    expect(h.state.lastBox.exec).toHaveBeenCalledWith('sleep 60', {
+      cwd: undefined,
+      env: undefined,
+      background: true,
+      timeoutSeconds: undefined,
+    });
+  });
+
+  it('maps native filesystem entries and file contents', async () => {
+    h.state.fileContent = 'file body';
+    h.state.lsResult = [
+      {
+        name: 'sub',
+        type: 'directory',
+        size: 4_096,
+        modifiedTime: 1_700_000_000,
+        mode: 0o755,
+      },
+      {
+        name: 'link',
+        type: 'symlink',
+        size: 7,
+        modifiedTime: 1_700_000_001.5,
+        mode: 0o777,
+      },
+    ];
+    const sandbox = await provider().sandbox.create();
+    expect(await sandbox.filesystem.readFile('/tmp/x')).toBe('file body');
+    expect(await sandbox.filesystem.readdir('/tmp')).toEqual([
+      {
+        name: 'sub',
+        type: 'directory',
+        size: 4_096,
+        modified: new Date(1_700_000_000_000),
+      },
+      {
+        name: 'link',
+        type: 'file',
+        size: 7,
+        modified: new Date(1_700_000_001_500),
+      },
+    ]);
+  });
+
+  it('maps lifecycle states and filters gone Sailboxes', async () => {
+    const sandbox = await provider().sandbox.create();
+    for (const [status, expected] of [
+      ['running', 'running'],
+      ['sleeping', 'stopped'],
+      ['create_failed', 'error'],
+    ] as const) {
+      h.state.getStatus = status;
+      await expect(sandbox.getInfo()).resolves.toMatchObject({ status: expected });
+    }
+
+    h.state.listStatuses = ['running', 'terminated', 'paused', 'failed'];
+    const listed = await provider().sandbox.list();
+    expect(listed.map((item) => item.sandboxId)).toEqual([
+      'sb_1',
+      'sb_3',
+      'sb_4',
+    ]);
+
+    h.state.getStatus = 'terminated';
+    await expect(provider().sandbox.getById('sb_dead')).resolves.toBeNull();
+  });
+
+  it('returns null for missing Sailboxes and an empty list for a missing app', async () => {
+    h.state.notFoundOnGet = true;
+    await expect(provider().sandbox.getById('sb_missing')).resolves.toBeNull();
+    h.state.appMissing = true;
+    await expect(provider().sandbox.list()).resolves.toEqual([]);
+  });
+
+  it('exposes HTTP ports once and preserves existing listener policy', async () => {
+    const sandbox = await provider().sandbox.create();
+    await expect(sandbox.getUrl({ port: 8080 })).resolves.toBe(
+      'https://sb.example/8080',
+    );
+    expect(h.state.lastBox.expose).toHaveBeenCalledWith(8080, {
+      protocol: 'http',
+    });
+
+    h.state.hasListener = true;
+    await expect(sandbox.getUrl({ port: 8080, protocol: 'https' })).resolves.toBe(
+      'https://sb.example/8080',
+    );
+    expect(h.state.lastBox.expose).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects unsupported and mismatched listener protocols', async () => {
+    const sandbox = await provider().sandbox.create();
+    await expect(sandbox.getUrl({ port: 53, protocol: 'udp' })).rejects.toThrow(
+      /protocol udp/,
+    );
+
+    h.state.hasListener = true;
+    h.state.lastBox.listenerValue = {
+      protocol: 'tcp',
+      endpoint: { kind: 'tcp', host: 'tcp.example', port: 40_000 },
+    };
+    await expect(sandbox.getUrl({ port: 8080 })).rejects.toThrow(
+      /already exposed as tcp/,
+    );
+
+    await expect(
+      sandbox.getUrl({ port: 8080, protocol: 'tcp' }),
+    ).resolves.toBe('tcp://tcp.example:40000');
+  });
+
+  it('destroys through the configured client and exposes the native instance', async () => {
+    const compute = provider();
+    const sandbox = await compute.sandbox.create();
+    expect(sandbox.getInstance()).toBe(h.state.lastBox);
+    await compute.sandbox.destroy('sb_x');
+    expect(h.state.terminate).toHaveBeenCalledWith('sb_x');
+  });
+});

--- a/packages/sail/src/index.ts
+++ b/packages/sail/src/index.ts
@@ -39,6 +39,7 @@ const PROVIDER = 'sail';
 const DEFAULT_APP = 'computesdk';
 const DEFAULT_SIZE: SailboxSize = 's';
 const GONE_STATUSES = new Set(['terminating', 'terminated']);
+const MAX_RESOLVED_CONFIGS = 32;
 
 interface ResolvedSailConfig {
   client: Client;
@@ -46,26 +47,48 @@ interface ResolvedSailConfig {
   appPromise?: Promise<App>;
 }
 
-const resolvedConfigs = new WeakMap<SailConfig, ResolvedSailConfig>();
+const resolvedConfigs = new Map<string, ResolvedSailConfig>();
 
-/** Resolve and cache the native client associated with one provider config. */
+/** Resolve and cache equivalent provider configs so their transports are shared. */
 function resolve(config: SailConfig): ResolvedSailConfig {
-  let entry = resolvedConfigs.get(config);
-  if (entry) return entry;
-
   const environment = resolveConfig();
-  if (!config.apiKey && !environment.apiKey) {
+  const apiKey = config.apiKey ?? environment.apiKey;
+  if (!apiKey) {
     throw new Error(
       'Missing Sail API key. Pass sail({ apiKey }) or set SAIL_API_KEY. ' +
         'Create a key at https://app.sailresearch.com.',
     );
   }
+  const appName = config.app ?? process.env.SAIL_APP ?? DEFAULT_APP;
+  const cacheKey = JSON.stringify([
+    apiKey,
+    appName,
+    environment.mode ?? null,
+    environment.apiUrl,
+    environment.sailboxApiUrl,
+    environment.imagebuilderUrl,
+    environment.ingressScheme,
+    environment.ingressBase,
+  ]);
+  let entry = resolvedConfigs.get(cacheKey);
+  if (entry) {
+    // Refresh insertion order so the bounded map behaves as an LRU cache.
+    resolvedConfigs.delete(cacheKey);
+    resolvedConfigs.set(cacheKey, entry);
+    return entry;
+  }
 
   entry = {
-    client: config.apiKey ? clientWithKey(config.apiKey) : Client.fromEnv(),
-    appName: config.app ?? process.env.SAIL_APP ?? DEFAULT_APP,
+    client: config.apiKey
+      ? clientWithKey(config.apiKey, environment)
+      : Client.fromEnv(),
+    appName,
   };
-  resolvedConfigs.set(config, entry);
+  resolvedConfigs.set(cacheKey, entry);
+  if (resolvedConfigs.size > MAX_RESOLVED_CONFIGS) {
+    const oldest = resolvedConfigs.keys().next().value;
+    if (oldest !== undefined) resolvedConfigs.delete(oldest);
+  }
   return entry;
 }
 
@@ -86,8 +109,7 @@ function resolveApp(config: SailConfig): Promise<App> {
 }
 
 /** Preserve connection settings resolved by the Sail SDK. */
-function clientWithKey(apiKey: string): Client {
-  const environment = resolveConfig();
+function clientWithKey(apiKey: string, environment: ReturnType<typeof resolveConfig>): Client {
   return Client.fromConfig({
     apiKey,
     mode: environment.mode ?? undefined,

--- a/packages/sail/src/index.ts
+++ b/packages/sail/src/index.ts
@@ -1,0 +1,373 @@
+/**
+ * Sail provider for ComputeSDK.
+ *
+ * The provider maps ComputeSDK's universal sandbox interface onto Sailboxes
+ * through the official `@sailresearch/sdk` package.
+ */
+
+import { defineProvider } from '@computesdk/provider';
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+  SandboxInfo,
+} from '@computesdk/provider';
+import {
+  App,
+  Client,
+  Image,
+  NotFoundError,
+  Sailbox,
+  resolveConfig,
+  type ExecOptions,
+  type ImageSpec,
+  type SailboxSize,
+} from '@sailresearch/sdk';
+
+/** Configuration for the Sail provider. */
+export interface SailConfig {
+  /** Sail API key. Falls back to `SAIL_API_KEY`. */
+  apiKey?: string;
+  /** App that owns created Sailboxes. Falls back to `SAIL_APP`, then `computesdk`. */
+  app?: string;
+  /** Image used by created Sailboxes. Defaults to Sail's ARM64 Devbox builtin. */
+  image?: ImageSpec | Image;
+}
+
+const PROVIDER = 'sail';
+const DEFAULT_APP = 'computesdk';
+const DEFAULT_SIZE: SailboxSize = 's';
+const GONE_STATUSES = new Set(['terminating', 'terminated']);
+
+interface ResolvedSailConfig {
+  client: Client;
+  appName: string;
+  appPromise?: Promise<App>;
+}
+
+const resolvedConfigs = new WeakMap<SailConfig, ResolvedSailConfig>();
+
+/** Resolve and cache the native client associated with one provider config. */
+function resolve(config: SailConfig): ResolvedSailConfig {
+  let entry = resolvedConfigs.get(config);
+  if (entry) return entry;
+
+  const environment = resolveConfig();
+  if (!config.apiKey && !environment.apiKey) {
+    throw new Error(
+      'Missing Sail API key. Pass sail({ apiKey }) or set SAIL_API_KEY. ' +
+        'Create a key at https://app.sailresearch.com.',
+    );
+  }
+
+  entry = {
+    client: config.apiKey ? clientWithKey(config.apiKey) : Client.fromEnv(),
+    appName: config.app ?? process.env.SAIL_APP ?? DEFAULT_APP,
+  };
+  resolvedConfigs.set(config, entry);
+  return entry;
+}
+
+/** Resolve an app once per provider config and share concurrent lookups. */
+function resolveApp(config: SailConfig): Promise<App> {
+  const entry = resolve(config);
+  if (entry.appPromise) return entry.appPromise;
+
+  const pending = App.find(entry.appName, {
+    client: entry.client,
+    mintIfMissing: true,
+  });
+  entry.appPromise = pending;
+  pending.catch(() => {
+    if (entry.appPromise === pending) entry.appPromise = undefined;
+  });
+  return pending;
+}
+
+/** Preserve connection settings resolved by the Sail SDK. */
+function clientWithKey(apiKey: string): Client {
+  const environment = resolveConfig();
+  return Client.fromConfig({
+    apiKey,
+    mode: environment.mode ?? undefined,
+    apiUrl: environment.apiUrl,
+    sailboxApiUrl: environment.sailboxApiUrl,
+    imagebuilderUrl: environment.imagebuilderUrl,
+    // `ingressUrl` is a path-mode override. Subdomain mode is carried by mode.
+    ingressUrl:
+      environment.ingressScheme === 'path'
+        ? environment.ingressBase
+        : undefined,
+  });
+}
+
+/** Convert an aborted signal into a stable Error for runtimes with arbitrary reasons. */
+function abortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  const error = new Error('Sailbox creation was aborted.');
+  error.name = 'AbortError';
+  return error;
+}
+
+/**
+ * Race creation against ComputeSDK cancellation and terminate a late result.
+ * Sail's create API is idempotent but not abortable, so cleanup must remain
+ * attached after the caller stops waiting to prevent an orphaned Sailbox.
+ */
+function createWithAbortCleanup(
+  create: Promise<Sailbox>,
+  signal: AbortSignal | undefined,
+  client: Client,
+): Promise<Sailbox> {
+  if (!signal) return create;
+  if (signal.aborted) {
+    void create.then((box) => client.terminateSailbox(box.sailboxId)).catch(() => undefined);
+    return Promise.reject(abortError(signal));
+  }
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    let settled = false;
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      void create.then((box) => client.terminateSailbox(box.sailboxId)).catch(() => undefined);
+      rejectPromise(abortError(signal));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    create.then(
+      (box) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        resolvePromise(box);
+      },
+      (error) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        rejectPromise(error);
+      },
+    );
+  });
+}
+
+/** Reject options that Sail cannot honor without changing their meaning. */
+function validateCreateOptions(options: CreateSandboxOptions | undefined): void {
+  const supported = new Set([
+    'memoryGib',
+    'name',
+    'provider',
+    'signal',
+    'size',
+    'timeout',
+  ]);
+  const unsupported = Object.keys(options ?? {}).filter(
+    (key) => options?.[key] !== undefined && !supported.has(key),
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Sail does not support create option(s): ${unsupported.join(', ')}. ` +
+        'Configure the image on sail({ image }) and set environment variables per command.',
+    );
+  }
+  if (options?.timeout !== undefined) {
+    throw new Error(
+      'Sail does not support ComputeSDK create timeout because it is a hard ' +
+        'sandbox lifetime. Bound individual commands with runCommand timeout ' +
+        'or call destroy() when finished.',
+    );
+  }
+  if (
+    options?.size !== undefined &&
+    options.size !== 's' &&
+    options.size !== 'm' &&
+    options.size !== 'l'
+  ) {
+    throw new Error(
+      `Sail does not support size ${options.size}; use s, m, or l.`,
+    );
+  }
+}
+
+/** Return a size after validateCreateOptions has narrowed it to Sail's tiers. */
+function sailboxSize(size: string | undefined): SailboxSize | undefined {
+  return size as SailboxSize | undefined;
+}
+
+/** Map ComputeSDK protocols onto Sail ingress listeners. */
+function toIngressProtocol(protocol: string | undefined): 'http' | 'tcp' {
+  if (protocol === undefined || protocol === 'http' || protocol === 'https') {
+    return 'http';
+  }
+  if (protocol === 'tcp') return 'tcp';
+  throw new Error(`Sail does not support ingress protocol ${protocol}; use http, https, or tcp.`);
+}
+
+/** Map Sail lifecycle states onto ComputeSDK's three status values. */
+function toStatus(status: string): SandboxInfo['status'] {
+  switch (status) {
+    case 'running':
+      return 'running';
+    case 'failed':
+    case 'create_failed':
+    case 'interrupted_unsafe_to_retry':
+      return 'error';
+    default:
+      return 'stopped';
+  }
+}
+
+/** Translate millisecond ComputeSDK command timeouts into Sail seconds. */
+function toExecOptions(options?: RunCommandOptions): ExecOptions {
+  return {
+    cwd: options?.cwd,
+    env: options?.env,
+    background: options?.background,
+    timeoutSeconds:
+      options?.timeout !== undefined ? options.timeout / 1_000 : undefined,
+  };
+}
+
+export const sail = defineProvider<Sailbox, SailConfig>({
+  name: PROVIDER,
+  methods: {
+    sandbox: {
+      create: async (config, options?: CreateSandboxOptions) => {
+        validateCreateOptions(options);
+        if (options?.signal?.aborted) throw abortError(options.signal);
+        const { client } = resolve(config);
+        const app = await resolveApp(config);
+        if (options?.signal?.aborted) throw abortError(options.signal);
+
+        const creation = Sailbox.create({
+          app,
+          name: options?.name ?? `csdk-${crypto.randomUUID().slice(0, 8)}`,
+          client,
+          image: config.image ?? Image.devbox('arm64'),
+          size: sailboxSize(options?.size) ?? DEFAULT_SIZE,
+          memoryGib: options?.memoryGib,
+        });
+        const sandbox = await createWithAbortCleanup(creation, options?.signal, client);
+        return { sandbox, sandboxId: sandbox.sailboxId };
+      },
+
+      getById: async (config, sandboxId) => {
+        const { client } = resolve(config);
+        try {
+          const sandbox = await Sailbox.get(sandboxId, { client });
+          if (GONE_STATUSES.has(sandbox.status)) return null;
+          return { sandbox, sandboxId: sandbox.sailboxId };
+        } catch (error) {
+          if (error instanceof NotFoundError) return null;
+          throw error;
+        }
+      },
+
+      list: async (config) => {
+        const { client, appName } = resolve(config);
+        let app: App;
+        try {
+          app = await App.find(appName, { client, mintIfMissing: false });
+        } catch (error) {
+          if (error instanceof NotFoundError) return [];
+          throw error;
+        }
+        const sandboxes = await Sailbox.list({ appId: app.id, client });
+        return sandboxes
+          .filter((sandbox) => !GONE_STATUSES.has(sandbox.status))
+          .map((sandbox) => ({ sandbox, sandboxId: sandbox.sailboxId }));
+      },
+
+      destroy: async (config, sandboxId) => {
+        await resolve(config).client.terminateSailbox(sandboxId);
+      },
+
+      runCommand: async (
+        sandbox,
+        command,
+        options?: RunCommandOptions,
+      ): Promise<CommandResult> => {
+        const startedAt = Date.now();
+        if (options?.background) {
+          await sandbox.exec(command, toExecOptions(options));
+          return {
+            stdout: '',
+            stderr: '',
+            exitCode: 0,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+        const result = await sandbox.run(command, toExecOptions(options));
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          durationMs: Date.now() - startedAt,
+        };
+      },
+
+      getInfo: async (sandbox): Promise<SandboxInfo> => {
+        const current = await Sailbox.get(sandbox.sailboxId, {
+          client: sandbox.client,
+        });
+        return {
+          id: current.sailboxId,
+          provider: PROVIDER,
+          status: toStatus(current.status),
+          createdAt: current.createdAt ?? new Date(0),
+          timeout: 0,
+        };
+      },
+
+      getUrl: async (sandbox, options): Promise<string> => {
+        const protocol = toIngressProtocol(options.protocol);
+        const existing = await sandbox.listener(options.port).catch((error: unknown) => {
+          if (!(error instanceof NotFoundError)) throw error;
+          return undefined;
+        });
+        if (existing === undefined) {
+          await sandbox.expose(options.port, { protocol });
+        } else if (existing.protocol !== protocol) {
+          throw new Error(
+            `Sailbox port ${options.port} is already exposed as ${existing.protocol}; ` +
+              `request ${existing.protocol} or unexpose it first.`,
+          );
+        }
+
+        const listener = await sandbox.waitForListener(options.port);
+        if (listener.endpoint?.kind === 'http') return listener.endpoint.url;
+        if (listener.endpoint?.kind === 'tcp') {
+          return `tcp://${listener.endpoint.host}:${listener.endpoint.port}`;
+        }
+        throw new Error(`Sailbox port ${options.port} has no reachable endpoint.`);
+      },
+
+      filesystem: {
+        readFile: async (sandbox, path) =>
+          (await sandbox.fs.read(path)).toString('utf8'),
+        writeFile: async (sandbox, path, content) => {
+          await sandbox.fs.write(path, content);
+        },
+        mkdir: async (sandbox, path) => {
+          await sandbox.fs.mkdir(path);
+        },
+        readdir: async (sandbox, path): Promise<FileEntry[]> =>
+          (await sandbox.fs.ls(path)).map((entry) => ({
+            name: entry.name,
+            type: entry.type === 'directory' ? 'directory' : 'file',
+            size: entry.size,
+            modified: new Date(entry.modifiedTime * 1_000),
+          })),
+        exists: async (sandbox, path) => sandbox.fs.exists(path),
+        remove: async (sandbox, path) => {
+          await sandbox.fs.remove(path);
+        },
+      },
+
+      getInstance: (sandbox) => sandbox,
+    },
+  },
+});

--- a/packages/sail/tsconfig.json
+++ b/packages/sail/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sail/tsup.config.ts
+++ b/packages/sail/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/sail/vitest.config.ts
+++ b/packages/sail/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1797,6 +1797,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/sail:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@sailresearch/sdk':
+        specifier: ^0.5.1
+        version: 0.5.1
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/sandbox0:
     dependencies:
       '@computesdk/provider':
@@ -4837,6 +4874,52 @@ packages:
   '@runloop/api-client@1.24.0':
     resolution: {integrity: sha512-A/G9l2MlBz/u0Wr2RvCEJvh0+4Pn/8p15BTq9wQt3vEgEGLEk844+9bIKsfWbDvU/4JdRvIUND79Vu5qvKQzUQ==}
 
+  '@sailresearch/sdk-darwin-arm64@0.5.1':
+    resolution: {integrity: sha512-ShPaFm0+9rfs0vdfKPVW74Q00xNu4IJhVIDF3oACWtkcr3SQg783E4HdgORSUpU45zavXPheRbKCVNoE8cGm4A==}
+    engines: {node: '>=22'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@sailresearch/sdk-darwin-x64@0.5.1':
+    resolution: {integrity: sha512-WwFqv0ds1TTPoVCda03smYLZhPQiuWhsFzHJvK/TTAdEEe0+MtAnWKjCiRlD4C1unljvAOzVdfOvPjn3SqFtUw==}
+    engines: {node: '>=22'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@sailresearch/sdk-linux-arm64-gnu@0.5.1':
+    resolution: {integrity: sha512-ivgHDITXxMO+LMlbgeZH/ywxqaIr1ax8srzNhMQxPas7nsY16h6vLhPDHW5pzMVpPFGl8b3vHGp6UB9PUHImYQ==}
+    engines: {node: '>=22'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@sailresearch/sdk-linux-arm64-musl@0.5.1':
+    resolution: {integrity: sha512-dISiV2oDSEX8wLxG4vcK/nVKAhNOm+JbRKi3skdDZ3vg25k8RbIv0LkijD66zATEmL6cb650HRrWUwIVAaF+Eg==}
+    engines: {node: '>=22'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@sailresearch/sdk-linux-x64-gnu@0.5.1':
+    resolution: {integrity: sha512-eZKhrq3yDGaH/6L8JBsB94OKu80AgimyFybzpbzNr7r/jdqmBneqhq882sE4x7gWPiD45I2Kj/Sgn67ed1/Eug==}
+    engines: {node: '>=22'}
+    cpu: [x64]
+    os: [linux]
+
+  '@sailresearch/sdk-linux-x64-musl@0.5.1':
+    resolution: {integrity: sha512-4+iAMHK2v4T8+ZQ3YRnvtF6DW/DdWdIjWXMd4gu32Q5gkngp4njBs5Ccv7n2GqSdt2MU4b8RglNcfcGJIbN1yA==}
+    engines: {node: '>=22'}
+    cpu: [x64]
+    os: [linux]
+
+  '@sailresearch/sdk-win32-x64-msvc@0.5.1':
+    resolution: {integrity: sha512-WHIgGmWVaag7SHMWEwbDUrxXAE/Wjm5nRyu7uT0ssktp9cIJ45trMJWjHeH87CgdKstw+b1ptRb1YTT/7jq3AQ==}
+    engines: {node: '>=22'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sailresearch/sdk@0.5.1':
+    resolution: {integrity: sha512-r9m2y/2pmdw2Ds6sw3DUSan9td5KfokiNHtXSBHYpVdaad/cRtI57krPcEebpNT9ALNKtQr6bmJvcOSTkk9awA==}
+    engines: {node: '>=22'}
+
   '@secure-exec/browser@0.1.1-rc.3':
     resolution: {integrity: sha512-syjym68632Yzba6Uu9tfnd2KGHTHoiOMTg3hnYRxs4t2RrTfzKm3fWOBVmOZHaZT7ECMCItXerDfYmH05tbHDg==}
 
@@ -5185,6 +5268,9 @@ packages:
 
   '@types/node@20.19.5':
     resolution: {integrity: sha512-M4CtoNkoQrYOD7O80KM7DjGdzwMvoXZ12SGUbxc0X1AK6gfBKjkJswW/B4MyTPMIuU0sodukEgj8CzIJKEAQXQ==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
@@ -12020,6 +12106,39 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@sailresearch/sdk-darwin-arm64@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk-darwin-x64@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk-linux-arm64-gnu@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk-linux-arm64-musl@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk-linux-x64-gnu@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk-linux-x64-musl@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk-win32-x64-msvc@0.5.1':
+    optional: true
+
+  '@sailresearch/sdk@0.5.1':
+    dependencies:
+      '@types/node': 22.20.1
+    optionalDependencies:
+      '@sailresearch/sdk-darwin-arm64': 0.5.1
+      '@sailresearch/sdk-darwin-x64': 0.5.1
+      '@sailresearch/sdk-linux-arm64-gnu': 0.5.1
+      '@sailresearch/sdk-linux-arm64-musl': 0.5.1
+      '@sailresearch/sdk-linux-x64-gnu': 0.5.1
+      '@sailresearch/sdk-linux-x64-musl': 0.5.1
+      '@sailresearch/sdk-win32-x64-msvc': 0.5.1
+
   '@secure-exec/browser@0.1.1-rc.3':
     dependencies:
       '@secure-exec/core': 0.1.1-rc.3
@@ -12489,6 +12608,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/node@20.19.5':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
 


### PR DESCRIPTION
## Summary

- add `@computesdk/sail` using the official `@sailresearch/sdk`
- support lifecycle, shell commands, native filesystem operations, HTTP/TCP listeners, resource sizing, and bounded cancellation cleanup
- default creates to a small ARM64 Devbox Sailbox while preserving explicit image and size overrides
- reject universal create options whose semantics Sail cannot honor instead of silently ignoring them
- add provider docs, focused unit tests, the shared provider contract suite, package build configuration, and a release changeset

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @computesdk/sail typecheck`
- `pnpm --filter @computesdk/sail lint`
- `pnpm --filter @computesdk/sail test` (27 tests)
- `pnpm --filter @computesdk/sail build`
- live shared provider suite: 14/14 integration cases passed
- packed `@computesdk/sail@1.0.0`, installed it into a clean npm consumer, and imported its ESM export successfully

## Live benchmark

ComputeSDK's standard create-to-first-`node -v` suites ran with 100 `S` ARM64 Sailboxes per mode. The architecture probe returned `aarch64`; all 300 iterations succeeded. These are ComputeSDK's official 5%-trimmed statistics and composite scores.

| Mode | p50 | p95 | p99 | Score | Success |
|---|---:|---:|---:|---:|---:|
| Sequential | 0.884s | 0.998s | 1.015s | 90.68 | 100/100 |
| Gradual, 200ms stagger | 1.739s | 2.073s | 2.098s | 81.24 | 100/100 |
| Simultaneous burst | 3.835s | 4.637s | 4.886s | 58.07 | 100/100 |

## Rollout note

This stays draft while ComputeSDK maintainers review the provider surface. The scheduled benchmark should only be activated after the package is merged and published.
