### PR TITLE
docs: reframe ComputeSDK as the benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <div align="center">
-  <strong>A unified SDK for running code in remote sandboxes.</strong>
+  <strong>The open, multi-provider harness behind ComputeSDK Benchmarks.</strong>
 </div>
 
 <div align="center">
@@ -19,7 +19,7 @@
 
 ## What is ComputeSDK?
 
-ComputeSDK provides a consistent TypeScript interface for executing code in remote sandboxes. Whether you're using E2B for data science, Modal for GPU workloads, or Vercel for serverless functions - ComputeSDK provides one unified API.
+ComputeSDK is the open, multi-provider harness behind [ComputeSDK Benchmarks](https://www.computesdk.com/benchmarks). It provides one unified TypeScript interface for executing code in remote sandboxes, so benchmarks can run the same workload on every provider and you can build applications on the same API. Whether you're using E2B for data science, Modal for GPU workloads, or Vercel for serverless functions - ComputeSDK provides one unified API.
 
 **Perfect for:**
 - 🤖 AI code execution agents

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,17 @@
 ---
 description: >-
-  ComputeSDK is a TypeScript sandbox SDK for secure code execution across
+  ComputeSDK is the open, multi-provider harness that powers ComputeSDK
+  Benchmarks and a TypeScript sandbox SDK for secure code execution across
   multiple cloud providers with one unified API.
 ---
 
 # Introduction
 
-## ComputeSDK for secure code execution
+## ComputeSDK: the benchmark harness for sandboxes
 
-ComputeSDK is a TypeScript sandbox SDK for secure code execution across multiple cloud providers. Use one provider-agnostic sandbox API to create isolated environments, run shell commands, and manage files without learning vendor-specific APIs.
+ComputeSDK is the open, multi-provider harness behind [ComputeSDK Benchmarks](https://www.computesdk.com/benchmarks). It exposes one provider-agnostic sandbox API so benchmarks can run the same workload on every provider and produce fair, reproducible results. The same API is also available as a TypeScript SDK for building AI agents, code execution platforms, developer tools, testing systems, and any product that needs safe cloud sandboxes.
 
-It works well for AI agents, code execution platforms, developer tools, testing systems, and any product that needs safe cloud sandboxes. Your application code stays the same even when you switch providers.
+Because every provider returns the same sandbox interface, your application code stays the same even when you switch providers.
 
 ## How the sandbox API works
 
@@ -51,6 +52,7 @@ When you install a package like `@computesdk/e2b`, you get a factory function fo
 ## Why teams use ComputeSDK
 
 **Provider-agnostic sandbox API** — Switch providers with minimal code changes\
+**Open benchmark harness** — Powers [ComputeSDK Benchmarks](https://www.computesdk.com/benchmarks) with the same API on every provider\
 **Secure code execution** — Run untrusted code in isolated sandboxes\
 **Lean installs** — Add only the cloud sandbox providers you need\
 **TypeScript-native SDK** — Get a clean developer experience with strong typing\
@@ -58,6 +60,7 @@ When you install a package like `@computesdk/e2b`, you get a factory function fo
 
 ### Common use cases
 
+* **Benchmarking infrastructure providers** — Compare sandbox, storage, browser, and AI gateway providers with one consistent harness
 * **AI agent infrastructure** — Let agents run code, commands, and file operations safely
 * **Code execution platforms** — Execute user-submitted code in isolated sandboxes
 * **Browser IDEs and education tools** — Provide interactive coding environments

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Welcome to ComputeSDK! This guide will get you up and running with secure, isolated code execution across multiple cloud providers using a unified TypeScript interface.
+Welcome to ComputeSDK! This guide will get you up and running with the open, multi-provider harness behind [ComputeSDK Benchmarks](https://www.computesdk.com/benchmarks): a unified TypeScript interface for secure, isolated code execution across cloud providers.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Reframes ComputeSDK from “a sandbox SDK” to “the open, multi-provider harness that powers ComputeSDK Benchmarks,” while keeping all SDK usage docs intact.

- `docs/README.md` — intro now leads with the benchmark-harness framing, adds “Open benchmark harness” and “Benchmarking infrastructure providers” to the use cases, and links to https://www.computesdk.com/benchmarks.
- `docs/getting-started/quick-start.md` — opening line now describes ComputeSDK as the harness behind ComputeSDK Benchmarks.
- `README.md` — tagline and “What is ComputeSDK?” updated to the same benchmark-harness framing.

This makes the SDK docs consistent with the benchmark-first site and repo positioning, so an LLM crawler that follows the Docs link sees ComputeSDK as the engine that makes fair, cross-provider benchmarks possible.

Link to Devin session: https://app.devin.ai/sessions/612a5ae92bcb45049d5f36ace3b9ebb6
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->