### PR TITLE
feat: core SDK improvements from hpc-sandbox-benchmarks audit

### DIFF
--- a/.changeset/benchmark-audit-core-fixes.md
+++ b/.changeset/benchmark-audit-core-fixes.md
@@ -1,0 +1,12 @@
+---
+"computesdk": patch
+"@computesdk/provider": patch
+"@computesdk/e2b": patch
+"@computesdk/daytona": patch
+---
+
+Core SDK improvements from the `hpc-sandbox-benchmarks` provider audit:
+
+- Export `DirectProvider` from `computesdk`.
+- Add optional `user` to `RunCommandOptions` and pass it through in `@computesdk/e2b` using the native `commands.run` options (`cwd`, `envs`, `background`, `timeoutMs`) instead of shell-wrapping.
+- Add optional `target` to `@computesdk/daytona` `DaytonaConfig` and use it when constructing the Daytona client for create, get, list, destroy, snapshot, and template calls.

--- a/packages/computesdk/src/index.ts
+++ b/packages/computesdk/src/index.ts
@@ -56,4 +56,4 @@ export type {
 // Works as both callable `compute({...}).sandbox.create()` and singleton
 // `compute.setConfig({...}); compute.sandbox.create()`.
 export { compute } from './compute';
-export type { CallableCompute, ExplicitComputeConfig } from './compute';
+export type { CallableCompute, DirectProvider, ExplicitComputeConfig } from './compute';

--- a/packages/computesdk/src/types/universal-sandbox.ts
+++ b/packages/computesdk/src/types/universal-sandbox.ts
@@ -60,6 +60,8 @@ export interface RunCommandOptions {
   env?: Record<string, string>;
   timeout?: number;
   background?: boolean;
+  /** User to run the command as, when the provider supports it. */
+  user?: string;
   /**
    * Callback for streamed stdout chunks when supported by the provider.
    */

--- a/packages/daytona/src/index.ts
+++ b/packages/daytona/src/index.ts
@@ -13,6 +13,8 @@ import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCo
 export interface DaytonaConfig {
   /** Daytona API key - if not provided, will fallback to DAYTONA_API_KEY environment variable */
   apiKey?: string;
+  /** Target region/location for Daytona sandboxes (e.g. 'us', 'eu'). Falls back to DAYTONA_TARGET. */
+  target?: string;
   /** Default runtime environment (e.g. 'python', 'node') */
   runtime?: string;
   /** Execution timeout in milliseconds */
@@ -22,27 +24,38 @@ export interface DaytonaConfig {
 /**
  * Create a Daytona provider instance using the factory pattern
  */
+function getDaytonaClient(config: DaytonaConfig, targetOverride?: string): Daytona {
+  const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.DAYTONA_API_KEY) || '';
+
+  if (!apiKey) {
+    throw new Error(
+      `Missing Daytona API key. Provide 'apiKey' in config or set DAYTONA_API_KEY environment variable. Get your API key from https://daytona.io/`
+    );
+  }
+
+  const target = targetOverride ?? config.target ?? (typeof process !== 'undefined' && process.env?.DAYTONA_TARGET);
+  const clientConfig: any = { apiKey };
+  if (target) {
+    clientConfig.target = target;
+  }
+
+  return new Daytona(clientConfig);
+}
+
 export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
   name: 'daytona',
   methods: {
     sandbox: {
       create: async (config: DaytonaConfig, options?: CreateSandboxOptions) => {
-        const apiKey = config.apiKey || (typeof process !== 'undefined' && process.env?.DAYTONA_API_KEY) || '';
-
-        if (!apiKey) {
-          throw new Error(
-            `Missing Daytona API key. Provide 'apiKey' in config or set DAYTONA_API_KEY environment variable. Get your API key from https://daytona.io/`
-          );
-        }
-
         const runtime = (options as any)?.runtime || config.runtime || 'node';
         const timeout = options?.timeout ?? config.timeout;
 
         try {
-          const daytona = new Daytona({ apiKey: apiKey });
+          const daytona = getDaytonaClient(config, (options as any)?.target);
 
           const {
             timeout: _timeout,
+            target: _target,
             envs,
             name,
             metadata,
@@ -102,9 +115,8 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
       },
 
       getById: async (config: DaytonaConfig, sandboxId: string) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         try {
-          const daytona = new Daytona({ apiKey: apiKey });
+          const daytona = getDaytonaClient(config);
           const session = await daytona.get(sandboxId);
           return { sandbox: session, sandboxId };
         } catch (error) {
@@ -116,9 +128,8 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
       },
 
       list: async (config: DaytonaConfig) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         try {
-          const daytona = new Daytona({ apiKey: apiKey });
+          const daytona = getDaytonaClient(config);
           // daytona.list() returns an auto-paginating async iterator (offset-based
           // /api/sandbox/paginated pagination was retired in @daytonaio/sdk v0.180.0).
           const sandboxes = [];
@@ -132,9 +143,8 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
       },
 
       destroy: async (config: DaytonaConfig, sandboxId: string) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
         try {
-          const daytona = new Daytona({ apiKey: apiKey });
+          const daytona = getDaytonaClient(config);
           const sandbox = await daytona.get(sandboxId);
           await sandbox.delete();
         } catch (error) {
@@ -245,8 +255,7 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
 
     snapshot: {
       create: async (config: DaytonaConfig, sandboxId: string, options?: { name?: string }) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-        const daytona = new Daytona({ apiKey: apiKey });
+        const daytona = getDaytonaClient(config);
         try {
           const snapshot = await (daytona as any).snapshot.create({
             workspaceId: sandboxId,
@@ -258,13 +267,11 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
         }
       },
       list: async (config: DaytonaConfig) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-        const daytona = new Daytona({ apiKey: apiKey });
+        const daytona = getDaytonaClient(config);
         try { return await (daytona as any).snapshot.list(); } catch { return []; }
       },
       delete: async (config: DaytonaConfig, snapshotId: string) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-        const daytona = new Daytona({ apiKey: apiKey });
+        const daytona = getDaytonaClient(config);
         try { await (daytona as any).snapshot.delete(snapshotId); } catch { /* ignore */ }
       }
     },
@@ -274,13 +281,11 @@ export const daytona = defineProvider<DaytonaSandbox, DaytonaConfig>({
         throw new Error('To create a template in Daytona, create a snapshot from a running sandbox using snapshot.create()');
       },
       list: async (config: DaytonaConfig) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-        const daytona = new Daytona({ apiKey: apiKey });
+        const daytona = getDaytonaClient(config);
         try { return await (daytona as any).snapshot.list(); } catch { return []; }
       },
       delete: async (config: DaytonaConfig, templateId: string) => {
-        const apiKey = config.apiKey || process.env.DAYTONA_API_KEY!;
-        const daytona = new Daytona({ apiKey: apiKey });
+        const daytona = getDaytonaClient(config);
         try { await (daytona as any).snapshot.delete(templateId); } catch { /* ignore */ }
       }
     }

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { Sandbox as E2BSandbox } from 'e2b';
-import { defineProvider, escapeShellArg } from '@computesdk/provider';
+import { defineProvider } from '@computesdk/provider';
 
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
@@ -113,15 +113,20 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
 
       runCommand: async (sandbox: E2BSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
         const startTime = Date.now();
+        const nativeOptions = {
+          ...(options?.user ? { user: options.user } : {}),
+          ...(options?.cwd ? { cwd: options.cwd } : {}),
+          ...(options?.env && Object.keys(options.env).length > 0 ? { envs: options.env } : {}),
+          ...(options?.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+          ...(options?.onStdout ? { onStdout: options.onStdout } : {}),
+          ...(options?.onStderr ? { onStderr: options.onStderr } : {}),
+        };
         try {
-          let fullCommand = command;
-          if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`).join(' ');
-            fullCommand = `${envPrefix} ${fullCommand}`;
+          if (options?.background) {
+            await sandbox.commands.run(command, { ...nativeOptions, background: true as const });
+            return { stdout: '', stderr: '', exitCode: 0, durationMs: Date.now() - startTime };
           }
-          if (options?.cwd) fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          if (options?.background) fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          const execution = await sandbox.commands.run(fullCommand, { timeoutMs: options?.timeout });
+          const execution = await sandbox.commands.run(command, nativeOptions);
           return { stdout: execution.stdout, stderr: execution.stderr, exitCode: execution.exitCode, durationMs: Date.now() - startTime };
         } catch (error) {
           const result = (error as { result?: E2BExecutionResult })?.result;

--- a/packages/e2b/src/index.ts
+++ b/packages/e2b/src/index.ts
@@ -123,7 +123,9 @@ export const e2b = defineProvider<E2BSandbox, E2BConfig>({
         };
         try {
           if (options?.background) {
-            await sandbox.commands.run(command, { ...nativeOptions, background: true as const });
+            // Native E2B background commands default to a 60s timeout. Detached work should run until
+            // explicitly stopped, so default to 0 (no timeout) when the caller did not specify one.
+            await sandbox.commands.run(command, { ...nativeOptions, timeoutMs: options?.timeout ?? 0, background: true as const });
             return { stdout: '', stderr: '', exitCode: 0, durationMs: Date.now() - startTime };
           }
           const execution = await sandbox.commands.run(command, nativeOptions);


### PR DESCRIPTION
## Summary

This PR ports three low-risk, high-value fixes from the `starslingdev/hpc-sandbox-benchmarks` provider layer back into the core SDK.

### `DirectProvider` is now exported

Downstream adapters currently recover the type with `NonNullable<ExplicitComputeConfig["provider"]>`. `compute.ts` already defines `interface DirectProvider`; this change re-exports it from `packages/computesdk/src/index.ts`.

```ts
import type { DirectProvider } from 'computesdk';
```

### `RunCommandOptions` supports `user`, and `@computesdk/e2b` uses native command options

- Added `user?: string` to `RunCommandOptions`.
- `@computesdk/e2b` now passes `user`, `cwd`, `envs`, `timeoutMs`, `onStdout`, `onStderr`, and `background` directly to `sandbox.commands.run(...)` instead of shell-wrapping `env`/`cwd`/`background` with `escapeShellArg` + `nohup`.
- `background: true` now uses the SDK's native background execution and returns `exitCode: 0` immediately, matching the behavior the benchmark relies on for detached work.

```ts
await sandbox.runCommand('apt-get update', { user: 'root', cwd: '/app' });
```

### `@computesdk/daytona` accepts a `target` region

`DaytonaConfig` now includes `target?: string` (with `DAYTONA_TARGET` env fallback). A helper builds the `Daytona` client with `target` set for `create`, `getById`, `list`, `destroy`, and all snapshot/template operations, so teardown uses the same region as creation. `create` also honors a per-call `(options as any).target` override.

```ts
daytona({ apiKey: process.env.DAYTONA_API_KEY, target: 'us-west-2' });
```

### Verification

- `pnpm build` for `computesdk`, `@computesdk/provider`, `@computesdk/e2b`, and `@computesdk/daytona`
- `pnpm typecheck` and `pnpm lint` on those packages
- `pnpm test` on `computesdk`, `@computesdk/provider`, `@computesdk/e2b`, and `@computesdk/daytona`

The Vercel v2 provider upgrade is intentionally left for a follow-up PR because it rewrites a provider and updates the `@vercel/sandbox` major version.

Link to Devin session: https://app.devin.ai/sessions/3637f4e1bd85437393631b058794d261
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->