### PR TITLE
feat(vercel): upgrade provider to @vercel/sandbox v2

### DIFF
--- a/.changeset/vercel-v2-upgrade.md
+++ b/.changeset/vercel-v2-upgrade.md
@@ -1,0 +1,12 @@
+---
+"@computesdk/vercel": patch
+---
+
+Upgrade the Vercel provider to `@vercel/sandbox` v2.
+
+- Switches sandbox lifecycle from v1 `sandboxId`/`token` to v2 name-keyed `Sandbox.create`, `Sandbox.get({ resume: false })`, `Sandbox.list`, and `sandbox.delete()`.
+- Uses `sandbox.currentSession().runCommand` for command execution, with native `detached` support for `background: true`.
+- Adds `image`, `vcpus`, and `runtime` to `VercelConfig`; removes the v1 credential fields (now handled by OIDC/environment credentials).
+- Supports restoring from a snapshot via `options.snapshotId` or `options.source`.
+- Adds filesystem and snapshot method implementations using v2 `Session`/`Snapshot` APIs.
+- Updates unit tests to match v2 call shapes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,16 +120,14 @@ jobs:
     - name: Run Vercel Integration Tests
       if: matrix.provider == 'vercel'
       env:
-        VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-        VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        VERCEL_OIDC_TOKEN: ${{ secrets.VERCEL_OIDC_TOKEN }}
         COMPUTESDK_API_KEY: ${{ secrets.COMPUTESDK_API_KEY }}
       run: |
-         if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_TEAM_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+         if [ -n "$VERCEL_OIDC_TOKEN" ]; then
            echo "Running Vercel integration tests with real API..."
            pnpm --filter @computesdk/vercel test
          else
-           echo "Skipping Vercel integration tests - missing required secrets"
+           echo "Skipping Vercel integration tests - missing VERCEL_OIDC_TOKEN"
          fi
         
     - name: Run Daytona Integration Tests
@@ -208,9 +206,7 @@ jobs:
         COMPUTESDK_INTEGRATION: "1"
         TEST_PROVIDER: ${{ matrix.provider }}
         E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-        VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        VERCEL_OIDC_TOKEN: ${{ secrets.VERCEL_OIDC_TOKEN }}
         DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
         MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
         MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -226,8 +222,8 @@ jobs:
             fi
             ;;
           vercel)
-            if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_TEAM_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
-              echo "Skipping computesdk integration for vercel - missing Vercel credentials"
+            if [ -z "$VERCEL_OIDC_TOKEN" ]; then
+              echo "Skipping computesdk integration for vercel - missing VERCEL_OIDC_TOKEN"
               exit 0
             fi
             ;;

--- a/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
+++ b/packages/computesdk/src/__tests__/compute-provider-integration.test.ts
@@ -71,11 +71,10 @@ function getProviderConfig(provider: SupportedProvider): Record<string, string> 
         apiKey: requireEnv('E2B_API_KEY'),
       };
     case 'vercel':
-      return {
-        token: requireEnv('VERCEL_TOKEN'),
-        teamId: requireEnv('VERCEL_TEAM_ID'),
-        projectId: requireEnv('VERCEL_PROJECT_ID'),
-      };
+      // V2 authenticates via OIDC/environment credentials; the provider reads
+      // VERCEL_OIDC_TOKEN directly. Old token/team/project config is ignored.
+      requireEnv('VERCEL_OIDC_TOKEN');
+      return {};
     case 'daytona':
       return {
         apiKey: requireEnv('DAYTONA_API_KEY'),

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -75,16 +75,22 @@ export VERCEL_PROJECT_ID=your_project_id_here
 
 ```typescript
 interface VercelConfig {
-  /** Vercel API token - if not provided, will use VERCEL_TOKEN env var */
-  token?: string;
-  /** Vercel team ID - if not provided, will use VERCEL_TEAM_ID env var */
-  teamId?: string;
-  /** Vercel project ID - if not provided, will use VERCEL_PROJECT_ID env var */
-  projectId?: string;
-  /** Execution timeout in milliseconds */
+  /** VCR image to boot from. If omitted, `runtime` is used. */
+  image?: string;
+  /** Number of vCPUs to allocate (default 1). */
+  vcpus?: number;
+  /** Stock runtime to use when `image` is not set (`node` or `python`, default `node24`). */
+  runtime?: string;
+  /** Maximum sandbox lifetime in milliseconds. */
   timeout?: number;
-  /** Ports to expose */
+  /** Ports to expose on the sandbox. */
   ports?: number[];
+  /** Vercel API token or OIDC token. Falls back to `VERCEL_TOKEN` env var. */
+  token?: string;
+  /** Vercel team ID. Falls back to `VERCEL_TEAM_ID` env var. */
+  teamId?: string;
+  /** Vercel project ID. Falls back to `VERCEL_PROJECT_ID` env var. */
+  projectId?: string;
 }
 ```
 
@@ -443,7 +449,7 @@ await sandbox.destroy();
 ## Limitations
 
 - **Ephemeral Sandboxes**: Each sandbox is single-use and cannot be reconnected to
-- **No Sandbox Listing**: Vercel doesn't support listing all sandboxes
+- **Sandbox Listing**: Only sandboxes created through ComputeSDK (tagged `computesdk:vercel`) are listed
 - **No Interactive Terminals**: Terminal operations are not supported
 - **Memory Limits**: Subject to Vercel sandbox memory constraints (2048 MB per vCPU)
 - **Execution Time**: Maximum 45 minutes execution time

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@vercel/sandbox": "^1.9.3",
+    "@vercel/sandbox": "^2.9.2",
     "computesdk": "workspace:*",
     "ms": "^2.1.3"
   },

--- a/packages/vercel/src/__tests__/index.test.ts
+++ b/packages/vercel/src/__tests__/index.test.ts
@@ -5,7 +5,8 @@ runProviderTestSuite({
   name: 'vercel',
   provider: vercel({}),
   supportsFilesystem: false,   // Vercel sandboxes don't support filesystem operations
-  skipIntegration: !process.env.VERCEL_TOKEN || !process.env.VERCEL_TEAM_ID || !process.env.VERCEL_PROJECT_ID,
+  // V2 authenticates via OIDC/environment credentials; integration tests need a live OIDC token.
+  skipIntegration: !process.env.VERCEL_OIDC_TOKEN,
   // Note: Vercel blocks certain ports (80, 443, 8080). Use allowed ports for getUrl tests.
   ports: [3000, 8000],
 });

--- a/packages/vercel/src/__tests__/snapshot-unit.test.ts
+++ b/packages/vercel/src/__tests__/snapshot-unit.test.ts
@@ -1,39 +1,43 @@
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { vercel } from '../index';
 import { Sandbox as VercelSandbox, Snapshot as VercelSnapshot } from '@vercel/sandbox';
 
-// Mock @vercel/sandbox
-vi.mock('@vercel/sandbox', () => {
-  const mockSnapshotInstance = {
+const mocks = vi.hoisted(() => ({
+  snapshotInstance: {
     delete: vi.fn().mockResolvedValue(undefined),
-  };
+  },
+  sandboxInstance: {
+    name: 'mock-sandbox-name',
+    status: 'running',
+    snapshot: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  },
+  listPaginator: {
+    toArray: vi.fn().mockResolvedValue([]),
+  },
+}));
 
-  const mockSandboxInstance = {
-    sandboxId: 'mock-sandbox-id',
-    snapshot: vi.fn().mockResolvedValue(mockSnapshotInstance),
-    stop: vi.fn().mockResolvedValue(undefined),
-  };
-
-  return {
-    Sandbox: {
-      create: vi.fn().mockResolvedValue(mockSandboxInstance),
-      get: vi.fn().mockResolvedValue(mockSandboxInstance),
-    },
-    Snapshot: {
-      get: vi.fn().mockResolvedValue(mockSnapshotInstance),
+vi.mock('@vercel/sandbox', () => ({
+  Sandbox: {
+    create: vi.fn().mockResolvedValue(mocks.sandboxInstance),
+    get: vi.fn().mockResolvedValue(mocks.sandboxInstance),
+    list: vi.fn().mockResolvedValue(mocks.listPaginator),
+  },
+  Snapshot: {
+    get: vi.fn().mockResolvedValue(mocks.snapshotInstance),
+    list: vi.fn().mockResolvedValue(mocks.listPaginator),
+  },
+  APIError: class extends Error {
+    response: { status: number };
+    constructor(response: { status: number }, message = 'API error') {
+      super(message);
+      this.response = response;
     }
-  };
-});
+  },
+}));
 
 describe('Vercel Snapshot Support', () => {
-  const config = {
-    token: 'mock-token',
-    teamId: 'mock-team',
-    projectId: 'mock-project'
-  };
-
-  const provider = vercel(config);
+  const provider = vercel({ vcpus: 1 });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -45,19 +49,13 @@ describe('Vercel Snapshot Support', () => {
     }
 
     await provider.snapshot.create('sandbox-123');
-    
+
     expect(VercelSandbox.get).toHaveBeenCalledWith(expect.objectContaining({
-      sandboxId: 'sandbox-123',
-      token: 'mock-token',
-      teamId: 'mock-team',
-      projectId: 'mock-project'
+      name: 'sandbox-123',
+      resume: false,
     }));
-    
-    // Check that .snapshot() was called on the sandbox instance
-    // We can't easily access the mock instance returned by get() inside the mock definition unless we expose it
-    // But verify calling sequence is enough for now or use the return value
-    const mockSandbox = await (VercelSandbox.get as any).mock.results[0].value;
-    expect(mockSandbox.snapshot).toHaveBeenCalled();
+
+    expect(mocks.sandboxInstance.snapshot).toHaveBeenCalled();
   });
 
   it('should delete a snapshot', async () => {
@@ -69,13 +67,9 @@ describe('Vercel Snapshot Support', () => {
 
     expect(VercelSnapshot.get).toHaveBeenCalledWith(expect.objectContaining({
       snapshotId: 'snapshot-123',
-      token: 'mock-token',
-      teamId: 'mock-team',
-      projectId: 'mock-project'
     }));
 
-    const mockSnapshot = await (VercelSnapshot.get as any).mock.results[0].value;
-    expect(mockSnapshot.delete).toHaveBeenCalled();
+    expect(mocks.snapshotInstance.delete).toHaveBeenCalled();
   });
 
   it('should create a sandbox from a snapshot', async () => {
@@ -84,40 +78,35 @@ describe('Vercel Snapshot Support', () => {
     expect(VercelSandbox.create).toHaveBeenCalledWith(expect.objectContaining({
       source: {
         type: 'snapshot',
-        snapshotId: 'snap-123'
+        snapshotId: 'snap-123',
       },
-      token: 'mock-token',
-      teamId: 'mock-team',
-      projectId: 'mock-project'
     }));
   });
 
   it('should create a sandbox from a snapshot using nested source format', async () => {
-    // This format matches the Vercel SDK's native format
-    // The gateway may pass options in this format
-    await provider.sandbox.create({ 
-      source: { 
-        type: 'snapshot', 
-        snapshotId: 'snap-456' 
-      } 
+    await provider.sandbox.create({
+      source: {
+        type: 'snapshot',
+        snapshotId: 'snap-456',
+      },
     } as any);
 
     expect(VercelSandbox.create).toHaveBeenCalledWith(expect.objectContaining({
       source: {
         type: 'snapshot',
-        snapshotId: 'snap-456'
+        snapshotId: 'snap-456',
       },
-      token: 'mock-token',
-      teamId: 'mock-team',
-      projectId: 'mock-project'
     }));
   });
 
-  it('should throw when listing snapshots', async () => {
+  it('should list snapshots', async () => {
     if (!provider.snapshot) {
       throw new Error('Snapshot manager not initialized');
     }
 
-    await expect(provider.snapshot.list()).rejects.toThrow('Vercel provider does not support listing snapshots');
+    const list = await provider.snapshot.list();
+
+    expect(VercelSnapshot.list).toHaveBeenCalled();
+    expect(list).toEqual([]);
   });
 });

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -1,72 +1,96 @@
 /**
- * Vercel Provider - Factory-based Implementation
+ * Vercel Provider - Factory-based Implementation (v2)
+ *
+ * Built against `@vercel/sandbox` v2, which is name-keyed and authenticates
+ * via OIDC or environment credentials. Sandboxes are created with
+ * `persistent: false` and `resume: false` so that a lost session is not
+ * silently replaced, matching the ComputeSDK lifecycle contract.
  */
 
-import { Sandbox as VercelSandbox, Snapshot as VercelSnapshot } from '@vercel/sandbox';
-import { defineProvider, escapeShellArg } from '@computesdk/provider';
+import { randomUUID } from 'node:crypto';
 import { Writable } from 'node:stream';
+import { APIError, Sandbox as VercelSandbox, Snapshot as VercelSnapshot } from '@vercel/sandbox';
+import { defineProvider } from '@computesdk/provider';
+
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+  SandboxInfo,
+} from '@computesdk/provider';
 
 export type { VercelSandbox, VercelSnapshot };
 
-import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
-
 export interface VercelConfig {
-  token?: string;
-  teamId?: string;
-  projectId?: string;
+  /**
+   * VCR image to boot from.
+   *
+   * If omitted, a stock `runtime` is used.
+   */
+  image?: string;
+  /**
+   * Number of vCPUs to allocate (default 1).
+   */
+  vcpus?: number;
+  /**
+   * Stock runtime to use when `image` is not set (default `node24`).
+   */
+  runtime?: string;
+  /** Maximum sandbox lifetime in milliseconds. */
   timeout?: number;
+  /** Ports to expose on the sandbox. */
   ports?: number[];
+  /** @deprecated V2 uses OIDC/environment credentials. Kept for source compatibility. */
+  token?: string;
+  /** @deprecated V2 uses OIDC/environment credentials. Kept for source compatibility. */
+  teamId?: string;
+  /** @deprecated V2 uses OIDC/environment credentials. Kept for source compatibility. */
+  projectId?: string;
+  /** @deprecated V2 does not expose a daemon SSE stream. */
   daemonSsePort?: number | false;
 }
 
-const DEFAULT_DAEMON_SSE_PORT = 38989;
+const NAME_PREFIX = 'computesdk-';
+const OWNER_TAG = 'computesdk';
+const OWNER_VALUE = 'vercel';
+const MAX_METADATA_TAGS = 4;
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof APIError && error.response.status === 404;
+}
 
 function mergeExposedPorts(primary?: number[], fallback?: number[], daemonSsePort?: number | false): number[] {
-  const daemonPort = daemonSsePort === false ? undefined : (daemonSsePort ?? DEFAULT_DAEMON_SSE_PORT);
+  const daemonPort = daemonSsePort === false ? undefined : (daemonSsePort ?? undefined);
   const merged = [...(primary ?? fallback ?? [])];
   if (typeof daemonPort === 'number') merged.push(daemonPort);
   return Array.from(new Set(merged.filter((port) => Number.isInteger(port) && port > 0 && port <= 65535)));
 }
 
-interface ResolvedCredentials {
-  useOidc: boolean;
-  token: string;
-  teamId: string;
-  projectId: string;
+function mapTags(metadata: Record<string, unknown> = {}): Record<string, string> {
+  return Object.fromEntries([
+    [OWNER_TAG, OWNER_VALUE],
+    ...Object.entries(metadata)
+      .slice(0, MAX_METADATA_TAGS)
+      .map(([key, value]) => [`meta.${key}`, String(value)]),
+  ]);
 }
 
-function resolveCredentials(config: VercelConfig): ResolvedCredentials {
-  const token = config.token || (typeof process !== 'undefined' && process.env?.VERCEL_TOKEN) || '';
-  const teamId = config.teamId || (typeof process !== 'undefined' && process.env?.VERCEL_TEAM_ID) || '';
-  const projectId = config.projectId || (typeof process !== 'undefined' && process.env?.VERCEL_PROJECT_ID) || '';
-  const hasConfigCredentials = !!(config.token || config.teamId || config.projectId);
-  const oidcToken = typeof process !== 'undefined' && process.env?.VERCEL_OIDC_TOKEN;
-  const useOidc = !hasConfigCredentials && !!oidcToken;
-  return { useOidc, token, teamId, projectId };
+function mapStatus(status: VercelSandbox['status']): SandboxInfo['status'] {
+  if (status === 'running') return 'running';
+  if (status === 'stopped' || status === 'aborted' || status === 'failed') return 'stopped';
+  return 'error';
 }
 
-function validateCredentials(creds: ResolvedCredentials): void {
-  if (creds.useOidc) return;
-  if (!creds.token) {
-    throw new Error(
-      `Missing Vercel authentication. Either:\n` +
-      `1. Use OIDC token: Run 'vercel env pull' to get VERCEL_OIDC_TOKEN, or\n` +
-      `2. Use traditional method: Provide 'token' in config or set VERCEL_TOKEN environment variable.`
-    );
+function ensureRunning(sandbox: VercelSandbox): VercelSandbox {
+  if (sandbox.status !== 'running') {
+    throw new Error(`Vercel sandbox "${sandbox.name}" is ${sandbox.status}, not running`);
   }
-  if (!creds.teamId) throw new Error(`Missing Vercel team ID. Provide 'teamId' in config or set VERCEL_TEAM_ID.`);
-  if (!creds.projectId) throw new Error(`Missing Vercel project ID. Provide 'projectId' in config or set VERCEL_PROJECT_ID.`);
+  return sandbox;
 }
 
-function getUtf8Sink() {
-  const chunks: string[] = [];
-  const sink = new Writable({
-    write(chunk, _enc, cb) {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
-      cb();
-    },
-  });
-  return { sink, value: () => chunks.join("") };
+async function getNative(name: string): Promise<VercelSandbox> {
+  return VercelSandbox.get({ name, resume: false });
 }
 
 export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSnapshot>({
@@ -74,185 +98,276 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
   methods: {
     sandbox: {
       create: async (config: VercelConfig, options?: CreateSandboxOptions) => {
-        const creds = resolveCredentials(config);
-        validateCredentials(creds);
-        const timeout = options?.timeout ?? config.timeout ?? 300000;
-        try {
-          const {
-            timeout: _timeout, envs: _envs, name: _name, metadata: _metadata,
-            templateId, snapshotId: optSnapshotId, sandboxId: _sandboxId,
-            namespace: _namespace, directory: _directory,
-            ...providerOptions
-          } = options || {};
-          const optRuntime = (options as any)?.runtime;
-          const optPorts = (options as any)?.ports;
-          const optSource = (options as any)?.source;
+        const name = options?.name ?? `${NAME_PREFIX}${randomUUID()}`;
+        const timeout = options?.timeout ?? config.timeout;
+        const ports = mergeExposedPorts(
+          (options as any)?.ports,
+          config.ports,
+          (options as any)?.daemonSsePort ?? config.daemonSsePort
+        );
 
-          const params: any = { timeout, ...providerOptions };
-          const optDaemonSsePort = (options as any)?.daemonSsePort as number | false | undefined;
-          const ports = mergeExposedPorts(optPorts, config.ports, optDaemonSsePort ?? config.daemonSsePort);
-          if (ports && ports.length > 0) params.ports = ports;
+        const createParams: any = {
+          name,
+          resources: { vcpus: config.vcpus ?? 1 },
+          persistent: false,
+          tags: mapTags(options?.metadata),
+          ...(options?.envs ? { env: options.envs } : {}),
+        };
 
-          if (optRuntime) {
-            params.runtime =
-              optRuntime === 'node' ? 'node24' :
-              optRuntime === 'python' ? 'python3.13' :
-              optRuntime;
-          }
-
-          const snapshotId = optSnapshotId || templateId ||
-            (optSource?.type === 'snapshot' && optSource?.snapshotId);
-          if (snapshotId) {
-            params.source = { type: 'snapshot', snapshotId };
-          } else if (optSource) {
-            params.source = optSource;
-          }
-
-          if (!creds.useOidc) {
-            params.token = creds.token;
-            params.teamId = creds.teamId;
-            params.projectId = creds.projectId;
-          }
-
-          const sandbox = await VercelSandbox.create(params);
-          return { sandbox, sandboxId: sandbox.sandboxId };
-        } catch (error) {
-          if (error instanceof Error) {
-            if (error.message.includes('unauthorized') || error.message.includes('token')) {
-              throw new Error(`Vercel authentication failed. Please check your VERCEL_TOKEN environment variable.`);
-            }
-            if (error.message.includes('team') || error.message.includes('project')) {
-              throw new Error(`Vercel team/project configuration failed. Check VERCEL_TEAM_ID and VERCEL_PROJECT_ID.`);
-            }
-          }
-          throw new Error(`Failed to create Vercel sandbox: ${error instanceof Error ? error.message : String(error)}`);
+        if (ports.length > 0) {
+          createParams.ports = ports;
         }
+
+        if (timeout !== undefined) {
+          createParams.timeout = timeout;
+        }
+
+        const source =
+          options?.source ??
+          (options?.snapshotId ? { type: 'snapshot' as const, snapshotId: options.snapshotId } : undefined);
+
+        if (source) {
+          createParams.source = source;
+        } else {
+          const image = options?.image ?? options?.templateId ?? config.image;
+          if (image) {
+            createParams.image = image;
+          } else {
+            createParams.runtime = config.runtime ?? 'node24';
+          }
+        }
+
+        const sandbox = await VercelSandbox.create(createParams);
+        return { sandbox, sandboxId: sandbox.name };
       },
 
-      getById: async (config: VercelConfig, sandboxId: string) => {
-        const creds = resolveCredentials(config);
+      getById: async (_config: VercelConfig, sandboxId: string) => {
         try {
-          const sandbox = creds.useOidc
-            ? await VercelSandbox.get({ sandboxId })
-            : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
-          return { sandbox, sandboxId };
-        } catch { return null; }
+          const sandbox = await getNative(sandboxId);
+          return { sandbox, sandboxId: sandbox.name };
+        } catch (error) {
+          if (isNotFound(error)) return null;
+          throw error;
+        }
       },
 
       list: async (_config: VercelConfig) => {
-        throw new Error(`Vercel provider does not support listing sandboxes.`);
+        const paginator = await VercelSandbox.list({ namePrefix: NAME_PREFIX });
+        const records = await paginator.toArray();
+        const results = await Promise.all(
+          records.map(async (record: { name: string }) => {
+            try {
+              const sandbox = await getNative(record.name);
+              return { sandbox, sandboxId: sandbox.name };
+            } catch (error) {
+              if (isNotFound(error)) return null;
+              throw error;
+            }
+          })
+        );
+        return results.filter((r): r is { sandbox: VercelSandbox; sandboxId: string } => r !== null);
       },
 
-      destroy: async (config: VercelConfig, sandboxId: string) => {
-        const creds = resolveCredentials(config);
+      destroy: async (_config: VercelConfig, sandboxId: string) => {
         try {
-          const sandbox = creds.useOidc
-            ? await VercelSandbox.get({ sandboxId })
-            : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
-          await sandbox.stop();
-        } catch { /* already destroyed or doesn't exist */ }
-      },
-
-      runCommand: async (sandbox: VercelSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> => {
-        const startTime = Date.now();
-        try {
-          let fullCommand = command;
-          if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env).map(([k, v]) => `${k}="${escapeShellArg(v)}"`).join(' ');
-            fullCommand = `${envPrefix} ${fullCommand}`;
-          }
-          const stdout = options?.background ? undefined : getUtf8Sink();
-          const stderr = options?.background ? undefined : getUtf8Sink();
-          const result = await sandbox.runCommand({
-            cmd: 'sh', args: ['-c', fullCommand],
-            cwd: options?.cwd, detached: options?.background,
-            stdout: stdout?.sink, stderr: stderr?.sink,
-          });
-          return { stdout: stdout?.value() ?? '', stderr: stderr?.value() ?? '', exitCode: result.exitCode ?? 0, durationMs: Date.now() - startTime };
+          const sandbox = await getNative(sandboxId);
+          await sandbox.delete();
         } catch (error) {
-          return { stdout: '', stderr: error instanceof Error ? error.message : String(error), exitCode: 127, durationMs: Date.now() - startTime };
+          if (isNotFound(error)) return;
+          throw error;
         }
       },
 
-      getInfo: async (_sandbox: VercelSandbox): Promise<SandboxInfo> => ({
-        id: 'vercel-unknown',
-        provider: 'vercel',
-        status: 'running',
-        createdAt: new Date(),
-        timeout: 300000,
-        metadata: { vercelSandboxId: 'vercel-unknown' }
-      }),
+      runCommand: async (
+        sandbox: VercelSandbox,
+        command: string,
+        options?: RunCommandOptions
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+        ensureRunning(sandbox);
+
+        const stdoutChunks: string[] = [];
+        const stderrChunks: string[] = [];
+
+        const stdoutSink = options?.onStdout
+          ? new Writable({
+              write(chunk, _enc, cb) {
+                const text = Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk);
+                stdoutChunks.push(text);
+                options.onStdout!(text);
+                cb();
+              },
+            })
+          : undefined;
+
+        const stderrSink = options?.onStderr
+          ? new Writable({
+              write(chunk, _enc, cb) {
+                const text = Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk);
+                stderrChunks.push(text);
+                options.onStderr!(text);
+                cb();
+              },
+            })
+          : undefined;
+
+        const params: any = {
+          cmd: '/bin/sh',
+          args: ['-lc', command],
+          ...(options?.cwd ? { cwd: options.cwd } : {}),
+          ...(options?.env ? { env: options.env } : {}),
+          ...(options?.timeout ? { timeoutMs: options.timeout } : {}),
+          ...(stdoutSink ? { stdout: stdoutSink } : {}),
+          ...(stderrSink ? { stderr: stderrSink } : {}),
+        };
+
+        if (options?.background) {
+          await sandbox.currentSession().runCommand({ ...params, detached: true as const });
+          return { stdout: '', stderr: '', exitCode: 0, durationMs: Date.now() - startTime };
+        }
+
+        const result = await sandbox.currentSession().runCommand(params);
+        const stdout = stdoutChunks.length ? stdoutChunks.join('') : await result.stdout();
+        const stderr = stderrChunks.length ? stderrChunks.join('') : await result.stderr();
+
+        return {
+          stdout,
+          stderr,
+          exitCode: result.exitCode ?? 1,
+          durationMs: result.durationMs ?? Date.now() - startTime,
+        };
+      },
+
+      getInfo: async (sandbox: VercelSandbox): Promise<SandboxInfo> => {
+        try {
+          const current = await getNative(sandbox.name);
+          return {
+            id: current.name,
+            provider: 'vercel',
+            status: mapStatus(current.status),
+            createdAt: current.createdAt,
+            timeout: current.timeout ?? 0,
+            metadata: {
+              ...(current.tags ?? {}),
+              image: current.image,
+              region: current.region,
+              vcpus: current.vcpus,
+              memoryMb: current.memory,
+            },
+          };
+        } catch (error) {
+          if (isNotFound(error)) {
+            return {
+              id: sandbox.name,
+              provider: 'vercel',
+              status: 'stopped',
+              createdAt: sandbox.createdAt,
+              timeout: sandbox.timeout ?? 0,
+              metadata: {
+                image: sandbox.image,
+                region: sandbox.region,
+                vcpus: sandbox.vcpus,
+                memoryMb: sandbox.memory,
+              },
+            };
+          }
+          throw error;
+        }
+      },
 
       getUrl: async (sandbox: VercelSandbox, options: { port: number; protocol?: string }): Promise<string> => {
-        try {
-          let url = sandbox.domain(options.port);
-          if (options.protocol) {
-            const urlObj = new URL(url);
-            urlObj.protocol = options.protocol + ':';
-            url = urlObj.toString();
-          }
-          return url;
-        } catch (error) {
-          throw new Error(`Failed to get Vercel domain for port ${options.port}: ${error instanceof Error ? error.message : String(error)}.`);
+        const url = ensureRunning(sandbox).currentSession().domain(options.port);
+        if (options.protocol) {
+          const urlObj = new URL(url);
+          urlObj.protocol = options.protocol + ':';
+          return urlObj.toString();
         }
+        return url;
       },
 
       filesystem: {
         readFile: async (sandbox: VercelSandbox, path: string): Promise<string> => {
-          const stream = await sandbox.readFile({ path });
-          if (!stream) throw new Error(`File not found: ${path}`);
-          const chunks: Buffer[] = [];
-          for await (const chunk of stream) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-          return Buffer.concat(chunks).toString('utf-8');
+          const buffer = await ensureRunning(sandbox).currentSession().readFileToBuffer({ path });
+          if (!buffer) throw new Error(`File not found or cannot be read: ${path}`);
+          return buffer.toString('utf-8');
         },
         writeFile: async (sandbox: VercelSandbox, path: string, content: string): Promise<void> => {
-          await sandbox.writeFiles([{ path, content: Buffer.from(content) }]);
+          await ensureRunning(sandbox).currentSession().writeFiles([{ path, content: Buffer.from(content) }]);
         },
-        mkdir: async (sandbox: VercelSandbox, path: string): Promise<void> => { await sandbox.mkDir(path); },
-        readdir: async (_sandbox: VercelSandbox, _path: string): Promise<FileEntry[]> => {
-          throw new Error('Vercel sandbox does not support readdir.');
+        mkdir: async (sandbox: VercelSandbox, path: string): Promise<void> => {
+          await ensureRunning(sandbox).currentSession().mkDir(path);
         },
-        exists: async (_sandbox: VercelSandbox, _path: string): Promise<boolean> => {
-          throw new Error('Vercel sandbox does not support exists.');
+        readdir: async (
+          sandbox: VercelSandbox,
+          path: string,
+          runCommand: (sandbox: VercelSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
+        ): Promise<FileEntry[]> => {
+          const response = await runCommand(sandbox, `ls -la "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`Directory not found or cannot be read: ${path}`);
+          const lines = response.stdout.split('\n').filter((l: string) => l.trim());
+          const entries: FileEntry[] = [];
+          for (const line of lines) {
+            if (line.startsWith('total ') || line.endsWith(' .') || line.endsWith(' ..')) continue;
+            const parts = line.trim().split(/\s+/);
+            if (parts.length >= 9) {
+              entries.push({
+                name: parts.slice(8).join(' '),
+                type: parts[0].startsWith('d') ? ('directory' as const) : ('file' as const),
+                size: parseInt(parts[4]) || 0,
+                modified: new Date(),
+              });
+            }
+          }
+          return entries;
         },
-        remove: async (_sandbox: VercelSandbox, _path: string): Promise<void> => {
-          throw new Error('Vercel sandbox does not support remove.');
-        }
+        exists: async (
+          sandbox: VercelSandbox,
+          path: string,
+          runCommand: (sandbox: VercelSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
+        ): Promise<boolean> => {
+          const response = await runCommand(sandbox, `test -e "${path}"`);
+          return response.exitCode === 0;
+        },
+        remove: async (
+          sandbox: VercelSandbox,
+          path: string,
+          runCommand: (sandbox: VercelSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
+        ): Promise<void> => {
+          const response = await runCommand(sandbox, `rm -rf "${path}"`);
+          if (response.exitCode !== 0) throw new Error(`Failed to remove: ${path}`);
+        },
       },
 
       getInstance: (sandbox: VercelSandbox): VercelSandbox => sandbox,
     },
 
     snapshot: {
-      create: async (config: VercelConfig, sandboxId: string) => {
-        const creds = resolveCredentials(config);
-        const sandbox = creds.useOidc
-          ? await VercelSandbox.get({ sandboxId })
-          : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+      create: async (_config: VercelConfig, sandboxId: string, _options?: { name?: string }) => {
+        const sandbox = await getNative(sandboxId);
         return await sandbox.snapshot();
       },
-      list: async (_config: VercelConfig) => { throw new Error(`Vercel provider does not support listing snapshots.`); },
-      delete: async (config: VercelConfig, snapshotId: string) => {
-        const creds = resolveCredentials(config);
-        const snapshot = creds.useOidc
-          ? await VercelSnapshot.get({ snapshotId })
-          : await VercelSnapshot.get({ snapshotId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+      list: async (_config: VercelConfig) => {
+        const paginator = await VercelSnapshot.list();
+        const page = await paginator.toArray();
+        return page as unknown as VercelSnapshot[];
+      },
+      delete: async (_config: VercelConfig, snapshotId: string) => {
+        const snapshot = await VercelSnapshot.get({ snapshotId });
         await snapshot.delete();
-      }
+      },
     },
 
     template: {
       create: async (_config: VercelConfig, _options: { name: string }) => {
-        throw new Error(`Vercel does not support creating templates directly. Use snapshot.create() instead.`);
+        throw new Error('Vercel does not support creating templates directly. Use snapshot.create() instead.');
       },
-      list: async (_config: VercelConfig) => { throw new Error(`Vercel provider does not support listing templates.`); },
-      delete: async (config: VercelConfig, templateId: string) => {
-        const creds = resolveCredentials(config);
-        const snapshot = creds.useOidc
-          ? await VercelSnapshot.get({ snapshotId: templateId })
-          : await VercelSnapshot.get({ snapshotId: templateId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+      list: async (_config: VercelConfig) => {
+        throw new Error('Vercel provider does not support listing templates.');
+      },
+      delete: async (_config: VercelConfig, templateId: string) => {
+        const snapshot = await VercelSnapshot.get({ snapshotId: templateId });
         await snapshot.delete();
-      }
-    }
-  }
+      },
+    },
+  },
 });

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -75,6 +75,17 @@ function resolveRuntime(runtime?: string): string {
   return runtime;
 }
 
+function resolveCredentials(config: VercelConfig): Partial<Pick<VercelConfig, 'token' | 'teamId' | 'projectId'>> {
+  const token = config.token ?? (typeof process !== 'undefined' && process.env?.VERCEL_TOKEN);
+  const teamId = config.teamId ?? (typeof process !== 'undefined' && process.env?.VERCEL_TEAM_ID);
+  const projectId = config.projectId ?? (typeof process !== 'undefined' && process.env?.VERCEL_PROJECT_ID);
+  const result: Partial<Pick<VercelConfig, 'token' | 'teamId' | 'projectId'>> = {};
+  if (typeof token === 'string' && token) result.token = token;
+  if (typeof teamId === 'string' && teamId) result.teamId = teamId;
+  if (typeof projectId === 'string' && projectId) result.projectId = projectId;
+  return result;
+}
+
 function mapTags(metadata: Record<string, unknown> = {}): Record<string, string> {
   return Object.fromEntries([
     [OWNER_TAG, OWNER_VALUE],
@@ -97,8 +108,9 @@ function ensureRunning(sandbox: VercelSandbox): VercelSandbox {
   return sandbox;
 }
 
-async function getNative(name: string): Promise<VercelSandbox> {
-  return VercelSandbox.get({ name, resume: false });
+async function getNative(name: string, config: VercelConfig): Promise<VercelSandbox> {
+  const creds = resolveCredentials(config);
+  return VercelSandbox.get({ name, resume: false, ...creds });
 }
 
 export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSnapshot>({
@@ -146,13 +158,14 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
           }
         }
 
-        const sandbox = await VercelSandbox.create(createParams);
+        const creds = resolveCredentials(config);
+        const sandbox = await VercelSandbox.create({ ...createParams, ...creds });
         return { sandbox, sandboxId: sandbox.name };
       },
 
-      getById: async (_config: VercelConfig, sandboxId: string) => {
+      getById: async (config: VercelConfig, sandboxId: string) => {
         try {
-          const sandbox = await getNative(sandboxId);
+          const sandbox = await getNative(sandboxId, config);
           return { sandbox, sandboxId: sandbox.name };
         } catch (error) {
           if (isNotFound(error)) return null;
@@ -160,13 +173,14 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         }
       },
 
-      list: async (_config: VercelConfig) => {
-        const paginator = await VercelSandbox.list({ tags: { [OWNER_TAG]: OWNER_VALUE } });
+      list: async (config: VercelConfig) => {
+        const creds = resolveCredentials(config);
+        const paginator = await VercelSandbox.list({ tags: { [OWNER_TAG]: OWNER_VALUE }, ...creds });
         const records = await paginator.toArray();
         const results = await Promise.all(
           records.map(async (record: { name: string }) => {
             try {
-              const sandbox = await getNative(record.name);
+              const sandbox = await getNative(record.name, config);
               return { sandbox, sandboxId: sandbox.name };
             } catch (error) {
               if (isNotFound(error)) return null;
@@ -177,9 +191,9 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         return results.filter((r): r is { sandbox: VercelSandbox; sandboxId: string } => r !== null);
       },
 
-      destroy: async (_config: VercelConfig, sandboxId: string) => {
+      destroy: async (config: VercelConfig, sandboxId: string) => {
         try {
-          const sandbox = await getNative(sandboxId);
+          const sandbox = await getNative(sandboxId, config);
           await sandbox.delete();
         } catch (error) {
           if (isNotFound(error)) return;
@@ -247,42 +261,20 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         };
       },
 
-      getInfo: async (sandbox: VercelSandbox): Promise<SandboxInfo> => {
-        try {
-          const current = await getNative(sandbox.name);
-          return {
-            id: current.name,
-            provider: 'vercel',
-            status: mapStatus(current.status),
-            createdAt: current.createdAt,
-            timeout: current.timeout ?? 0,
-            metadata: {
-              ...(current.tags ?? {}),
-              image: current.image,
-              region: current.region,
-              vcpus: current.vcpus,
-              memoryMb: current.memory,
-            },
-          };
-        } catch (error) {
-          if (isNotFound(error)) {
-            return {
-              id: sandbox.name,
-              provider: 'vercel',
-              status: 'stopped',
-              createdAt: sandbox.createdAt,
-              timeout: sandbox.timeout ?? 0,
-              metadata: {
-                image: sandbox.image,
-                region: sandbox.region,
-                vcpus: sandbox.vcpus,
-                memoryMb: sandbox.memory,
-              },
-            };
-          }
-          throw error;
-        }
-      },
+      getInfo: async (sandbox: VercelSandbox): Promise<SandboxInfo> => ({
+        id: sandbox.name,
+        provider: 'vercel',
+        status: mapStatus(sandbox.status),
+        createdAt: sandbox.createdAt,
+        timeout: sandbox.timeout ?? 0,
+        metadata: {
+          ...(sandbox.tags ?? {}),
+          image: sandbox.image,
+          region: sandbox.region,
+          vcpus: sandbox.vcpus,
+          memoryMb: sandbox.memory,
+        },
+      }),
 
       getUrl: async (sandbox: VercelSandbox, options: { port: number; protocol?: string }): Promise<string> => {
         const url = ensureRunning(sandbox).currentSession().domain(options.port);
@@ -351,17 +343,19 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
     },
 
     snapshot: {
-      create: async (_config: VercelConfig, sandboxId: string, _options?: { name?: string }) => {
-        const sandbox = await getNative(sandboxId);
+      create: async (config: VercelConfig, sandboxId: string, _options?: { name?: string }) => {
+        const sandbox = await getNative(sandboxId, config);
         return await sandbox.snapshot();
       },
-      list: async (_config: VercelConfig) => {
-        const paginator = await VercelSnapshot.list();
+      list: async (config: VercelConfig) => {
+        const creds = resolveCredentials(config);
+        const paginator = await VercelSnapshot.list({ ...creds });
         const page = await paginator.toArray();
         return page as unknown as VercelSnapshot[];
       },
-      delete: async (_config: VercelConfig, snapshotId: string) => {
-        const snapshot = await VercelSnapshot.get({ snapshotId });
+      delete: async (config: VercelConfig, snapshotId: string) => {
+        const creds = resolveCredentials(config);
+        const snapshot = await VercelSnapshot.get({ snapshotId, ...creds });
         await snapshot.delete();
       },
     },
@@ -373,8 +367,9 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
       list: async (_config: VercelConfig) => {
         throw new Error('Vercel provider does not support listing templates.');
       },
-      delete: async (_config: VercelConfig, templateId: string) => {
-        const snapshot = await VercelSnapshot.get({ snapshotId: templateId });
+      delete: async (config: VercelConfig, templateId: string) => {
+        const creds = resolveCredentials(config);
+        const snapshot = await VercelSnapshot.get({ snapshotId: templateId, ...creds });
         await snapshot.delete();
       },
     },

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -10,7 +10,7 @@
 import { randomUUID } from 'node:crypto';
 import { Writable } from 'node:stream';
 import { APIError, Sandbox as VercelSandbox, Snapshot as VercelSnapshot } from '@vercel/sandbox';
-import { defineProvider } from '@computesdk/provider';
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type {
   CommandResult,
@@ -55,16 +55,24 @@ const NAME_PREFIX = 'computesdk-';
 const OWNER_TAG = 'computesdk';
 const OWNER_VALUE = 'vercel';
 const MAX_METADATA_TAGS = 4;
+const DEFAULT_DAEMON_SSE_PORT = 38989;
 
 function isNotFound(error: unknown): boolean {
   return error instanceof APIError && error.response.status === 404;
 }
 
 function mergeExposedPorts(primary?: number[], fallback?: number[], daemonSsePort?: number | false): number[] {
-  const daemonPort = daemonSsePort === false ? undefined : (daemonSsePort ?? undefined);
+  const daemonPort = daemonSsePort === false ? undefined : (daemonSsePort ?? DEFAULT_DAEMON_SSE_PORT);
   const merged = [...(primary ?? fallback ?? [])];
   if (typeof daemonPort === 'number') merged.push(daemonPort);
   return Array.from(new Set(merged.filter((port) => Number.isInteger(port) && port > 0 && port <= 65535)));
+}
+
+function resolveRuntime(runtime?: string): string {
+  if (!runtime) return 'node24';
+  if (runtime === 'node') return 'node24';
+  if (runtime === 'python') return 'python3.13';
+  return runtime;
 }
 
 function mapTags(metadata: Record<string, unknown> = {}): Record<string, string> {
@@ -124,16 +132,17 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
 
         const source =
           options?.source ??
-          (options?.snapshotId ? { type: 'snapshot' as const, snapshotId: options.snapshotId } : undefined);
+          (options?.snapshotId ? { type: 'snapshot' as const, snapshotId: options.snapshotId } : undefined) ??
+          (options?.templateId ? { type: 'snapshot' as const, snapshotId: options.templateId } : undefined);
 
         if (source) {
           createParams.source = source;
         } else {
-          const image = options?.image ?? options?.templateId ?? config.image;
+          const image = options?.image ?? config.image;
           if (image) {
             createParams.image = image;
           } else {
-            createParams.runtime = config.runtime ?? 'node24';
+            createParams.runtime = resolveRuntime(options?.runtime ?? config.runtime);
           }
         }
 
@@ -152,7 +161,7 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
       },
 
       list: async (_config: VercelConfig) => {
-        const paginator = await VercelSandbox.list({ namePrefix: NAME_PREFIX });
+        const paginator = await VercelSandbox.list({ tags: { [OWNER_TAG]: OWNER_VALUE } });
         const records = await paginator.toArray();
         const results = await Promise.all(
           records.map(async (record: { name: string }) => {
@@ -302,7 +311,7 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
           path: string,
           runCommand: (sandbox: VercelSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
         ): Promise<FileEntry[]> => {
-          const response = await runCommand(sandbox, `ls -la "${path}"`);
+          const response = await runCommand(sandbox, `ls -la "${escapeShellArg(path)}"`);
           if (response.exitCode !== 0) throw new Error(`Directory not found or cannot be read: ${path}`);
           const lines = response.stdout.split('\n').filter((l: string) => l.trim());
           const entries: FileEntry[] = [];
@@ -325,7 +334,7 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
           path: string,
           runCommand: (sandbox: VercelSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
         ): Promise<boolean> => {
-          const response = await runCommand(sandbox, `test -e "${path}"`);
+          const response = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
           return response.exitCode === 0;
         },
         remove: async (
@@ -333,7 +342,7 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
           path: string,
           runCommand: (sandbox: VercelSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
         ): Promise<void> => {
-          const response = await runCommand(sandbox, `rm -rf "${path}"`);
+          const response = await runCommand(sandbox, `rm -rf "${escapeShellArg(path)}"`);
           if (response.exitCode !== 0) throw new Error(`Failed to remove: ${path}`);
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
     dependencies:
       '@arker-ai/sdk':
         specifier: ^0.9.0
-        version: 0.9.0(@computesdk/daytona@1.7.32)(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+        version: 0.9.0(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2266,8 +2266,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@vercel/sandbox':
-        specifier: ^1.9.3
-        version: 1.9.3
+        specifier: ^2.9.2
+        version: 2.9.2
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -3029,14 +3029,12 @@ packages:
     engines: {node: '>=24.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@currentspace/http3-linux-x64-gnu@0.8.5':
     resolution: {integrity: sha512-pENtrt3EVG3O5ktGci2hoNJmIIOokuUVDYzhs/6teMcNFSUqWTHIm7VGfJajj67iUgRzWeRYjVv3/Y0lcinNqA==}
     engines: {node: '>=24.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@currentspace/http3@0.8.5':
     resolution: {integrity: sha512-Quxr3ul3raPslOi0xS3NGMx/TkjDiChafqJ1Td3qeyQXT5tqLpFSQDqA54Ewg0YemEMB5JInFWc9dsVCKW16dw==}
@@ -3980,183 +3978,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -4220,25 +4190,21 @@ packages:
     resolution: {integrity: sha512-tTFnCj24lftvF5q+14W8tIA4RosT2a8F1teqpo9A0DBeTrsqE9UIeJUdiStGtfTJfdEM3QAjAninMpQ95tZMOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@isorun/http-transport-linux-arm64-musl@0.8.8':
     resolution: {integrity: sha512-mCAe5LHr2h6zBf6gyNJwnFVIumeR9kHQvgAYGuWm3I9xd2eWUMN+90905i2tXnhShqVHOT3DnJbiWJmt8lKvsg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@isorun/http-transport-linux-x64-gnu@0.8.8':
     resolution: {integrity: sha512-13IyNfK47jXXix/AQB7lIvhYb0obDykdJR4cSey4vl+iptEVNqJLHr+DK13+VNmNeBKVzWemQJtF0Ui+RheAoQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@isorun/http-transport-linux-x64-musl@0.8.8':
     resolution: {integrity: sha512-TJM8TaHr36YnNMl5JEzzeB4YQBYSHZNqCY2Ivd5KMo2FzPCdHJjjZ0Z6AQlldqst5X0C9khgfWEr+0CRNzmZsg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -4873,67 +4839,56 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.1':
     resolution: {integrity: sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==}
@@ -4970,28 +4925,24 @@ packages:
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@sailresearch/sdk-linux-arm64-musl@0.5.1':
     resolution: {integrity: sha512-dISiV2oDSEX8wLxG4vcK/nVKAhNOm+JbRKi3skdDZ3vg25k8RbIv0LkijD66zATEmL6cb650HRrWUwIVAaF+Eg==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@sailresearch/sdk-linux-x64-gnu@0.5.1':
     resolution: {integrity: sha512-eZKhrq3yDGaH/6L8JBsB94OKu80AgimyFybzpbzNr7r/jdqmBneqhq882sE4x7gWPiD45I2Kj/Sgn67ed1/Eug==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@sailresearch/sdk-linux-x64-musl@0.5.1':
     resolution: {integrity: sha512-4+iAMHK2v4T8+ZQ3YRnvtF6DW/DdWdIjWXMd4gu32Q5gkngp4njBs5Ccv7n2GqSdt2MU4b8RglNcfcGJIbN1yA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@sailresearch/sdk-win32-x64-msvc@0.5.1':
     resolution: {integrity: sha512-WHIgGmWVaag7SHMWEwbDUrxXAE/Wjm5nRyu7uT0ssktp9cIJ45trMJWjHeH87CgdKstw+b1ptRb1YTT/7jq3AQ==}
@@ -5454,8 +5405,8 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vercel/sandbox@1.9.3':
-    resolution: {integrity: sha512-G6ef1izdlYftkmv2xxBfks76gm2oxIH3LgiASe8WMw7xoge6zFzyFjY91/dPMT0Pkd4UNX9nsaOedj98ywdk8Q==}
+  '@vercel/sandbox@2.9.2':
+    resolution: {integrity: sha512-tnPtCNL6MZKM9eRYvmyL0geA2Nifq+PSxVXBNhk/lQNeCWgMp/EYzCDOotKEWR/VH+c0Yv9HG4qk0w2I65xnLA==}
 
   '@vitest/coverage-v8@1.6.1':
     resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
@@ -8893,10 +8844,6 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@7.19.0:
-    resolution: {integrity: sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -9326,9 +9273,6 @@ packages:
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -9347,12 +9291,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@arker-ai/sdk@0.9.0(@computesdk/daytona@1.7.32)(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+  '@arker-ai/sdk@0.9.0(@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.52)(@computesdk/modal@1.9.4)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
       tar: 7.5.22
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
-      '@computesdk/daytona': 1.7.32
+      '@computesdk/daytona': 1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@computesdk/e2b': 1.7.52
       '@computesdk/modal': 1.9.4
       computesdk: link:packages/computesdk
@@ -10342,10 +10286,10 @@ snapshots:
   '@computesdk/cmd@0.4.1':
     optional: true
 
-  '@computesdk/daytona@1.7.32':
+  '@computesdk/daytona@1.7.32(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@computesdk/provider': 2.1.4
-      '@daytonaio/sdk': 0.192.0
+      '@daytonaio/sdk': 0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       computesdk: 4.1.4
     transitivePeerDependencies:
       - aws-crt
@@ -10450,38 +10394,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  '@daytonaio/sdk@0.192.0':
-    dependencies:
-      '@aws-sdk/client-s3': 3.1045.0
-      '@aws-sdk/lib-storage': 3.1045.0(@aws-sdk/client-s3@3.1045.0)
-      '@daytona/api-client': 0.192.0
-      '@daytona/toolbox-api-client': 0.192.0
-      '@iarna/toml': 2.2.5
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-node': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      axios: 1.18.1
-      busboy: 1.6.0
-      dotenv: 17.4.2
-      expand-tilde: 2.0.2
-      fast-glob: 3.3.3
-      form-data: 4.0.5
-      isomorphic-ws: 5.0.0
-      pathe: 2.0.3
-      shell-quote: 1.8.3
-      tar: 7.5.16
-    transitivePeerDependencies:
-      - aws-crt
-      - debug
-      - supports-color
-      - ws
-    optional: true
 
   '@daytonaio/sdk@0.192.0(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
@@ -12959,18 +12871,19 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/sandbox@1.9.3':
+  '@vercel/sandbox@2.9.2':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2
       async-retry: 1.3.3
+      jose: 6.2.3
       jsonlines: 0.1.1
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.19.0
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
-      zod: 3.24.4
+      zod: 4.4.3
 
   '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))':
     dependencies:
@@ -14949,9 +14862,6 @@ snapshots:
       node-gyp-build: 4.8.4
 
   isomorphic-timers-promises@1.0.1: {}
-
-  isomorphic-ws@5.0.0:
-    optional: true
 
   isomorphic-ws@5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -16980,8 +16890,6 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@7.19.0: {}
-
   undici@7.28.0: {}
 
   undici@8.3.0: {}
@@ -17522,8 +17430,6 @@ snapshots:
       zod: 4.4.3
 
   zod@3.22.3: {}
-
-  zod@3.24.4: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Rewrites `@computesdk/vercel` against `@vercel/sandbox` v2, porting the provider design used in `starslingdev/hpc-sandbox-benchmarks` into the core SDK.

### What's changed

- Bumps the dependency from `^1.9.3` to `^2.9.2`.
- Sandboxes are name-keyed: `create` generates `${NAME_PREFIX}<uuid>` and returns `sandbox.name` as the universal `sandboxId`.
- `getById` uses `Sandbox.get({ name, resume: false })` so a lost session is not silently replaced, matching the ComputeSDK teardown contract.
- `list` uses `Sandbox.list({ tags: { computesdk: 'vercel' } })` and reconnects each record with `resume: false`.
- `destroy` fetches the sandbox and calls `sandbox.delete()`.
- `runCommand` runs `/bin/sh -lc <command>` through `sandbox.currentSession().runCommand`, with native `detached: true` for `background: true`.
- `getUrl` resolves the session `domain` for the requested port.
- `VercelConfig` now exposes `image`, `vcpus`, `runtime`, `timeout`, and `ports`. v1 credential fields (`token`, `teamId`, `projectId`) are deprecated but still forwarded to the v2 SDK (with env fallbacks), so existing token-based auth continues to work.
- Authentication supports both explicit `token`/`teamId`/`projectId` config/env and ambient OIDC (`VERCEL_OIDC_TOKEN`).
- `create` supports `options.snapshotId`, `options.templateId`, and `options.source` to restore from a snapshot, otherwise boots from `image` or a mapped runtime (`node` -> `node24`, `python` -> `python3.13`, default `node24`).
- Exposes the default daemon SSE port (`38989`) through `mergeExposedPorts` so real-time output streaming still works.
- Adds filesystem and snapshot method implementations using v2 `Session`/`Snapshot` APIs, with shell-backed filesystem helpers that escape paths via `escapeShellArg`.
- Updates integration test skip and CI workflow to require `VERCEL_OIDC_TOKEN` for live v2 integration tests.

### Verification

- `pnpm build` for `computesdk`, `@computesdk/provider`, `@computesdk/test-utils`, and `@computesdk/vercel`
- `pnpm typecheck` and `pnpm lint` on `@computesdk/vercel` and `computesdk`
- `pnpm test` on `@computesdk/vercel` (unit/mocked tests pass; integration tests skipped without live Vercel credentials)

### Backward compatibility

The old `token`/`teamId`/`projectId` config fields are still honored and passed to the v2 SDK. If only `VERCEL_OIDC_TOKEN` is present, the SDK uses OIDC. Anyone relying on v1's `sandboxId` style identifiers should move to sandbox names, because v2 identifies sandboxes by `name`.


Link to Devin session: https://app.devin.ai/sessions/3637f4e1bd85437393631b058794d261
Requested by: @HeyGarrison