### PR TITLE
Add RunTools sandbox provider

### DIFF
--- a/.changeset/add-runtools-provider.md
+++ b/.changeset/add-runtools-provider.md
@@ -1,0 +1,7 @@
+---
+"@computesdk/runtools": patch
+"@computesdk/workbench": patch
+---
+
+Add the RunTools provider with full sandbox lifecycle, command execution,
+preview URL, filesystem, workbench, and shared CRUD-test integration.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ npm install @computesdk/modal            # Modal provider
 npm install @computesdk/mosaic           # Mosaic provider
 npm install @computesdk/northflank       # Northflank provider
 npm install @computesdk/runloop          # Runloop provider
+npm install @computesdk/runtools         # RunTools Firecracker provider
 npm install @computesdk/sail             # Sail provider
 npm install @computesdk/sandbox0         # Sandbox0 provider
 npm install @computesdk/superserve       # Superserve provider
@@ -326,6 +327,7 @@ See individual provider READMEs for details:
 - **[@computesdk/mosaic](./packages/mosaic)** - Firecracker-based sandbox environments
 - **[@computesdk/northflank](./packages/northflank)** - Cloud sandboxes with preview URLs
 - **[@computesdk/runloop](./packages/runloop)** - Code execution, automation
+- **[@computesdk/runtools](./packages/runtools)** - Firecracker sandboxes for agents and code execution
 - **[@computesdk/sandbox0](./packages/sandbox0)** - Fast persistent sandboxes with native filesystem access
 - **[@computesdk/superserve](./packages/superserve)** - Firecracker microVM sandboxes
 - **[@computesdk/tensorlake](./packages/tensorlake)** - Stateful MicroVM sandboxes for agentic applications, with snapshot support

--- a/packages/runtools/CHANGELOG.md
+++ b/packages/runtools/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @computesdk/runtools
+
+## 0.1.0
+
+- Initial release. Uses `@runtools-ai/sdk` to expose lifecycle, command
+  execution, preview URLs, sandbox information, and filesystem operations
+  through the ComputeSDK provider interface.

--- a/packages/runtools/README.md
+++ b/packages/runtools/README.md
@@ -1,0 +1,58 @@
+# @computesdk/runtools
+
+[RunTools](https://runtools.ai) provider for [ComputeSDK](https://computesdk.com).
+Run isolated Firecracker sandboxes through the same public RunTools API used by
+the dashboard, CLI, and RunTools SDK.
+
+## Install
+
+```bash
+npm install @computesdk/runtools
+```
+
+## Usage
+
+```typescript
+import { runtools } from '@computesdk/runtools'
+
+const compute = runtools({
+  apiKey: process.env.RUNTOOLS_API_KEY,
+})
+
+const sandbox = await compute.sandbox.create()
+const result = await sandbox.runCommand('node -v')
+console.log(result.stdout)
+
+await sandbox.filesystem.writeFile('/tmp/hello.txt', 'hello from RunTools')
+console.log(await sandbox.filesystem.readFile('/tmp/hello.txt'))
+
+await sandbox.destroy()
+```
+
+## Configuration
+
+| Option | Environment variable | Default | Description |
+| --- | --- | --- | --- |
+| `apiKey` | `RUNTOOLS_API_KEY` | required | RunTools organization API key |
+| `apiUrl` | `RUNTOOLS_API_URL` | `https://api.runtools.ai` | API origin |
+| `template` | — | `base-ubuntu` | Default sandbox template |
+| `timeout` | — | `300000` ms | ComputeSDK timeout and sandbox idle lease |
+
+Get an API key from the RunTools dashboard. The provider only uses public SDK
+surfaces and does not require host or Firecracker credentials.
+
+## Create options
+
+The provider accepts standard ComputeSDK fields including `name`, `envs`,
+`timeout`, `templateId`, `vcpus`, `memoryMb`, and `diskMiB`. RunTools-native
+fields `template`, `tags`, `sshKeys`, `rootPassword`, `idleTimeout`, and
+`resources` are also available.
+
+`runtime: 'node'` and `runtime: 'python'` both select `base-ubuntu`, which ships
+the standard development runtimes. Set `template: 'desktop-ubuntu'` only when a
+desktop sandbox is actually needed.
+
+## Beyond the ComputeSDK interface
+
+`getInstance()` returns the native `Sandbox` from `@runtools-ai/sdk`, exposing
+RunTools-specific pause, resume, metrics, VNC, SSH, and activity APIs.

--- a/packages/runtools/package.json
+++ b/packages/runtools/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@computesdk/runtools",
+  "version": "0.1.0",
+  "description": "RunTools provider for ComputeSDK — Firecracker sandboxes for agents and code execution",
+  "author": "RunTools <hello@runtools.ai>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "runtools",
+    "sandbox",
+    "firecracker",
+    "microvm",
+    "code-execution",
+    "ai-agent",
+    "compute",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/runtools"
+  },
+  "homepage": "https://runtools.ai",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "dependencies": {
+    "@runtools-ai/sdk": "^0.3.1",
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/runtools/src/__tests__/crud.test.ts
+++ b/packages/runtools/src/__tests__/crud.test.ts
@@ -1,0 +1,9 @@
+import { runProviderCrudTest } from '@computesdk/test-utils'
+import { runtools } from '../index'
+
+runProviderCrudTest({
+  name: 'runtools',
+  provider: runtools({}),
+  timeout: 120_000,
+  skipIntegration: !process.env.RUNTOOLS_API_KEY,
+})

--- a/packages/runtools/src/__tests__/index.test.ts
+++ b/packages/runtools/src/__tests__/index.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sdk = vi.hoisted(() => {
+  class MockRunToolsApiError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly payload: unknown = null,
+    ) {
+      super(message)
+    }
+  }
+
+  return {
+    constructors: vi.fn(),
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    destroy: vi.fn(),
+    getUrl: vi.fn(),
+    MockRunToolsApiError,
+  }
+})
+
+vi.mock('@runtools-ai/sdk', () => ({
+  RunToolsApiError: sdk.MockRunToolsApiError,
+  RunTools: class MockRunTools {
+    readonly sandbox = {
+      create: sdk.create,
+      get: sdk.get,
+      list: sdk.list,
+      destroy: sdk.destroy,
+      getUrl: sdk.getUrl,
+    }
+
+    constructor(options: unknown) {
+      sdk.constructors(options)
+    }
+  },
+}))
+
+import { mapStatus, parseFindOutput, resolveTemplate, runtools, shellQuote } from '../index'
+
+function nativeSandbox(id = 'sandbox-test123') {
+  const state = {
+    sandboxId: id,
+    agentId: 'agent-1',
+    orgId: 'org-1',
+    status: 'running',
+    template: 'base-ubuntu',
+    sshReady: true,
+    vncReady: false,
+    createdAt: '2026-08-08T00:00:00.000Z',
+    updatedAt: Date.now(),
+  }
+  return {
+    id,
+    state,
+    refresh: vi.fn().mockResolvedValue(state),
+    exec: vi.fn().mockResolvedValue({
+      stdout: 'v22.0.0\n',
+      stderr: '',
+      exitCode: 0,
+    }),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('RunTools provider', () => {
+  it('maps ComputeSDK create options onto the public RunTools SDK', async () => {
+    const native = nativeSandbox()
+    sdk.create.mockResolvedValue(native)
+    const provider = runtools({
+      apiKey: 'rt_test_compute',
+      apiUrl: 'https://api.example.test',
+    })
+
+    const sandbox = await provider.sandbox.create({
+      name: 'benchmark',
+      templateId: 'base-ubuntu',
+      timeout: 120_000,
+      envs: { BENCHMARK: '1' },
+      vcpus: 1,
+      memoryMb: 1024,
+      diskMiB: 10_240,
+    })
+
+    expect(sdk.constructors).toHaveBeenCalledWith({
+      apiKey: 'rt_test_compute',
+      apiUrl: 'https://api.example.test',
+    })
+    expect(sdk.create).toHaveBeenCalledWith({
+      template: 'base-ubuntu',
+      name: 'benchmark',
+      tags: undefined,
+      sshKeys: undefined,
+      rootPassword: undefined,
+      resources: { vcpus: 1, memory: '1024MB', disk: '10GB' },
+      env: { BENCHMARK: '1' },
+      idleTimeout: 120,
+    })
+    expect(sandbox.sandboxId).toBe(native.id)
+  })
+
+  it('executes commands and synthesizes background mode', async () => {
+    const native = nativeSandbox()
+    sdk.create.mockResolvedValue(native)
+    const sandbox = await runtools({ apiKey: 'rt_test_exec' }).sandbox.create()
+
+    const result = await sandbox.runCommand('node -v', {
+      cwd: '/workspace',
+      env: { FOO: 'bar' },
+      timeout: 20_000,
+    })
+    expect(native.exec).toHaveBeenCalledWith('node -v', {
+      cwd: '/workspace',
+      env: { HOME: '/root', FOO: 'bar' },
+      timeout: 20_000,
+    })
+    expect(result).toMatchObject({ stdout: 'v22.0.0\n', exitCode: 0 })
+
+    await sandbox.runCommand('sleep 5', { background: true })
+    expect(native.exec.mock.calls[1]?.[0]).toContain("nohup sh -lc 'sleep 5'")
+  })
+
+  it('maps only genuine 404s to absent/idempotent lifecycle outcomes', async () => {
+    const missing = nativeSandbox('missing')
+    missing.refresh.mockRejectedValue(new sdk.MockRunToolsApiError('not found', 404))
+    sdk.get.mockReturnValue(missing)
+
+    const provider = runtools({ apiKey: 'rt_test_not_found' })
+    await expect(provider.sandbox.getById('missing')).resolves.toBeNull()
+
+    sdk.destroy.mockRejectedValueOnce(new sdk.MockRunToolsApiError('gone', 404))
+    await expect(provider.sandbox.destroy('missing')).resolves.toBeUndefined()
+
+    sdk.destroy.mockRejectedValueOnce(new sdk.MockRunToolsApiError('unavailable', 503))
+    await expect(provider.sandbox.destroy('broken')).rejects.toThrow('unavailable')
+  })
+
+  it('lists native handles and uses the RunTools preview URL', async () => {
+    const native = nativeSandbox('sandbox-list1')
+    sdk.list.mockResolvedValue([{ id: native.id, status: 'running', createdAt: '2026-08-08T00:00:00Z' }])
+    sdk.get.mockReturnValue(native)
+    sdk.getUrl.mockResolvedValue({ url: 'https://sandbox-list1.preview.runtools.ai', port: 3000 })
+
+    const [sandbox] = await runtools({ apiKey: 'rt_test_list' }).sandbox.list()
+    expect(sandbox?.sandboxId).toBe(native.id)
+    await expect(sandbox?.getUrl({ port: 3000, protocol: 'wss' }))
+      .resolves.toBe('wss://sandbox-list1.preview.runtools.ai/')
+  })
+})
+
+describe('pure helpers', () => {
+  it('maps lifecycle status without reporting transitional states as ready', () => {
+    expect(mapStatus('running')).toBe('running')
+    expect(mapStatus('creating')).toBe('stopped')
+    expect(mapStatus('failed')).toBe('error')
+  })
+
+  it('defaults ComputeSDK node/python runtimes to base-ubuntu', () => {
+    expect(resolveTemplate({ runtime: 'node' }, {})).toBe('base-ubuntu')
+    expect(resolveTemplate({ image: 'desktop-ubuntu' }, {})).toBe('desktop-ubuntu')
+  })
+
+  it('quotes shell tokens and parses NUL-delimited find output', () => {
+    expect(shellQuote("a'b c")).toBe("'a'\\''b c'")
+    const findOutput = [
+      'one.txt', 'f', '3', '1723120000.5',
+      'dir', 'd', '0', '1723120001',
+      '',
+    ].join('\0')
+    expect(parseFindOutput(findOutput))
+      .toEqual([
+        { name: 'one.txt', type: 'file', size: 3, modified: new Date(1_723_120_000_500) },
+        { name: 'dir', type: 'directory', size: 0, modified: new Date(1_723_120_001_000) },
+      ])
+  })
+})

--- a/packages/runtools/src/__tests__/integration.test.ts
+++ b/packages/runtools/src/__tests__/integration.test.ts
@@ -1,0 +1,12 @@
+import { runProviderTestSuite } from '@computesdk/test-utils'
+import { runtools } from '../index'
+
+runProviderTestSuite({
+  name: 'runtools',
+  provider: runtools({}),
+  supportsFilesystem: true,
+  supportsGetUrl: true,
+  ports: [3000, 8080],
+  timeout: 120_000,
+  skipIntegration: !process.env.RUNTOOLS_API_KEY,
+})

--- a/packages/runtools/src/index.ts
+++ b/packages/runtools/src/index.ts
@@ -1,0 +1,355 @@
+/**
+ * @computesdk/runtools — RunTools provider for ComputeSDK.
+ *
+ * Uses the public @runtools-ai/sdk surface, so benchmark traffic follows the
+ * same create, exec, URL, and destroy paths as every other RunTools customer.
+ */
+
+import { RunTools, RunToolsApiError } from '@runtools-ai/sdk'
+import { defineProvider } from '@computesdk/provider'
+
+import type {
+  Sandbox as NativeSandbox,
+  SandboxCreateOptions as NativeCreateOptions,
+  SandboxState as NativeSandboxState,
+  SandboxStatus as NativeSandboxStatus,
+  SandboxSummary as NativeSandboxSummary,
+} from '@runtools-ai/sdk'
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+  SandboxInfo,
+} from '@computesdk/provider'
+
+const PROVIDER_NAME = 'runtools'
+const DEFAULT_TEMPLATE = 'base-ubuntu'
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export interface RunToolsConfig {
+  /** RunTools API key. Falls back to RUNTOOLS_API_KEY. */
+  apiKey?: string
+  /** RunTools API origin. Falls back to RUNTOOLS_API_URL, then production. */
+  apiUrl?: string
+  /** Default RunTools sandbox template. */
+  template?: string
+  /** Default ComputeSDK timeout and RunTools idle lease, in milliseconds. */
+  timeout?: number
+}
+
+/** ComputeSDK options plus RunTools-native create fields. */
+export interface RunToolsCreateOptions extends CreateSandboxOptions {
+  template?: string
+  tags?: string[]
+  sshKeys?: string[]
+  rootPassword?: string
+  idleTimeout?: number
+  resources?: {
+    vcpus?: number
+    memory?: string
+    disk?: string
+  }
+}
+
+interface SandboxContext {
+  client: RunTools
+  timeout: number
+  createdAt?: Date
+  template?: string
+}
+
+const clients = new WeakMap<RunToolsConfig, RunTools>()
+const sandboxContexts = new WeakMap<NativeSandbox, SandboxContext>()
+
+function env(key: string): string | undefined {
+  return typeof process !== 'undefined' ? process.env?.[key] : undefined
+}
+
+function getClient(config: RunToolsConfig): RunTools {
+  let client = clients.get(config)
+  if (client) return client
+
+  const apiKey = config.apiKey ?? env('RUNTOOLS_API_KEY')
+  if (!apiKey) {
+    throw new Error(
+      "Missing RunTools API key. Provide 'apiKey' in config or set RUNTOOLS_API_KEY.",
+    )
+  }
+
+  client = new RunTools({
+    apiKey,
+    apiUrl: config.apiUrl ?? env('RUNTOOLS_API_URL'),
+  })
+  clients.set(config, client)
+  return client
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof RunToolsApiError && error.status === 404
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined
+}
+
+export function resolveTemplate(
+  options: RunToolsCreateOptions,
+  config: RunToolsConfig,
+): string {
+  const requested = options.template ?? options.templateId ?? options.image ?? config.template
+  if (!requested || requested === 'node' || requested === 'python') return DEFAULT_TEMPLATE
+  return String(requested)
+}
+
+function resolveResources(options: RunToolsCreateOptions): NativeCreateOptions['resources'] {
+  const explicit = options.resources
+  const vcpus = explicit?.vcpus
+    ?? positiveNumber(options.vcpus)
+    ?? positiveNumber(options.cpus)
+    ?? positiveNumber(options.cpu)
+
+  const memoryMb = positiveNumber(options.memoryMb)
+    ?? positiveNumber(options.memoryMiB)
+    ?? positiveNumber(options.memMiB)
+    ?? positiveNumber(typeof options.memory === 'number' ? options.memory : undefined)
+  const diskMiB = positiveNumber(options.diskMiB)
+
+  const memory = explicit?.memory ?? (memoryMb ? `${Math.ceil(memoryMb)}MB` : undefined)
+  const disk = explicit?.disk ?? (diskMiB ? `${Math.ceil(diskMiB / 1024)}GB` : undefined)
+
+  if (vcpus === undefined && memory === undefined && disk === undefined) return undefined
+  return { vcpus, memory, disk }
+}
+
+function contextForSummary(
+  client: RunTools,
+  timeout: number,
+  summary?: NativeSandboxSummary | NativeSandboxState,
+): SandboxContext {
+  return {
+    client,
+    timeout,
+    createdAt: summary?.createdAt ? new Date(summary.createdAt) : undefined,
+    template: summary?.template,
+  }
+}
+
+function rememberSandbox(
+  sandbox: NativeSandbox,
+  context: SandboxContext,
+): NativeSandbox {
+  sandboxContexts.set(sandbox, context)
+  return sandbox
+}
+
+export function mapStatus(status: NativeSandboxStatus): SandboxInfo['status'] {
+  if (status === 'running') return 'running'
+  if (
+    status === 'failed'
+    || status === 'error'
+    || status === 'orphaned'
+    || status === 'suspected_missing'
+  ) return 'error'
+  return 'stopped'
+}
+
+/** Quote one complete POSIX shell token. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function commandFailure(action: string, result: CommandResult): Error {
+  const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.exitCode}`
+  return new Error(`${action}: ${detail}`)
+}
+
+function assertCommand(action: string, result: CommandResult): void {
+  if (result.exitCode !== 0) throw commandFailure(action, result)
+}
+
+export function parseFindOutput(stdout: string): FileEntry[] {
+  const fields = stdout.split('\0')
+  const entries: FileEntry[] = []
+  for (let i = 0; i + 3 < fields.length; i += 4) {
+    const name = fields[i]
+    if (!name) continue
+    const type = fields[i + 1]
+    const size = Number(fields[i + 2])
+    const modifiedSeconds = Number(fields[i + 3])
+    entries.push({
+      name,
+      type: type === 'd' ? 'directory' : 'file',
+      size: Number.isFinite(size) ? size : undefined,
+      modified: Number.isFinite(modifiedSeconds)
+        ? new Date(modifiedSeconds * 1000)
+        : undefined,
+    })
+  }
+  return entries
+}
+
+type CommandRunner = (
+  sandbox: NativeSandbox,
+  command: string,
+  options?: RunCommandOptions,
+) => Promise<CommandResult>
+
+export const runtools = defineProvider<NativeSandbox, RunToolsConfig>({
+  name: PROVIDER_NAME,
+  methods: {
+    sandbox: {
+      create: async (config, options) => {
+        const client = getClient(config)
+        const opts = (options ?? {}) as RunToolsCreateOptions
+        const timeout = opts.timeout ?? config.timeout ?? DEFAULT_TIMEOUT_MS
+        const template = resolveTemplate(opts, config)
+
+        const sandbox = await client.sandbox.create({
+          template,
+          name: opts.name,
+          tags: opts.tags,
+          sshKeys: opts.sshKeys,
+          rootPassword: opts.rootPassword,
+          resources: resolveResources(opts),
+          env: opts.envs,
+          idleTimeout: opts.idleTimeout ?? Math.max(1, Math.ceil(timeout / 1000)),
+        })
+
+        rememberSandbox(sandbox, contextForSummary(client, timeout, sandbox.state ?? undefined))
+        return { sandbox, sandboxId: sandbox.id }
+      },
+
+      getById: async (config, sandboxId) => {
+        const client = getClient(config)
+        const sandbox = client.sandbox.get(sandboxId)
+        try {
+          const state = await sandbox.refresh()
+          rememberSandbox(
+            sandbox,
+            contextForSummary(client, config.timeout ?? DEFAULT_TIMEOUT_MS, state),
+          )
+          return { sandbox, sandboxId }
+        } catch (error) {
+          if (isNotFound(error)) return null
+          throw error
+        }
+      },
+
+      list: async (config) => {
+        const client = getClient(config)
+        const summaries = await client.sandbox.list()
+        return summaries.map((summary) => {
+          const sandbox = client.sandbox.get(summary.id)
+          rememberSandbox(
+            sandbox,
+            contextForSummary(client, config.timeout ?? DEFAULT_TIMEOUT_MS, summary),
+          )
+          return { sandbox, sandboxId: summary.id }
+        })
+      },
+
+      destroy: async (config, sandboxId) => {
+        try {
+          await getClient(config).sandbox.destroy(sandboxId)
+        } catch (error) {
+          if (!isNotFound(error)) throw error
+        }
+      },
+
+      runCommand: async (sandbox, command, options): Promise<CommandResult> => {
+        const startedAt = Date.now()
+        const nativeOptions = {
+          timeout: options?.timeout,
+          cwd: options?.cwd,
+          env: { HOME: '/root', ...options?.env },
+        }
+        const executable = options?.background
+          ? `nohup sh -lc ${shellQuote(command)} >/dev/null 2>&1 &`
+          : command
+        const result = await sandbox.exec(executable, nativeOptions)
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          durationMs: Date.now() - startedAt,
+        }
+      },
+
+      getInfo: async (sandbox): Promise<SandboxInfo> => {
+        const state = sandbox.state ?? await sandbox.refresh()
+        const context = sandboxContexts.get(sandbox)
+        return {
+          id: sandbox.id,
+          provider: PROVIDER_NAME,
+          status: mapStatus(state.status),
+          createdAt: context?.createdAt
+            ?? (state.createdAt ? new Date(state.createdAt) : new Date()),
+          timeout: context?.timeout ?? DEFAULT_TIMEOUT_MS,
+          metadata: {
+            template: state.template ?? context?.template,
+            sshReady: state.sshReady,
+            runtoolsStatus: state.status,
+          },
+        }
+      },
+
+      getUrl: async (sandbox, options): Promise<string> => {
+        const context = sandboxContexts.get(sandbox)
+        if (!context) throw new Error(`Missing RunTools client context for ${sandbox.id}`)
+        const result = await context.client.sandbox.getUrl(sandbox.id, options.port)
+        if (!options.protocol) return result.url
+        const url = new URL(result.url)
+        url.protocol = `${options.protocol}:`
+        return url.toString()
+      },
+
+      getInstance: (sandbox) => sandbox,
+
+      filesystem: {
+        readFile: async (sandbox, path, runCommand: CommandRunner): Promise<string> => {
+          const result = await runCommand(sandbox, `cat -- ${shellQuote(path)}`)
+          assertCommand(`Failed to read ${path}`, result)
+          return result.stdout
+        },
+
+        writeFile: async (sandbox, path, content, runCommand: CommandRunner): Promise<void> => {
+          const encoded = Buffer.from(content, 'utf8').toString('base64')
+          const result = await runCommand(
+            sandbox,
+            `printf %s ${shellQuote(encoded)} | base64 --decode > ${shellQuote(path)}`,
+          )
+          assertCommand(`Failed to write ${path}`, result)
+        },
+
+        mkdir: async (sandbox, path, runCommand: CommandRunner): Promise<void> => {
+          const result = await runCommand(sandbox, `mkdir -p -- ${shellQuote(path)}`)
+          assertCommand(`Failed to create ${path}`, result)
+        },
+
+        readdir: async (sandbox, path, runCommand: CommandRunner): Promise<FileEntry[]> => {
+          const result = await runCommand(
+            sandbox,
+            `find ${shellQuote(path)} -mindepth 1 -maxdepth 1 -printf '%f\\0%y\\0%s\\0%T@\\0'`,
+          )
+          assertCommand(`Failed to list ${path}`, result)
+          return parseFindOutput(result.stdout)
+        },
+
+        exists: async (sandbox, path, runCommand: CommandRunner): Promise<boolean> => {
+          const result = await runCommand(sandbox, `test -e ${shellQuote(path)}`)
+          if (result.exitCode === 0) return true
+          if (result.exitCode === 1) return false
+          throw commandFailure(`Failed to inspect ${path}`, result)
+        },
+
+        remove: async (sandbox, path, runCommand: CommandRunner): Promise<void> => {
+          const result = await runCommand(sandbox, `rm -rf -- ${shellQuote(path)}`)
+          assertCommand(`Failed to remove ${path}`, result)
+        },
+      },
+    },
+  },
+})

--- a/packages/runtools/tsconfig.json
+++ b/packages/runtools/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/runtools/tsup.config.ts
+++ b/packages/runtools/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/runtools/vitest.config.ts
+++ b/packages/runtools/vitest.config.ts
@@ -1,0 +1,23 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*',
+      ],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})

--- a/packages/test-utils/src/provider-crud-test.ts
+++ b/packages/test-utils/src/provider-crud-test.ts
@@ -41,6 +41,7 @@ const CRUD_ENABLED_PROVIDERS = [
   'avm',
   'northflank', // Service-per-sandbox lifecycle is fully stable and listed
   'isorun',   // Isolated Linux VM, full create/getById/list/destroy lifecycle
+  'runtools', // Firecracker sandbox with full create/getById/list/destroy lifecycle
   'agentcore', // AgentCore Code Interpreter sessions support full CRUD lifecycle
   // Add more providers here as they become stable for CRUD testing
   // 'e2b',      // Add when CRUD implementation is stable

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -67,6 +67,7 @@
     "@computesdk/hopx": "workspace:*",
     "@computesdk/declaw": "workspace:*",
     "@computesdk/isorun": "workspace:*",
+    "@computesdk/runtools": "workspace:*",
     "@computesdk/modal": "workspace:*",
     "@computesdk/runloop": "workspace:*",
     "@computesdk/vercel": "workspace:*",
@@ -120,6 +121,9 @@
       "optional": true
     },
     "@computesdk/isorun": {
+      "optional": true
+    },
+    "@computesdk/runtools": {
       "optional": true
     },
     "@computesdk/beam": {

--- a/packages/workbench/src/cli/providers.ts
+++ b/packages/workbench/src/cli/providers.ts
@@ -21,6 +21,7 @@ const SHARED_PROVIDER_NAMES = [
   'hopx',
   'declaw',
   'isorun',
+  'runtools',
   'sprites',
   'agentuity',
   'freestyle',
@@ -57,6 +58,7 @@ const SHARED_PROVIDER_AUTH: Record<SharedProviderName, readonly (readonly string
   hopx: [['HOPX_API_KEY']],
   declaw: [['DECLAW_API_KEY']],
   isorun: [['ISORUN_API_KEY']],
+  runtools: [['RUNTOOLS_API_KEY']],
   sprites: [['SPRITES_TOKEN']],
   agentuity: [['AGENTUITY_SDK_KEY']],
   freestyle: [['FREESTYLE_API_KEY']],
@@ -96,6 +98,7 @@ const PROVIDER_ENV_MAP: Record<SharedProviderName, Record<string, string | reado
   hopx: { apiKey: 'HOPX_API_KEY' },
   declaw: { apiKey: 'DECLAW_API_KEY' },
   isorun: { apiKey: 'ISORUN_API_KEY' },
+  runtools: { apiKey: 'RUNTOOLS_API_KEY', apiUrl: 'RUNTOOLS_API_URL' },
   sprites: { token: 'SPRITES_TOKEN' },
   agentuity: { sdkKey: 'AGENTUITY_SDK_KEY' },
   freestyle: { apiKey: 'FREESTYLE_API_KEY' },
@@ -365,6 +368,8 @@ export async function loadProvider(providerName: ProviderName): Promise<any> {
         return await import('@computesdk/declaw');
       case 'isorun':
         return await import('@computesdk/isorun');
+      case 'runtools':
+        return await import('@computesdk/runtools');
       case 'sprites':
         return await import('@computesdk/sprites');
       case 'agentuity':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1797,6 +1797,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/runtools:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@runtools-ai/sdk':
+        specifier: ^0.3.1
+        version: 0.3.1
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/s3:
     dependencies:
       '@computesdk/provider':
@@ -2371,6 +2408,9 @@ importers:
       '@computesdk/runloop':
         specifier: workspace:*
         version: link:../runloop
+      '@computesdk/runtools':
+        specifier: workspace:*
+        version: link:../runtools
       '@computesdk/secure-exec':
         specifier: workspace:*
         version: link:../secure-exec
@@ -4952,6 +4992,10 @@ packages:
 
   '@runloop/api-client@1.24.0':
     resolution: {integrity: sha512-A/G9l2MlBz/u0Wr2RvCEJvh0+4Pn/8p15BTq9wQt3vEgEGLEk844+9bIKsfWbDvU/4JdRvIUND79Vu5qvKQzUQ==}
+
+  '@runtools-ai/sdk@0.3.1':
+    resolution: {integrity: sha512-rdHSRv+TNCpUX9iu5WLAwb+wH6ZNQzkoO1awjIfrozhb5LW3JxrJNSN9E9tvhrxvKLpb1JA67X+onRae0iSZXg==}
+    engines: {node: '>=18'}
 
   '@sailresearch/sdk-darwin-arm64@0.5.1':
     resolution: {integrity: sha512-ShPaFm0+9rfs0vdfKPVW74Q00xNu4IJhVIDF3oACWtkcr3SQg783E4HdgORSUpU45zavXPheRbKCVNoE8cGm4A==}
@@ -12241,6 +12285,8 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
+
+  '@runtools-ai/sdk@0.3.1': {}
 
   '@sailresearch/sdk-darwin-arm64@0.5.1':
     optional: true


### PR DESCRIPTION
## Summary

Adds `@computesdk/runtools`, backed by the public `@runtools-ai/sdk` and the same production API path used by RunTools customers.

- full create/get/list/destroy lifecycle
- command execution with cwd/env/timeout/background support
- filesystem read/write/mkdir/readdir/exists/remove
- public preview URLs and native RunTools sandbox access
- Workbench provider discovery and auth mapping
- shared provider and CRUD suites
- package docs, changelog, and changeset

The adapter has no benchmark-only shortcut: create and first exec use the normal public RunTools control plane.

## Verification

- provider unit/integration tests without credentials: 23 pass, 1 credential-gated skip
- provider typecheck, lint, and build: pass
- root monorepo test and typecheck: pass
- full 65-workspace build: pass
- frozen lockfile install: pass

## Live validation status

The credential-gated production suite reached 27/28. The remaining failure exposed a RunTools host-side lifecycle race rather than an adapter failure: a first placement timed out, a second host succeeded, but failed-attempt cleanup published a terminal state for the shared sandbox ID. The focused product fix is runtools-ai/runtools-fc-agent#81. I will rerun the live suite and mark this PR ready once that fix is deployed.

After publication, RunTools will provide a recurring benchmark credential for the separate `computesdk/benchmarks` leaderboard integration.