### PR TITLE
superserve: update @superserve/sdk to ^0.8.3

### DIFF
--- a/.changeset/superserve-sdk-083.md
+++ b/.changeset/superserve-sdk-083.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/superserve": patch
+---
+
+Update @superserve/sdk to ^0.8.3

--- a/packages/superserve/package.json
+++ b/packages/superserve/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@superserve/sdk": "^0.7.6",
+    "@superserve/sdk": "^0.8.3",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },


### PR DESCRIPTION
Bumps the `@superserve/sdk` dependency range from `^0.7.6` to `^0.8.3`.