### PR TITLE
Fix typo in Isorun readme

### DIFF
--- a/packages/isorun/README.md
+++ b/packages/isorun/README.md
@@ -59,7 +59,7 @@ await sandbox.destroy()
 The `isorun` SDK exposes a few capabilities that don't have slots in the standard ComputeSDK interface — fork (`sandbox.fork(n)`), hibernate/resume (`sandbox.hibernate()` / `sandbox.resume()`), and timeout reset (`sandbox.setTimeout(seconds)`). Reach the underlying instance via:
 
 ```typescript
-const native = sandbox.getInstance(sandbox) // returns the raw Sandbox
+const native = sandbox.getInstance() // returns the raw Sandbox
 await native.fork(4)
 await native.hibernate()
 ```

--- a/packages/isorun/README.md
+++ b/packages/isorun/README.md
@@ -59,7 +59,7 @@ await sandbox.destroy()
 The `isorun` SDK exposes a few capabilities that don't have slots in the standard ComputeSDK interface — fork (`sandbox.fork(n)`), hibernate/resume (`sandbox.hibernate()` / `sandbox.resume()`), and timeout reset (`sandbox.setTimeout(seconds)`). Reach the underlying instance via:
 
 ```typescript
-const native = compute.sandbox.getInstance(sandbox) // returns the raw Sandbox
+const native = sandbox.getInstance(sandbox) // returns the raw Sandbox
 await native.fork(4)
 await native.hibernate()
 ```


### PR DESCRIPTION
Minor change in the README for getting the raw `Sandbox`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->