### PR TITLE
Update Arker SDK for better compatibility

### DIFF
--- a/.changeset/arker-sdk-compat.md
+++ b/.changeset/arker-sdk-compat.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/arker": patch
+---
+
+Drop custom output decoding and background-run polling now handled by the Arker SDK; require @arker-ai/sdk ^0.9.0 and add a `platforms` option.

--- a/packages/arker/package.json
+++ b/packages/arker/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@arker-ai/sdk": "^0.8.3",
+    "@arker-ai/sdk": "^0.9.0",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/arker/src/index.ts
+++ b/packages/arker/src/index.ts
@@ -23,6 +23,8 @@ export interface ArkerConfig {
   region?: string;
   /** Golden source VM to fork on create(). Falls back to ARKER_SOURCE, then `ubuntu-small`. */
   source?: string;
+  /** Compute platforms to fork onto, e.g. `['graviton4']`. Falls back to ARKER_PLATFORMS (comma-separated). */
+  platforms?: string[];
 }
 
 const env = (key: string): string | undefined => {
@@ -42,38 +44,24 @@ function makeClient(config: ArkerConfig): Arker {
   });
 }
 
-const decoder = new TextDecoder();
-
 /** Single-quote a string for `sh -c`, escaping any embedded single quotes. */
 const singleQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
 
-/** Decode a run-status output field per its declared encoding. */
-const decodeOutput = (value: string, encoding: string): string =>
-  encoding === 'base64' ? Buffer.from(value, 'base64').toString('utf8') : value;
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * A run that outlives its synchronous window (default 30s) converts to a
- * background run; poll it to completion. The platform imposes no inner
- * timeout on the command itself, so an unbounded command is the caller's.
- */
-async function pollRunToCompletion(sandbox: VM, runId: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  let delayMs = 500;
-  for (;;) {
-    const run = await sandbox.getRun(runId);
-    if (run.state === 'completed') {
-      if (run.exit_code == null) throw new Error(`Arker run ${runId} completed without an exit code.`);
-      return {
-        stdout: decodeOutput(run.stdout, run.stdout_encoding),
-        stderr: decodeOutput(run.stderr, run.stderr_encoding),
-        exitCode: run.exit_code,
-      };
-    }
-    if (run.state === 'failed') throw new Error(`Arker run ${runId} failed: ${run.fail_reason ?? 'unknown reason'}`);
-    if (run.state === 'cancelled') throw new Error(`Arker run ${runId} was cancelled.`);
-    await sleep(delayMs);
-    delayMs = Math.min(delayMs * 2, 2000);
+/** Reject once `ms` elapses, so a caller's timeout is a real deadline. */
+async function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`Arker command timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer!);
+    // The losing run keeps going until its server-side kill bound; swallow its
+    // outcome so it cannot surface as an unhandled rejection.
+    promise.catch(() => {});
   }
 }
 
@@ -87,9 +75,16 @@ export const arker = defineProvider<VM, ArkerConfig>({
         const client = makeClient(config);
         const name = options?.name ?? null;
         
+        const platforms =
+          config.platforms ??
+          env('ARKER_PLATFORMS')?.split(',').map((p) => p.trim()).filter(Boolean);
+
         const vm = options?.snapshotId
           ? await client.fork({ sourceVmId: options.snapshotId, name })
-          : await client.fork(options?.templateId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE, { name });
+          : await client.fork(options?.templateId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE, {
+              name,
+              ...(platforms?.length ? { platforms } : {}),
+            });
 
         return { sandbox: vm, sandboxId: vm.id };
       },
@@ -145,27 +140,25 @@ export const arker = defineProvider<VM, ArkerConfig>({
         // a bare `nohup cd … && …` would run only `cd` under nohup.
         if (options?.background) fullCommand = `nohup sh -c ${singleQuote(fullCommand)} > /dev/null 2>&1 &`;
 
-        const runOptions: RunOptions = {};
-        if (options?.timeout) runOptions.timeout = options.timeout;
+        // `background: false` picks the SDK's synchronous overload, which polls a
+        // backgrounded run to completion itself and always yields CompletedRunResult.
+        const runOptions: RunOptions & { background?: false } = { background: false };
+        // ComputeSDK's timeout is milliseconds; Arker's is seconds (rounded up so a
+        // sub-second timeout stays non-zero — 0 means "no limit" to Arker).
+        if (options?.timeout) runOptions.timeout = Math.max(1, Math.ceil(options.timeout / 1000));
 
-        const result = await sandbox.run(fullCommand, runOptions);
-        if (result.type === 'completed') {
-          return {
-            stdout: decoder.decode(result.stdout),
-            stderr: decoder.decode(result.stderr),
-            exitCode: result.exitCode,
-            durationMs: Date.now() - startTime,
-          };
-        }
-        // The run outlived its synchronous window and converted to background.
-        // With an explicit timeout the window *was* the caller's deadline —
-        // cancel and report the timeout; otherwise poll to completion.
-        if (options?.timeout) {
-          await sandbox.cancelRun(result.runId).catch(() => {});
-          throw new Error(`Arker command timed out after ${options.timeout}ms and was cancelled (run ${result.runId}).`);
-        }
-        const polled = await pollRunToCompletion(sandbox, result.runId);
-        return { ...polled, durationMs: Date.now() - startTime };
+        const run = sandbox.run(fullCommand, runOptions);
+        // The run's `timeout` is a server-side kill bound, so an over-running command
+        // comes back as a completed run with a non-zero exit code rather than a
+        // rejection. RunCommandOptions.timeout is documented as a deadline, so reject
+        // once it passes; the kill bound above stops the command server-side.
+        const result = options?.timeout ? await withDeadline(run, options.timeout) : await run;
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          durationMs: Date.now() - startTime,
+        };
       },
 
       getInfo: async (sandbox: VM): Promise<SandboxInfo> => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
   packages/arker:
     dependencies:
       '@arker-ai/sdk':
-        specifier: ^0.8.3
-        version: 0.8.3(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+        specifier: ^0.9.0
+        version: 0.9.0(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2351,8 +2351,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@arker-ai/sdk@0.8.3':
-    resolution: {integrity: sha512-QZpfH3kWyozf/VdoXZzD+qX1O45ZiYMZQhy143jfgAnpfakPj9lrP94yxGvkD5cuISxRb26ZNbLeamsfES32kQ==}
+  '@arker-ai/sdk@0.9.0':
+    resolution: {integrity: sha512-fwtQmS4MQH7fvctM1jGtfGauVYsz8vS380oJmWKh+iEjWJUKyc9O18tujqHR/aljfusNCR1ILY3ZBKbJz5nsKg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -8463,6 +8463,10 @@ packages:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
@@ -9174,9 +9178,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@arker-ai/sdk@0.8.3(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+  '@arker-ai/sdk@0.9.0(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      tar: 7.5.22
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@computesdk/daytona': 1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@computesdk/e2b': 1.7.52
@@ -15708,7 +15713,7 @@ snapshots:
 
   pyodide@0.27.7(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16443,6 +16448,14 @@ snapshots:
       yallist: 4.0.0
 
   tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
The Arker SDK has taken over two things the provider was doing itself, so this
removes the local copies and lets the SDK own them.

**Output decoding.** A completed run now exposes `stdout`/`stderr` as decoded
strings, with the raw bytes on `stdoutBytes`/`stderrBytes`. The provider still
ran them through `TextDecoder.decode()`, which throws once that shape lands:

```
TypeError: The "list" argument must be an instance of SharedArrayBuffer,
ArrayBuffer or ArrayBufferView
```

Reproduced against a clean install of the published `@computesdk/arker@0.1.1`
against production — it affects every `runCommand`. Both streams are now passed
through unchanged.

**Background-run polling.** `VM.run()` already polls a run that outlives the
sync window through to completion, so the provider's `pollRunToCompletion`
helper is redundant; the synchronous overload always resolves to a
`CompletedRunResult`.

The dependency moves to `^0.9.0`, which is where both behaviours are available.
`^0.8.9` would not do: a caret on a 0.x version locks the minor, so it excludes
0.9.0.

**Timeout handling** (thanks @devin-ai-integration for catching this). Two
separate problems, both now fixed and covered above:

- `RunCommandOptions.timeout` is milliseconds, but Arker's `RunRequest.timeout`
  is *"maximum command runtime in seconds"* — so the value was being passed
  1000x too large. This predates the PR; it was masked because the old
  cancel-on-timeout path was doing the real enforcement.
- With that path removed, nothing rejected at the caller's deadline. A
  `withDeadline` race now rejects at `options.timeout`, and the corrected
  server-side kill bound stops the command rather than leaving it running.

Verified against production:

```
timeout 3000ms vs sleep 30    threw    3.0s  "Arker command timed out after 3000ms"
timeout 20000ms vs sleep 2    resolved 2.1s  exit=0
no timeout, quick cmd         resolved 0.1s  exit=0
```

Before the fix that first case resolved after 30.1s with `exit=0`.

Also adds an optional `platforms` config (with an `ARKER_PLATFORMS` env
fallback) to pin a fork to a compute platform.

Full verification: typecheck, build, 14/14 unit, 14/14 integration against
production.

### Notes for reviewers

- **Disclosure:** I work for Arker.
- **Snapshots via fork:** `create({ snapshotId })` branches an existing VM by
  id; `create({ templateId })` forks a golden by name.
- Happy to provide API credentials for the daily benchmarks once merged.
