### PR TITLE
Improve Beam sandbox create and destroy

### DIFF
--- a/packages/beam/package.json
+++ b/packages/beam/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@beamcloud/beam-js": "^1.0.13",
+    "@beamcloud/beam-js": "^1.0.17",
     "computesdk": "workspace:*",
     "@computesdk/provider": "workspace:*"
   },

--- a/packages/beam/src/__tests__/index.test.ts
+++ b/packages/beam/src/__tests__/index.test.ts
@@ -13,6 +13,8 @@
  */
 
 import { runProviderTestSuite } from '@computesdk/test-utils';
+import { Sandbox, type SandboxInstance } from '@beamcloud/beam-js';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { beam } from '../index';
 
 // Run the shared provider test suite
@@ -24,4 +26,66 @@ runProviderTestSuite({
   supportsFilesystem: true,
   // Skip integration tests if required environment variables are not set
   skipIntegration: !process.env.BEAM_TOKEN || !process.env.BEAM_WORKSPACE_ID,
+});
+
+function mockSandbox() {
+  const process = {
+    wait: vi.fn().mockResolvedValue(undefined),
+    stdout: { read: vi.fn().mockResolvedValue('') },
+    stderr: { read: vi.fn().mockResolvedValue('') },
+    exitCode: 0,
+  };
+  const instance = {
+    containerId: 'sandbox-123',
+    exec: vi.fn().mockResolvedValue(process),
+    exposePort: vi.fn().mockResolvedValue('https://sandbox.example'),
+    fs: {
+      listFiles: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as SandboxInstance;
+  vi.spyOn(Sandbox.prototype, 'create').mockResolvedValue(instance);
+  return instance;
+}
+
+describe('lazy sandbox readiness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('connects once before concurrent native operations', async () => {
+    const instance = mockSandbox();
+    let connected = false;
+    const connect = vi.spyOn(Sandbox, 'connect').mockImplementation(async () => {
+      connected = true;
+      return instance;
+    });
+    vi.mocked(instance.exposePort).mockImplementation(async () => {
+      expect(connected).toBe(true);
+      return 'https://sandbox.example';
+    });
+    vi.mocked(instance.fs.listFiles).mockImplementation(async () => {
+      expect(connected).toBe(true);
+      return [];
+    });
+
+    const sandbox = await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create();
+    await Promise.all([
+      sandbox.getUrl({ port: 3000 }),
+      sandbox.filesystem.readdir('/tmp'),
+    ]);
+
+    expect(connect).toHaveBeenCalledOnce();
+  });
+
+  test('does not reconnect after a successful command', async () => {
+    const instance = mockSandbox();
+    const connect = vi.spyOn(Sandbox, 'connect').mockResolvedValue(instance);
+    const sandbox = await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create();
+
+    await sandbox.runCommand('true');
+    await sandbox.getUrl({ port: 3000 });
+    await sandbox.filesystem.readdir('/tmp');
+
+    expect(connect).not.toHaveBeenCalled();
+  });
 });

--- a/packages/beam/src/index.ts
+++ b/packages/beam/src/index.ts
@@ -77,6 +77,21 @@ function sandboxCacheKey(sandboxConfig: any): string {
 
 const MAX_SANDBOX_CACHE_ENTRIES = 32;
 const sandboxCache = new Map<string, Sandbox>();
+const sandboxReadiness = new WeakMap<SandboxInstance, Promise<void>>();
+
+function ensureSandboxReady(sandbox: SandboxInstance): Promise<void> {
+  const pending = sandboxReadiness.get(sandbox);
+  if (pending) return pending;
+
+  const readiness = Sandbox.connect(sandbox.containerId)
+    .then(() => undefined)
+    .catch((error) => {
+      sandboxReadiness.delete(sandbox);
+      throw error;
+    });
+  sandboxReadiness.set(sandbox, readiness);
+  return readiness;
+}
 
 function getCachedSandbox(cacheKey: string, sandboxConfig: any): Sandbox {
   const cachedSandbox = sandboxCache.get(cacheKey);
@@ -156,7 +171,7 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
 
           cacheKey = sandboxCacheKey(sandboxConfig);
           const sandbox = getCachedSandbox(cacheKey, sandboxConfig);
-          const instance = await sandbox.create();
+          const instance = await sandbox.create({ waitForReady: false });
           return { sandbox: instance, sandboxId: instance.containerId };
         } catch (error) {
           if (cacheKey) sandboxCache.delete(cacheKey);
@@ -186,8 +201,7 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
         configureBeamOpts(config);
         if (!beamOpts.token) return;
         try {
-          const instance = await Sandbox.connect(sandboxId);
-          await instance.terminate();
+          await Sandbox.terminate(sandboxId);
         } catch { /* Sandbox might already be destroyed */ }
       },
 
@@ -207,6 +221,7 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
             { wait: true } as Parameters<SandboxInstance['exec']>[1],
           );
           await proc.wait();
+          sandboxReadiness.set(sandbox, Promise.resolve());
           const [stdoutStr, stderrStr] = await Promise.all([proc.stdout.read(), proc.stderr.read()]);
           return { stdout: stdoutStr || '', stderr: stderrStr || '', exitCode: proc.exitCode || 0, durationMs: Date.now() - startTime };
         } catch (error) {
@@ -242,6 +257,7 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
 
       getUrl: async (sandbox: SandboxInstance, options: { port: number; protocol?: string }): Promise<string> => {
         try {
+          await ensureSandboxReady(sandbox);
           return await sandbox.exposePort(options.port);
         } catch (error) {
           throw new Error(`Failed to get Beam URL for port ${options.port}: ${error instanceof Error ? error.message : String(error)}`);
@@ -264,6 +280,7 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
           if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
         },
         readdir: async (sandbox: SandboxInstance, path: string, _runCommand: RunCommandFn): Promise<FileEntry[]> => {
+          await ensureSandboxReady(sandbox);
           const files = await sandbox.fs.listFiles(path);
           return files.map((file: any) => ({
             name: file.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
     dependencies:
       '@arker-ai/sdk':
         specifier: ^0.8.3
-        version: 0.8.3(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+        version: 0.8.3(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -323,8 +323,8 @@ importers:
   packages/beam:
     dependencies:
       '@beamcloud/beam-js':
-        specifier: ^1.0.13
-        version: 1.0.13(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
+        specifier: ^1.0.17
+        version: 1.0.17(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -843,7 +843,7 @@ importers:
         version: link:../provider
       '@daytonaio/sdk':
         specifier: ^0.192.0
-        version: 0.192.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -2632,8 +2632,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.13':
-    resolution: {integrity: sha512-y2DDUKNr2lK8mQbeSkeo1W6RMhTeLeZRyED8FfxjowLxYEj2QN3kgXxn2/v93OY1OCRW4mRYSe0+cHhpe65iqQ==}
+  '@beamcloud/beam-js@1.0.17':
+    resolution: {integrity: sha512-LcgLeUDYZajTOktXXwRiWH6waE7ikWdaM5PjVv0bctjEOxwwFuUEtEc2iyj3SYAXaCJaXDiWs1LSB5frIkzBhQ==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -5396,6 +5396,7 @@ packages:
 
   anchorbrowser@0.16.3:
     resolution: {integrity: sha512-slz85Zmj0T3XDOKLH8n7nxcLFHcvpPJInCHcysuOyUbP2sMAyhMwMS6LiS727WqnTMaVGx4p6KgJpIJ8+FWhlw==}
+    deprecated: 'anchorbrowser 0.x.x is deprecated. Upgrade to anchorbrowser@^1.0.0 — see the migration guide: https://github.com/anchorbrowser/AnchorBrowser-SDK-Typescript/blob/main/MIGRATION.md'
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -9113,6 +9114,9 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -9170,11 +9174,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@arker-ai/sdk@0.8.3(@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+  '@arker-ai/sdk@0.8.3(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
-      '@computesdk/daytona': 1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@computesdk/daytona': 1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@computesdk/e2b': 1.7.52
       '@computesdk/modal': 1.9.4
       computesdk: link:packages/computesdk
@@ -9832,15 +9836,15 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.13(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.17(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
     dependencies:
-      archiver: 7.0.1
       axios: 1.18.1
       commander: 12.1.0
       ignore: 7.0.5
       strip-ansi: 7.2.0
       typescript: 5.8.3
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      yazl: 3.3.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -10164,10 +10168,10 @@ snapshots:
   '@computesdk/cmd@0.4.1':
     optional: true
 
-  '@computesdk/daytona@1.7.32(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@computesdk/provider': 2.1.4
-      '@daytonaio/sdk': 0.192.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@daytonaio/sdk': 0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       computesdk: 4.1.4
     transitivePeerDependencies:
       - aws-crt
@@ -10273,7 +10277,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@daytonaio/sdk@0.192.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@daytonaio/sdk@0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@aws-sdk/client-s3': 3.1045.0
       '@aws-sdk/lib-storage': 3.1045.0(@aws-sdk/client-s3@3.1045.0)
@@ -10294,7 +10298,7 @@ snapshots:
       expand-tilde: 2.0.2
       fast-glob: 3.3.3
       form-data: 4.0.5
-      isomorphic-ws: 5.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 5.0.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       pathe: 2.0.3
       shell-quote: 1.8.3
       tar: 7.5.16
@@ -14587,7 +14591,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -14707,9 +14711,9 @@ snapshots:
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isomorphic-ws@5.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@5.0.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   isorun@1.0.0(@modelcontextprotocol/sdk@1.26.0(zod@4.4.3))(zod@4.4.3):
     dependencies:
@@ -14794,7 +14798,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -15711,7 +15715,7 @@ snapshots:
 
   pyodide@0.28.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17217,6 +17221,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
     optional: true
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- require `@beamcloud/beam-js` `^1.0.17`
- reuse Beam's prepared sandbox state and skip the redundant create-time readiness round trip
- lazily confirm readiness before native filesystem and port-exposure operations
- terminate sandboxes directly by ID instead of connecting first

## Why

Beam JS 1.0.17 adds a cross-process prepared-stub fast path with image-aware cache keys. Beam's command endpoint already retries while a newly created sandbox becomes ready, so awaiting a second connect during `create()` adds latency without improving correctness.

Native filesystem and port-exposure endpoints do not have that server-side startup retry. Their first use now awaits one deduplicated readiness connection. A successful command marks the instance ready, preserving the zero-extra-RTT command path.

Version 1.0.17 removes the ambiguous `download`/`downloadFile` aliases that triggered a supply-chain heuristic while preserving native reads through `readBytes`/`readText`.

## Validation

- one commit over current upstream `main`
- frozen lockfile install passed
- `@computesdk/beam` typecheck, lint, and build passed
- 17/17 provider tests passed
- lockfile resolves the published `@beamcloud/beam-js@1.0.17` tarball and registry integrity
- Superagent Security Scan and Supply Chain Scan passed
- full ComputeSDK CI and integration matrix passed
- the same provider behavior previously completed 23/23 staging sandboxes across sequential, staggered, and burst lifecycles