### PR TITLE
feat: add Mosaic provider

### DIFF
--- a/.changeset/add-mosaic-provider.md
+++ b/.changeset/add-mosaic-provider.md
@@ -1,5 +1,5 @@
 ---
-'@computesdk/mosaic': minor
+'@computesdk/mosaic': patch
 ---
 
 Add the Mosaic sandbox provider for Firecracker-based command-execution environments.

--- a/.changeset/add-mosaic-provider.md
+++ b/.changeset/add-mosaic-provider.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/mosaic': minor
+---
+
+Add the Mosaic sandbox provider for Firecracker-based command-execution environments.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ npm install @computesdk/hopx             # HopX provider
 npm install @computesdk/isorun           # Isorun provider
 npm install @computesdk/lightning        # Lightning AI provider
 npm install @computesdk/modal            # Modal provider
+npm install @computesdk/mosaic           # Mosaic provider
 npm install @computesdk/northflank       # Northflank provider
 npm install @computesdk/runloop          # Runloop provider
 npm install @computesdk/sail             # Sail provider
@@ -322,6 +323,7 @@ See individual provider READMEs for details:
 - **[@computesdk/isorun](./packages/isorun)** - Code execution with snapshot support
 - **[@computesdk/lightning](./packages/lightning)** - Lightning AI cloud sandboxes for command execution and filesystem access
 - **[@computesdk/modal](./packages/modal)** - GPU computing, ML inference
+- **[@computesdk/mosaic](./packages/mosaic)** - Firecracker-based sandbox environments
 - **[@computesdk/northflank](./packages/northflank)** - Cloud sandboxes with preview URLs
 - **[@computesdk/runloop](./packages/runloop)** - Code execution, automation
 - **[@computesdk/sandbox0](./packages/sandbox0)** - Fast persistent sandboxes with native filesystem access

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,7 @@
   * [Lelantos](providers/lelantos.md)
   * [Lightning](providers/lightning.md)
   * [Modal](providers/modal.md)
+  * [Mosaic](providers/mosaic.md)
   * [Namespace](providers/namespace.md)
   * [Northflank](providers/northflank.md)
   * [OpenComputer](providers/opencomputer.md)

--- a/docs/providers/mosaic.md
+++ b/docs/providers/mosaic.md
@@ -1,0 +1,72 @@
+---
+description: >-
+  Mosaic provider for ComputeSDK - Firecracker-based sandbox environments with command execution.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# Mosaic
+
+Mosaic provides Firecracker-based sandbox environments with command execution and explicit resource sizing.
+
+## Installation and setup
+
+```bash
+npm install computesdk @computesdk/mosaic
+```
+
+Set the API endpoint and bearer token:
+
+```bash
+export MOSAIC_API_URL=https://your-mosaic-api.example.com
+export MOSAIC_API_TOKEN=your_mosaic_token
+```
+
+## Usage
+
+```typescript
+import { compute } from 'computesdk';
+import { mosaic } from '@computesdk/mosaic';
+
+compute.setConfig({
+  provider: mosaic({
+    baseUrl: process.env.MOSAIC_API_URL,
+    apiKey: process.env.MOSAIC_API_TOKEN,
+  }),
+});
+
+const sandbox = await compute.sandbox.create({
+  templateId: 'node-20',
+  memoryMb: 4096,
+  vcpus: 2,
+});
+
+const result = await sandbox.runCommand('node --version');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+## Configuration options
+
+The provider accepts `baseUrl`, `apiKey`, `template`, `memoryMb`, `vcpu`, and `requestTimeoutMs`. If `baseUrl` or `apiKey` is omitted, the provider reads `MOSAIC_API_URL` or `MOSAIC_API_TOKEN`.
+
+## Supported operations
+
+`create`, `getById`, `list`, `destroy`, `runCommand`, and `getInfo` are supported. Preview URLs and the ComputeSDK filesystem helpers are not currently implemented; use `runCommand` for file operations.

--- a/packages/mosaic/README.md
+++ b/packages/mosaic/README.md
@@ -1,0 +1,64 @@
+# @computesdk/mosaic
+
+Mosaic provider for ComputeSDK. Mosaic provides Firecracker-based sandbox environments with command execution and lifecycle management.
+
+## Installation
+
+```bash
+npm install computesdk @computesdk/mosaic
+```
+
+## Quick start
+
+```typescript
+import { compute } from 'computesdk';
+import { mosaic } from '@computesdk/mosaic';
+
+compute.setConfig({
+  provider: mosaic({
+    baseUrl: process.env.MOSAIC_API_URL,
+    apiKey: process.env.MOSAIC_API_TOKEN,
+  }),
+});
+
+const sandbox = await compute.sandbox.create({
+  templateId: 'node-20',
+  memoryMb: 4096,
+  vcpus: 2,
+});
+
+const result = await sandbox.runCommand('node --version');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+The provider also reads `MOSAIC_API_URL` and `MOSAIC_API_TOKEN` when those values are omitted from the configuration. `baseUrl` should point to a Mosaic API deployment, and `apiKey` is sent as a bearer token.
+
+## Configuration
+
+```typescript
+interface MosaicConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  template?: string;
+  memoryMb?: number;
+  vcpu?: number;
+  requestTimeoutMs?: number;
+}
+```
+
+Per-sandbox `templateId`, `runtime`, `memoryMb`, `memoryMiB`, `vcpus`, and `cpus` options override the provider defaults.
+
+## Supported operations
+
+| Method | Supported | Notes |
+|---|---|---|
+| `create` | ✅ | Creates a Mosaic sandbox with template and resource overrides. |
+| `getById` | ✅ | Returns `null` when the sandbox is not found. |
+| `list` | ✅ | Lists sandboxes visible to the API token. |
+| `destroy` | ✅ | Idempotent for missing sandboxes. |
+| `runCommand` | ✅ | Supports working directory, environment, timeout, and background execution. |
+| `getInfo` | ✅ | Returns lifecycle state and resource metadata. |
+| `getUrl` | ❌ | Preview URL support is not currently implemented. |
+| `filesystem` | ❌ | Use `runCommand` for file operations. |

--- a/packages/mosaic/package.json
+++ b/packages/mosaic/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@computesdk/mosaic",
+  "version": "0.1.0",
+  "description": "Mosaic provider for ComputeSDK - Firecracker-based sandbox environments",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "mosaic",
+    "sandbox",
+    "firecracker",
+    "code-execution",
+    "compute",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/mosaic"
+  },
+  "homepage": "https://www.mosaicos.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/mosaic/src/__tests__/index.test.ts
+++ b/packages/mosaic/src/__tests__/index.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { compute } from 'computesdk';
+import { mosaic } from '../index.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('Mosaic ComputeSDK provider', () => {
+  it('measures the public ComputeSDK create and runCommand path', async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({
+        url,
+        method: init?.method || 'GET',
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (url.endsWith('/v1/sandboxes') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 'sbx-1', state: 'running', tti_ms: 11 }));
+      }
+      if (url.endsWith('/v1/sandboxes/sbx-1/exec')) {
+        return new Response(JSON.stringify({ stdout: 'v20.11.0\n', stderr: '', exit_code: 0, tti_ms: 18 }));
+      }
+      if (url.endsWith('/v1/sandboxes/sbx-1') && init?.method === 'DELETE') {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    const sdk = compute({
+      provider: mosaic({ baseUrl: 'https://sandbox.example.test', apiKey: 'secret' }),
+    });
+    const sandbox = await sdk.sandbox.create({ templateId: 'node-20', memoryMb: 4096, vcpus: 2 });
+    const result = await sandbox.runCommand('node -v');
+    await sandbox.destroy();
+
+    expect(result.stdout).toBe('v20.11.0\n');
+    expect(result.exitCode).toBe(0);
+    expect(calls.map((call) => [call.method, new URL(call.url).pathname])).toEqual([
+      ['POST', '/v1/sandboxes'],
+      ['POST', '/v1/sandboxes/sbx-1/exec'],
+      ['DELETE', '/v1/sandboxes/sbx-1'],
+    ]);
+    expect(calls[0].body).toEqual({
+      template: 'node-20', memory_mb: 4096, vcpu: 2, enable_ssh: false, network_enabled: false,
+    });
+  });
+
+  it('maps ComputeSDK runtime and resource options', async () => {
+    let body: Record<string, unknown> | undefined;
+    globalThis.fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ id: 'sbx-python', state: 'running', tti_ms: 1 }));
+    }) as typeof fetch;
+
+    const provider = mosaic({ baseUrl: 'https://sandbox.example.test' });
+    await provider.sandbox.create({ runtime: 'python', memoryMiB: 2048, cpus: 1 });
+
+    expect(body).toEqual({
+      template: 'python-3.11', memory_mb: 2048, vcpu: 1, enable_ssh: false, network_enabled: false,
+    });
+  });
+});

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -9,6 +9,7 @@ import type {
 
 const PROVIDER = 'mosaic' as const;
 const DEFAULT_TIMEOUT_MS = 120_000;
+const COMMAND_HTTP_TIMEOUT_BUFFER_MS = 5_000;
 
 export interface MosaicConfig {
   /** Public or private MAR REST endpoint. Falls back to MOSAIC_API_URL. */
@@ -244,6 +245,9 @@ export const mosaic = defineProvider<MosaicSandbox, MosaicConfig>({
 
       runCommand: async (sandbox, command, options): Promise<CommandResult> => {
         const started = performance.now();
+        const httpTimeoutMs = options?.timeout
+          ? options.timeout + COMMAND_HTTP_TIMEOUT_BUFFER_MS
+          : undefined;
         const result = await request<MarExecResponse>(
           sandbox.config,
           `/v1/sandboxes/${encodeURIComponent(sandbox.id)}/exec`,
@@ -254,7 +258,7 @@ export const mosaic = defineProvider<MosaicSandbox, MosaicConfig>({
               ...(options?.timeout ? { timeout_ms: options.timeout } : {}),
             }),
           },
-          options?.timeout,
+          httpTimeoutMs,
         );
         options?.onStdout?.(result.stdout);
         options?.onStderr?.(result.stderr);

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -1,0 +1,298 @@
+import { performance } from 'node:perf_hooks';
+import { defineProvider } from '@computesdk/provider';
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  RunCommandOptions,
+  SandboxInfo,
+} from '@computesdk/provider';
+
+const PROVIDER = 'mosaic' as const;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface MosaicConfig {
+  /** Public or private MAR REST endpoint. Falls back to MOSAIC_API_URL. */
+  baseUrl?: string;
+  /** Bearer token. Falls back to MOSAIC_API_TOKEN. */
+  apiKey?: string;
+  /** Default snapshot template. */
+  template?: string;
+  /** Default memory allocation in MiB. */
+  memoryMb?: number;
+  /** Default vCPU allocation. */
+  vcpu?: number;
+  /** HTTP request timeout. */
+  requestTimeoutMs?: number;
+}
+
+export interface MosaicSandbox {
+  id: string;
+  template: string;
+  memoryMb: number;
+  vcpu: number;
+  state: string;
+  createdAt: Date;
+  config: MosaicConfig;
+}
+
+interface MarCreateResponse {
+  id: string;
+  state: string;
+  tti_ms: number;
+}
+
+interface MarExecResponse {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  tti_ms: number;
+}
+
+interface MarVmInfo {
+  id: string;
+  template: string;
+  state: string;
+  memory_mb: number;
+  vcpu: number;
+}
+
+class MosaicApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MosaicApiError';
+  }
+}
+
+function env(name: string): string | undefined {
+  return typeof process === 'undefined' ? undefined : process.env?.[name];
+}
+
+function resolvedConfig(config: MosaicConfig): Required<MosaicConfig> {
+  const baseUrl = config.baseUrl || env('MOSAIC_API_URL') || '';
+  if (!baseUrl) {
+    throw new Error('Missing Mosaic API URL. Provide baseUrl or set MOSAIC_API_URL.');
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey: config.apiKey || env('MOSAIC_API_TOKEN') || '',
+    template: config.template || 'node-20',
+    memoryMb: config.memoryMb ?? 4096,
+    vcpu: config.vcpu ?? 2,
+    requestTimeoutMs: config.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+}
+
+async function request<T>(
+  config: MosaicConfig,
+  path: string,
+  init: RequestInit = {},
+  timeoutMs?: number,
+): Promise<T> {
+  const resolved = resolvedConfig(config);
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error('Mosaic API request timed out')),
+    timeoutMs ?? resolved.requestTimeoutMs,
+  );
+  const upstreamSignal = init.signal;
+  const abort = () => controller.abort(upstreamSignal?.reason);
+  upstreamSignal?.addEventListener('abort', abort, { once: true });
+  try {
+    const response = await fetch(`${resolved.baseUrl}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        'content-type': 'application/json',
+        ...(resolved.apiKey ? { authorization: `Bearer ${resolved.apiKey}` } : {}),
+        ...init.headers,
+      },
+    });
+    const body = await response.text();
+    if (!response.ok) {
+      let detail = body;
+      try {
+        detail = JSON.parse(body).error || body;
+      } catch {
+        // Keep the response body as the diagnostic.
+      }
+      throw new MosaicApiError(response.status, `Mosaic API request failed (${response.status}): ${detail}`);
+    }
+    return (body ? JSON.parse(body) : undefined) as T;
+  } finally {
+    clearTimeout(timer);
+    upstreamSignal?.removeEventListener('abort', abort);
+  }
+}
+
+function templateFor(config: Required<MosaicConfig>, options?: CreateSandboxOptions): string {
+  if (options?.templateId) return options.templateId;
+  if (options?.runtime === 'python') return 'python-3.11';
+  if (options?.runtime === 'node') return 'node-20';
+  return config.template;
+}
+
+function memoryFor(config: Required<MosaicConfig>, options?: CreateSandboxOptions): number {
+  return options?.memoryMb ?? options?.memoryMiB ?? options?.memMiB ?? options?.memory ?? config.memoryMb;
+}
+
+function vcpuFor(config: Required<MosaicConfig>, options?: CreateSandboxOptions): number {
+  return options?.vcpus ?? options?.cpus ?? options?.cpu ?? config.vcpu;
+}
+
+function fromInfo(config: MosaicConfig, info: MarVmInfo): MosaicSandbox {
+  return {
+    id: info.id,
+    template: info.template,
+    memoryMb: info.memory_mb,
+    vcpu: info.vcpu,
+    state: info.state,
+    createdAt: new Date(),
+    config,
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.split("'").join("'\"'\"'")}'`;
+}
+
+function commandWithOptions(command: string, options?: RunCommandOptions): string {
+  let result = command;
+  if (options?.cwd) result = `cd ${shellQuote(options.cwd)} && ${result}`;
+  if (options?.env && Object.keys(options.env).length > 0) {
+    const assignments = Object.entries(options.env).map(([key, value]) => {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+        throw new Error(`Invalid environment variable name: ${JSON.stringify(key)}`);
+      }
+      return `${key}=${shellQuote(value)}`;
+    });
+    result = `env ${assignments.join(' ')} ${result}`;
+  }
+  if (options?.background) result = `nohup sh -lc ${shellQuote(result)} >/dev/null 2>&1 &`;
+  return result;
+}
+
+export const mosaic = defineProvider<MosaicSandbox, MosaicConfig>({
+  name: PROVIDER,
+  methods: {
+    sandbox: {
+      create: async (config, options) => {
+        const resolved = resolvedConfig(config);
+        const template = templateFor(resolved, options);
+        const memoryMb = memoryFor(resolved, options);
+        const vcpu = vcpuFor(resolved, options);
+        const created = await request<MarCreateResponse>(
+          config,
+          '/v1/sandboxes',
+          {
+            method: 'POST',
+            // ComputeSDK TTI measures create -> command-over-vsock. SSH setup
+            // is benchmarked separately and must not contaminate this metric.
+            body: JSON.stringify({
+              template,
+              memory_mb: memoryMb,
+              vcpu,
+              enable_ssh: false,
+              network_enabled: false,
+            }),
+            signal: options?.signal,
+          },
+          options?.timeout,
+        );
+        const sandbox: MosaicSandbox = {
+          id: created.id,
+          template,
+          memoryMb,
+          vcpu,
+          state: created.state,
+          createdAt: new Date(),
+          config,
+        };
+        return { sandbox, sandboxId: sandbox.id };
+      },
+
+      getById: async (config, sandboxId) => {
+        try {
+          const info = await request<MarVmInfo>(config, `/v1/sandboxes/${encodeURIComponent(sandboxId)}`, {
+            method: 'GET',
+          });
+          return { sandbox: fromInfo(config, info), sandboxId };
+        } catch (error) {
+          if (error instanceof MosaicApiError && (error.status === 400 || error.status === 404)) return null;
+          throw error;
+        }
+      },
+
+      list: async (config) => {
+        const result = await request<{ sandboxes: MarVmInfo[] }>(config, '/v1/sandboxes', { method: 'GET' });
+        return result.sandboxes.map((info) => ({
+          sandbox: fromInfo(config, info),
+          sandboxId: info.id,
+        }));
+      },
+
+      destroy: async (config, sandboxId) => {
+        try {
+          await request<void>(config, `/v1/sandboxes/${encodeURIComponent(sandboxId)}`, { method: 'DELETE' });
+        } catch (error) {
+          if (error instanceof MosaicApiError && (error.status === 400 || error.status === 404)) return;
+          throw error;
+        }
+      },
+
+      runCommand: async (sandbox, command, options): Promise<CommandResult> => {
+        const started = performance.now();
+        const result = await request<MarExecResponse>(
+          sandbox.config,
+          `/v1/sandboxes/${encodeURIComponent(sandbox.id)}/exec`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              cmd: commandWithOptions(command, options),
+              ...(options?.timeout ? { timeout_ms: options.timeout } : {}),
+            }),
+          },
+          options?.timeout,
+        );
+        options?.onStdout?.(result.stdout);
+        options?.onStderr?.(result.stderr);
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exit_code,
+          durationMs: performance.now() - started,
+        };
+      },
+
+      getInfo: async (sandbox): Promise<SandboxInfo> => {
+        const info = await request<MarVmInfo>(
+          sandbox.config,
+          `/v1/sandboxes/${encodeURIComponent(sandbox.id)}`,
+          { method: 'GET' },
+        );
+        return {
+          id: info.id,
+          provider: PROVIDER,
+          status: info.state === 'running' ? 'running' : info.state === 'paused' ? 'stopped' : 'error',
+          createdAt: sandbox.createdAt,
+          timeout: resolvedConfig(sandbox.config).requestTimeoutMs,
+          metadata: {
+            template: info.template,
+            memoryMb: info.memory_mb,
+            vcpu: info.vcpu,
+          },
+        };
+      },
+
+      getUrl: async () => {
+        throw new Error('Mosaic preview URLs are not implemented yet.');
+      },
+
+      getInstance: (sandbox) => sandbox,
+    },
+  },
+});
+
+export default mosaic;

--- a/packages/mosaic/tsconfig.json
+++ b/packages/mosaic/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mosaic/tsup.config.ts
+++ b/packages/mosaic/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/mosaic/vitest.config.ts
+++ b/packages/mosaic/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
     dependencies:
       '@arker-ai/sdk':
         specifier: ^0.9.0
-        version: 0.9.0(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+        version: 0.9.0(@computesdk/daytona@1.7.32)(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -1432,6 +1432,40 @@ importers:
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
+  packages/mosaic:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
   packages/namespace:
     dependencies:
@@ -2995,12 +3029,14 @@ packages:
     engines: {node: '>=24.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@currentspace/http3-linux-x64-gnu@0.8.5':
     resolution: {integrity: sha512-pENtrt3EVG3O5ktGci2hoNJmIIOokuUVDYzhs/6teMcNFSUqWTHIm7VGfJajj67iUgRzWeRYjVv3/Y0lcinNqA==}
     engines: {node: '>=24.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@currentspace/http3@0.8.5':
     resolution: {integrity: sha512-Quxr3ul3raPslOi0xS3NGMx/TkjDiChafqJ1Td3qeyQXT5tqLpFSQDqA54Ewg0YemEMB5JInFWc9dsVCKW16dw==}
@@ -3944,155 +3980,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -4156,21 +4220,25 @@ packages:
     resolution: {integrity: sha512-tTFnCj24lftvF5q+14W8tIA4RosT2a8F1teqpo9A0DBeTrsqE9UIeJUdiStGtfTJfdEM3QAjAninMpQ95tZMOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@isorun/http-transport-linux-arm64-musl@0.8.8':
     resolution: {integrity: sha512-mCAe5LHr2h6zBf6gyNJwnFVIumeR9kHQvgAYGuWm3I9xd2eWUMN+90905i2tXnhShqVHOT3DnJbiWJmt8lKvsg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@isorun/http-transport-linux-x64-gnu@0.8.8':
     resolution: {integrity: sha512-13IyNfK47jXXix/AQB7lIvhYb0obDykdJR4cSey4vl+iptEVNqJLHr+DK13+VNmNeBKVzWemQJtF0Ui+RheAoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@isorun/http-transport-linux-x64-musl@0.8.8':
     resolution: {integrity: sha512-TJM8TaHr36YnNMl5JEzzeB4YQBYSHZNqCY2Ivd5KMo2FzPCdHJjjZ0Z6AQlldqst5X0C9khgfWEr+0CRNzmZsg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -4805,56 +4873,67 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -4891,24 +4970,28 @@ packages:
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@sailresearch/sdk-linux-arm64-musl@0.5.1':
     resolution: {integrity: sha512-dISiV2oDSEX8wLxG4vcK/nVKAhNOm+JbRKi3skdDZ3vg25k8RbIv0LkijD66zATEmL6cb650HRrWUwIVAaF+Eg==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@sailresearch/sdk-linux-x64-gnu@0.5.1':
     resolution: {integrity: sha512-eZKhrq3yDGaH/6L8JBsB94OKu80AgimyFybzpbzNr7r/jdqmBneqhq882sE4x7gWPiD45I2Kj/Sgn67ed1/Eug==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@sailresearch/sdk-linux-x64-musl@0.5.1':
     resolution: {integrity: sha512-4+iAMHK2v4T8+ZQ3YRnvtF6DW/DdWdIjWXMd4gu32Q5gkngp4njBs5Ccv7n2GqSdt2MU4b8RglNcfcGJIbN1yA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@sailresearch/sdk-win32-x64-msvc@0.5.1':
     resolution: {integrity: sha512-WHIgGmWVaag7SHMWEwbDUrxXAE/Wjm5nRyu7uT0ssktp9cIJ45trMJWjHeH87CgdKstw+b1ptRb1YTT/7jq3AQ==}
@@ -9264,12 +9347,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@arker-ai/sdk@0.9.0(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+  '@arker-ai/sdk@0.9.0(@computesdk/daytona@1.7.32)(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
       tar: 7.5.22
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
-      '@computesdk/daytona': 1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@computesdk/daytona': 1.7.32
       '@computesdk/e2b': 1.7.52
       '@computesdk/modal': 1.9.4
       computesdk: link:packages/computesdk
@@ -10259,10 +10342,10 @@ snapshots:
   '@computesdk/cmd@0.4.1':
     optional: true
 
-  '@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@computesdk/daytona@1.7.32':
     dependencies:
       '@computesdk/provider': 2.1.4
-      '@daytonaio/sdk': 0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@daytonaio/sdk': 0.192.0
       computesdk: 4.1.4
     transitivePeerDependencies:
       - aws-crt
@@ -10367,6 +10450,38 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  '@daytonaio/sdk@0.192.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1045.0
+      '@aws-sdk/lib-storage': 3.1045.0(@aws-sdk/client-s3@3.1045.0)
+      '@daytona/api-client': 0.192.0
+      '@daytona/toolbox-api-client': 0.192.0
+      '@iarna/toml': 2.2.5
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.217.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.217.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      axios: 1.18.1
+      busboy: 1.6.0
+      dotenv: 17.4.2
+      expand-tilde: 2.0.2
+      fast-glob: 3.3.3
+      form-data: 4.0.5
+      isomorphic-ws: 5.0.0
+      pathe: 2.0.3
+      shell-quote: 1.8.3
+      tar: 7.5.16
+    transitivePeerDependencies:
+      - aws-crt
+      - debug
+      - supports-color
+      - ws
+    optional: true
 
   '@daytonaio/sdk@0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
@@ -14834,6 +14949,9 @@ snapshots:
       node-gyp-build: 4.8.4
 
   isomorphic-timers-promises@1.0.1: {}
+
+  isomorphic-ws@5.0.0:
+    optional: true
 
   isomorphic-ws@5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:


### PR DESCRIPTION
## Summary
- add `@computesdk/mosaic` as an official direct provider package
- support Mosaic API endpoint/token configuration via `MOSAIC_API_URL` and `MOSAIC_API_TOKEN`
- support sandbox creation, lookup, listing, destruction, command execution, and metadata
- add unit tests, package README, provider docs, and changeset

## Validation
- package typecheck passed
- 2 provider unit tests passed
- package build and declaration generation passed

The provider intentionally does not modify ComputeSDK core. Preview URLs and filesystem helpers are reported as unsupported; command execution is available through `runCommand`.