### PR TITLE
feat: add NeevCloud provider

### DIFF
--- a/.changeset/add-neevcloud-provider.md
+++ b/.changeset/add-neevcloud-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/neevcloud": patch
+---
+
+Add NeevCloud provider

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Isorun** | `ISORUN_API_KEY` | Code execution with snapshot support |
 | **Lightning** | `LIGHTNING_API_KEY` | Cloud sandboxes for command execution and filesystem access |
 | **Modal** | `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET` | GPU computing, ML inference |
+| **NeevCloud** | `NEEV_API_KEY`, `NEEV_ORG_ID`, `NEEV_PROJECT_ID` | Cloud sandboxes with command execution and preview URLs |
 | **Northflank** | `NORTHFLANK_TOKEN`, `NORTHFLANK_PROJECT_ID` | Cloud sandboxes with preview URLs |
 | **OpenComputer** | `OPENCOMPUTER_API_KEY` | Persistent cloud VMs with checkpoints and preview URLs |
 | **Runloop** | `RUNLOOP_API_KEY` | Code execution, automation |
@@ -324,6 +325,7 @@ See individual provider READMEs for details:
 - **[@computesdk/lightning](./packages/lightning)** - Lightning AI cloud sandboxes for command execution and filesystem access
 - **[@computesdk/modal](./packages/modal)** - GPU computing, ML inference
 - **[@computesdk/mosaic](./packages/mosaic)** - Firecracker-based sandbox environments
+- **[@computesdk/neevcloud](./packages/neevcloud)** - Secure cloud sandboxes with command execution, filesystem, and preview URLs
 - **[@computesdk/northflank](./packages/northflank)** - Cloud sandboxes with preview URLs
 - **[@computesdk/runloop](./packages/runloop)** - Code execution, automation
 - **[@computesdk/sandbox0](./packages/sandbox0)** - Fast persistent sandboxes with native filesystem access

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Lightning** | `LIGHTNING_API_KEY` | Cloud sandboxes for command execution and filesystem access |
 | **Modal** | `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET` | GPU computing, ML inference |
 | **Mosaic** | `MOSAIC_API_URL`, `MOSAIC_API_TOKEN` | Firecracker microVMs with preview URLs, snapshots, and container-image environments |
+| **NeevCloud** | `NEEV_API_KEY`, `NEEV_ORG_ID`, `NEEV_PROJECT_ID` | Cloud sandboxes with command execution and preview URLs |
 | **Northflank** | `NORTHFLANK_TOKEN`, `NORTHFLANK_PROJECT_ID` | Cloud sandboxes with preview URLs |
 | **OpenComputer** | `OPENCOMPUTER_API_KEY` | Persistent cloud VMs with checkpoints and preview URLs |
 | **Run Cloud** | `RUN_CLOUD_API_KEY` | Fast Firecracker microVM sandboxes with snapshots |
@@ -327,6 +328,7 @@ See individual provider READMEs for details:
 - **[@computesdk/lightning](./packages/lightning)** - Lightning AI cloud sandboxes for command execution and filesystem access
 - **[@computesdk/modal](./packages/modal)** - GPU computing, ML inference
 - **[@computesdk/mosaic](./packages/mosaic)** - Firecracker microVMs with preview URLs, snapshots, and container-image environments
+- **[@computesdk/neevcloud](./packages/neevcloud)** - Secure cloud sandboxes with command execution, filesystem, and preview URLs
 - **[@computesdk/northflank](./packages/northflank)** - Cloud sandboxes with preview URLs
 - **[@computesdk/run-cloud](./packages/run-cloud)** - Fast Firecracker microVM sandboxes with filesystem and snapshot support
 - **[@computesdk/runloop](./packages/runloop)** - Code execution, automation

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
   * [Modal](providers/modal.md)
   * [Mosaic](providers/mosaic.md)
   * [Namespace](providers/namespace.md)
+  * [NeevCloud](providers/neevcloud.md)
   * [Northflank](providers/northflank.md)
   * [OpenComputer](providers/opencomputer.md)
   * [Quilt](providers/quilt.md)

--- a/docs/providers/neevcloud.md
+++ b/docs/providers/neevcloud.md
@@ -1,0 +1,96 @@
+---
+description: >-
+  NeevCloud provider for ComputeSDK - run commands and manage files in secure
+  cloud sandboxes with preview URLs.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# NeevCloud
+
+[NeevCloud](https://neevcloud.com) provider for ComputeSDK - run commands and manage files in secure cloud sandboxes.
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/neevcloud
+```
+
+Add your NeevCloud credentials to a `.env` file:
+
+```bash
+NEEV_API_KEY=your_neev_api_key
+NEEV_ORG_ID=your_neev_org_id
+NEEV_PROJECT_ID=your_neev_project_id
+```
+
+## Usage
+
+```typescript
+import { neevcloud } from '@computesdk/neevcloud';
+
+const compute = neevcloud({
+  apiKey: process.env.NEEV_API_KEY,
+  orgId: process.env.NEEV_ORG_ID,
+  projectId: process.env.NEEV_PROJECT_ID,
+});
+
+// Create sandbox
+const sandbox = await compute.sandbox.create();
+
+// Run a command
+const result = await sandbox.runCommand('echo "Hello from NeevCloud!"');
+console.log(result.stdout); // "Hello from NeevCloud!"
+
+// Clean up
+await sandbox.destroy();
+```
+
+### Configuration Options
+
+```typescript
+interface NeevCloudConfig {
+  /** NeevCloud API key - if not provided, will use NEEV_API_KEY env var */
+  apiKey?: string;
+  /** Org the sandboxes belong to - if not provided, will use NEEV_ORG_ID env var */
+  orgId?: string;
+  /** Project the sandboxes belong to - if not provided, will use NEEV_PROJECT_ID env var */
+  projectId?: string;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+}
+```
+
+### Preview URLs
+
+Expose any port over a public HTTPS URL:
+
+```typescript
+await sandbox.runCommand('python3 -m http.server 3000', { background: true });
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+### Boot Source
+
+Start from a catalogue template, a raw OCI image, or the platform default (`templateId` and `image` are mutually exclusive):
+
+```typescript
+await compute.sandbox.create({ templateId: 'sb-ubuntu-24-04-minimal' });
+await compute.sandbox.create({ image: 'docker.io/library/python:3.12' });
+```

--- a/packages/neevcloud/README.md
+++ b/packages/neevcloud/README.md
@@ -1,0 +1,132 @@
+# @computesdk/neevcloud
+
+[NeevCloud](https://neevcloud.com) provider for [ComputeSDK](https://github.com/computesdk/computesdk) — run commands and manage files in secure cloud sandboxes.
+
+## Installation
+
+```bash
+npm install @computesdk/neevcloud
+```
+
+## Setup
+
+Get an API key from the NeevCloud console and note the org and project the sandboxes should live in, then set:
+
+```bash
+export NEEV_API_KEY=sk-nc-...
+export NEEV_ORG_ID=org-...
+export NEEV_PROJECT_ID=prj-...
+```
+
+## Quick Start
+
+```typescript
+import { neevcloud } from '@computesdk/neevcloud';
+
+const compute = neevcloud();
+const sandbox = await compute.sandbox.create();
+
+const res = await sandbox.runCommand('echo "Hello from NeevCloud!"');
+console.log(res.stdout); // "Hello from NeevCloud!"
+
+await sandbox.filesystem.writeFile('/app.txt', 'hi');
+console.log(await sandbox.filesystem.readFile('/app.txt')); // "hi"
+
+const url = await sandbox.getUrl({ port: 3000 });
+console.log(url); // https://3000-<id>.<region>.neevsandbox.app
+
+await sandbox.destroy();
+```
+
+## Configuration
+
+`neevcloud(config)` accepts `{ apiKey?, orgId?, projectId?, timeout? }`. Every field is optional and is read from the matching environment variable when omitted, so most callers can use `neevcloud()` with no arguments.
+
+```typescript
+interface NeevCloudConfig {
+  /** NeevCloud API key. Read from NEEV_API_KEY when omitted. */
+  apiKey?: string;
+  /** Org the sandboxes belong to. Read from NEEV_ORG_ID when omitted. */
+  orgId?: string;
+  /** Project the sandboxes belong to. Read from NEEV_PROJECT_ID when omitted. */
+  projectId?: string;
+  /** Request timeout in milliseconds. */
+  timeout?: number;
+}
+```
+
+## Features
+
+- **Command execution** — run shell commands, buffered or streamed, foreground or background.
+- **Filesystem access** — read, write, list, stat, and remove files rooted at the sandbox workspace.
+- **Preview URLs** — expose any port over a public HTTPS URL with `getUrl({ port })`.
+- **Flexible boot** — start from a catalogue template, a raw OCI image, or the platform default.
+
+## API Reference
+
+### Command Execution
+
+```typescript
+// Buffered — resolves with the full result
+const res = await sandbox.runCommand('ls -la');
+console.log(res.stdout, res.exitCode, res.durationMs);
+
+// Streamed — pass output callbacks to receive chunks as they arrive
+await sandbox.runCommand('npm install', {
+  onStdout: (chunk) => process.stdout.write(chunk),
+  onStderr: (chunk) => process.stderr.write(chunk),
+});
+
+// Background — returns immediately, leaves the process running
+await sandbox.runCommand('python3 -m http.server 3000', { background: true });
+```
+
+The command runs through a shell, so pipes and redirection work. A `cwd` is resolved relative to the workspace root.
+
+### Filesystem Operations
+
+```typescript
+await sandbox.filesystem.writeFile('/data/input.csv', csv);
+const content = await sandbox.filesystem.readFile('/data/input.csv');
+await sandbox.filesystem.mkdir('/data/output');
+const entries = await sandbox.filesystem.readdir('/data');
+const present = await sandbox.filesystem.exists('/data/input.csv');
+await sandbox.filesystem.remove('/data/input.csv');
+```
+
+The filesystem is rooted at the sandbox workspace and takes workspace-relative paths; a leading `/` is treated as relative to the workspace root, so `filesystem` calls for `/app.txt` and `app.txt` hit the same file. Shell commands also run from the workspace root, so **relative paths address the same file across `runCommand` and `filesystem`**. Note that a leading-slash path inside a `runCommand` string is a real absolute path (e.g. `cat /app.txt` looks at the filesystem root, not the workspace) — use a relative path, or a `/workspace/...` prefix, to reach a workspace file from a command.
+
+### Preview URLs
+
+```typescript
+// Start a server, then expose its port over public HTTPS
+await sandbox.runCommand('python3 -m http.server 3000', { background: true });
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+### Sandbox Management
+
+```typescript
+const sandbox = await compute.sandbox.create({ templateId: 'sb-ubuntu-24-04-minimal' });
+const sandbox = await compute.sandbox.create({ image: 'docker.io/library/python:3.12' });
+
+const info = await sandbox.getInfo(); // { id, provider, status, createdAt, timeout }
+const all = await compute.sandbox.list();
+const one = await compute.sandbox.getById(id); // null if not found
+await sandbox.destroy();
+```
+
+`templateId` and `image` are mutually exclusive; omit both for the platform default.
+
+## Beyond the ComputeSDK Surface
+
+For capabilities outside the ComputeSDK contract — interactive PTYs, long-running process supervision, snapshots, and fork/restore — reach the underlying [`@neevcloud/sdk`](https://github.com/NeevCloudAI/neev-sdk-js) handle:
+
+```typescript
+const native = sandbox.getInstance();
+const snapshot = await native.snapshot();
+```
+
+## License
+
+MIT

--- a/packages/neevcloud/package.json
+++ b/packages/neevcloud/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@computesdk/neevcloud",
+  "version": "1.0.0",
+  "description": "NeevCloud provider for ComputeSDK - secure cloud sandboxes with command execution, filesystem access, and preview URLs",
+  "author": "NeevCloud",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "provider",
+    "sandbox",
+    "code-execution",
+    "cloud",
+    "compute",
+    "neevcloud",
+    "neev"
+  ],
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*",
+    "@neevcloud/sdk": "^0.7.0-beta"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/neevcloud"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  }
+}

--- a/packages/neevcloud/src/__tests__/crud.test.ts
+++ b/packages/neevcloud/src/__tests__/crud.test.ts
@@ -1,0 +1,8 @@
+import { runProviderCrudTest } from '@computesdk/test-utils';
+import { neevcloud } from '../index';
+
+runProviderCrudTest({
+  name: 'neevcloud',
+  provider: neevcloud({}), // Uses NEEV_API_KEY from env
+  skipIntegration: !process.env.NEEV_API_KEY,
+});

--- a/packages/neevcloud/src/__tests__/index.test.ts
+++ b/packages/neevcloud/src/__tests__/index.test.ts
@@ -1,0 +1,10 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { neevcloud } from '../index';
+
+runProviderTestSuite({
+  name: 'neevcloud',
+  provider: neevcloud({}),
+  supportsFilesystem: true, // NeevCloud supports filesystem operations
+  skipIntegration: !process.env.NEEV_API_KEY,
+  ports: [3000, 8080], // Enable getUrl tests
+});

--- a/packages/neevcloud/src/index.ts
+++ b/packages/neevcloud/src/index.ts
@@ -1,0 +1,186 @@
+import { type SandboxMethods, defineProvider } from "@computesdk/provider";
+import {
+  Neev,
+  type FileEntry as NeevFileEntry,
+  NotFoundError,
+  type Sandbox,
+  type SandboxPhase,
+} from "@neevcloud/sdk";
+import type { FileEntry } from "computesdk";
+
+// Provider config. Every field is optional; the Neev client reads the matching NEEV_* env
+// var when a field is omitted.
+export interface NeevCloudConfig {
+  /** NeevCloud API key. Read from NEEV_API_KEY when omitted. */
+  apiKey?: string;
+  /** Org the sandboxes belong to. Read from NEEV_ORG_ID when omitted. */
+  orgId?: string;
+  /** Project the sandboxes belong to. Read from NEEV_PROJECT_ID when omitted. */
+  projectId?: string;
+  /** Request timeout in milliseconds. */
+  timeout?: number;
+}
+
+// Shared object used to key the client cache when the provider is created without a config.
+const DEFAULT_CONFIG: NeevCloudConfig = {};
+const clients = new WeakMap<NeevCloudConfig, Neev>();
+
+// Builds (once per config object) the Neev client the lifecycle methods talk to.
+function clientFor(config: NeevCloudConfig = DEFAULT_CONFIG): Neev {
+  let client = clients.get(config);
+  if (!client) {
+    client = new Neev({
+      apiKey: config.apiKey,
+      orgId: config.orgId,
+      projectId: config.projectId,
+      timeoutMs: config.timeout,
+    });
+    clients.set(config, client);
+  }
+  return client;
+}
+
+// Neev files.* take workspace-relative paths and reject absolute ones; strip a leading
+// slash so ComputeSDK's absolute paths resolve under the sandbox workspace root.
+function toWorkspacePath(path: string): string {
+  return path.replace(/^\/+/, "");
+}
+
+// Neev distinguishes symlinks; ComputeSDK's FileEntry only has file|directory, so a
+// symlink is surfaced as a file.
+function mapFileEntry(entry: NeevFileEntry): FileEntry {
+  return {
+    name: entry.name,
+    type: entry.type === "directory" ? "directory" : "file",
+    size: entry.size,
+    modified: new Date(entry.modifiedTime),
+  };
+}
+
+// Maps the SDK phase onto ComputeSDK's 3-state status: Paused is stopped, RestoreFailed is
+// a terminal failure, and every other phase (Ready, Pending, NotReady, Unknown) is running.
+function phaseToStatus(phase: SandboxPhase): "running" | "stopped" | "error" {
+  switch (phase) {
+    case "Paused":
+      return "stopped";
+    case "RestoreFailed":
+      return "error";
+    default:
+      return "running";
+  }
+}
+
+const LIST_PAGE_SIZE = 100;
+
+const sandboxMethods: SandboxMethods<Sandbox, NeevCloudConfig> = {
+  // Create a sandbox and wait until Ready. Boot from a raw OCI image or a catalogue template
+  // (mutually exclusive; image wins, else templateId, else platform default). Name is left
+  // unset so the server generates one.
+  create: async (config, options) => {
+    const source = options?.image
+      ? { image: options.image }
+      : { sandbox_template_id: options?.templateId };
+    const sandbox = await clientFor(config).sandboxes.create(source);
+    await sandbox.waitUntilReady();
+    return { sandbox, sandboxId: sandbox.id };
+  },
+
+  // Look a sandbox up; a missing id is not an error to ComputeSDK — return null.
+  getById: async (config, sandboxId) => {
+    try {
+      const sandbox = await clientFor(config).sandboxes.get(sandboxId);
+      return { sandbox, sandboxId: sandbox.id };
+    } catch (err) {
+      if (err instanceof NotFoundError) return null;
+      throw err;
+    }
+  },
+
+  // Page through every sandbox; ComputeSDK's list returns the full set. Driven by the
+  // reported total, with an empty-page guard so it always terminates.
+  list: async (config) => {
+    const client = clientFor(config);
+    const out: Array<{ sandbox: Sandbox; sandboxId: string }> = [];
+    for (let page = 1; ; page++) {
+      const res = await client.sandboxes.list({ page, limit: LIST_PAGE_SIZE });
+      for (const sandbox of res.items) out.push({ sandbox, sandboxId: sandbox.id });
+      if (res.items.length === 0 || out.length >= res.total) break;
+    }
+    return out;
+  },
+
+  destroy: async (config, sandboxId) => {
+    await clientFor(config).sandboxes.delete(sandboxId);
+  },
+
+  // Run a command. ComputeSDK passes a shell string, so wrap it in `sh -c`; Neev exec runs
+  // a program. Buffered by default; stream only when output callbacks are supplied.
+  runCommand: async (sandbox, command, options) => {
+    const argv = ["sh", "-c", command];
+    // sandboxd requires a workspace-relative cwd, like file paths.
+    const cwd = options?.cwd === undefined ? undefined : toWorkspacePath(options.cwd);
+    const started = Date.now();
+    if (options?.background) {
+      await sandbox.processes.start(argv, { cwd, env: options.env });
+      return { stdout: "", stderr: "", exitCode: 0, durationMs: Date.now() - started };
+    }
+    const execOptions = { cwd, env: options?.env, timeoutMs: options?.timeout };
+    if (options?.onStdout || options?.onStderr) {
+      let stdout = "";
+      let stderr = "";
+      let exitCode = 0;
+      for await (const event of sandbox.execStream(argv, execOptions)) {
+        if (event.type === "stdout") {
+          stdout += event.data;
+          options.onStdout?.(event.data);
+        } else if (event.type === "stderr") {
+          stderr += event.data;
+          options.onStderr?.(event.data);
+        } else if (event.type === "exit") {
+          exitCode = event.exitCode;
+        }
+      }
+      return { stdout, stderr, exitCode, durationMs: Date.now() - started };
+    }
+    const result = await sandbox.exec(argv, execOptions);
+    return { ...result, durationMs: Date.now() - started };
+  },
+
+  // Neev has no per-sandbox timeout, so report 0.
+  getInfo: async (sandbox) => ({
+    id: sandbox.id,
+    provider: "neevcloud",
+    status: phaseToStatus(sandbox.phase),
+    createdAt: new Date(sandbox.data.created_at),
+    timeout: 0,
+  }),
+
+  getUrl: async (sandbox, options) => sandbox.getUrl({ port: options.port }),
+
+  getInstance: (sandbox) => sandbox,
+
+  // Workspace-rooted filesystem over the native sandboxd file endpoints. The `runCommand`
+  // helper is unused because Neev has real file APIs.
+  filesystem: {
+    readFile: (sandbox, path) => sandbox.files.readText(toWorkspacePath(path)),
+    writeFile: async (sandbox, path, content) => {
+      await sandbox.files.write(toWorkspacePath(path), content);
+    },
+    mkdir: async (sandbox, path) => {
+      await sandbox.files.mkdir(toWorkspacePath(path));
+    },
+    readdir: async (sandbox, path) =>
+      (await sandbox.files.list(toWorkspacePath(path))).map(mapFileEntry),
+    exists: (sandbox, path) => sandbox.files.exists(toWorkspacePath(path)),
+    remove: async (sandbox, path) => {
+      await sandbox.files.remove(toWorkspacePath(path));
+    },
+  },
+};
+
+// ComputeSDK provider for NeevCloud sandboxes.
+// Usage: `createCompute({ defaultProvider: neevcloud({ apiKey }) })`.
+export const neevcloud = defineProvider<Sandbox, NeevCloudConfig>({
+  name: "neevcloud",
+  methods: { sandbox: sandboxMethods },
+});

--- a/packages/neevcloud/tsconfig.json
+++ b/packages/neevcloud/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/neevcloud/tsup.config.ts
+++ b/packages/neevcloud/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/neevcloud/vitest.config.ts
+++ b/packages/neevcloud/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,6 +1504,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/neevcloud:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@neevcloud/sdk':
+        specifier: ^0.7.0-beta
+        version: 0.7.0-beta(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/northflank:
     dependencies:
       '@computesdk/provider':
@@ -4314,6 +4351,15 @@ packages:
   '@mongodb-js/zstd@7.0.0':
     resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
     engines: {node: '>= 20.19.0'}
+
+  '@neevcloud/sdk@0.7.0-beta':
+    resolution: {integrity: sha512-AIYO6s+wI+s5SvSRhAPZ2uDSnTC03oE4h7b1TvSuSdWRBH4+oxnnTPtvh7+q665RZOqFVEFdwqDkadEvqOstZQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ws: ^8
+    peerDependenciesMeta:
+      ws:
+        optional: true
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -7715,8 +7761,14 @@ packages:
   openapi-fetch@0.14.1:
     resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   openid-client@6.8.4:
     resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
@@ -11412,6 +11464,12 @@ snapshots:
       node-addon-api: 8.6.0
       prebuild-install: 7.1.3
     optional: true
+
+  '@neevcloud/sdk@0.7.0-beta(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      openapi-fetch: 0.17.0
+    optionalDependencies:
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@nodable/entities@2.1.0': {}
 
@@ -15594,7 +15652,13 @@ snapshots:
     dependencies:
       openapi-typescript-helpers: 0.0.15
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
   openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript-helpers@0.1.0: {}
 
   openid-client@6.8.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,6 +1504,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/neevcloud:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@neevcloud/sdk':
+        specifier: ^0.7.0-beta
+        version: 0.7.0-beta(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.5
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/northflank:
     dependencies:
       '@computesdk/provider':
@@ -4351,6 +4388,15 @@ packages:
   '@mongodb-js/zstd@7.0.0':
     resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
     engines: {node: '>= 20.19.0'}
+
+  '@neevcloud/sdk@0.7.0-beta':
+    resolution: {integrity: sha512-AIYO6s+wI+s5SvSRhAPZ2uDSnTC03oE4h7b1TvSuSdWRBH4+oxnnTPtvh7+q665RZOqFVEFdwqDkadEvqOstZQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ws: ^8
+    peerDependenciesMeta:
+      ws:
+        optional: true
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -7759,8 +7805,14 @@ packages:
   openapi-fetch@0.14.1:
     resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   openid-client@6.8.4:
     resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
@@ -11456,6 +11508,12 @@ snapshots:
       node-addon-api: 8.6.0
       prebuild-install: 7.1.3
     optional: true
+
+  '@neevcloud/sdk@0.7.0-beta(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      openapi-fetch: 0.17.0
+    optionalDependencies:
+      ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@nodable/entities@2.1.0': {}
 
@@ -15650,7 +15708,13 @@ snapshots:
     dependencies:
       openapi-typescript-helpers: 0.0.15
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
   openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript-helpers@0.1.0: {}
 
   openid-client@6.8.4:
     dependencies:


### PR DESCRIPTION
## Summary

- add `@computesdk/neevcloud` using the official `@neevcloud/sdk`
- support sandbox lifecycle (create, getById, list, destroy), shell command execution (buffered, streamed, and background), a workspace-rooted filesystem, and preview URLs via `getUrl`
- boot from a catalogue template, a raw OCI image, or the platform default (mutually exclusive)
- read `NEEV_API_KEY` / `NEEV_ORG_ID` / `NEEV_PROJECT_ID` from the environment when not passed explicitly
- add the shared provider contract suite, package README, provider docs, and a changeset

## Verification

- `pnpm --filter @computesdk/neevcloud typecheck`
- `pnpm --filter @computesdk/neevcloud lint`
- `pnpm --filter @computesdk/neevcloud test` (16 tests)
- `pnpm --filter @computesdk/neevcloud build`
- live shared provider suite: 16/16 cases passed against a NeevCloud project, including create, exec, filesystem, and a preview URL returning 200

The provider does not modify ComputeSDK core or other packages.