### PR TITLE
Stream a command's output while it runs, over the provider's own process API

### DIFF
--- a/.changeset/streaming-conformance-suite.md
+++ b/.changeset/streaming-conformance-suite.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/test-utils": patch
+---
+
+Add a shared live-output suite to the provider tests. A provider opting in with `supportsStreaming: true` is checked against its real sandbox for output arriving before the command exits, streamed text matching the final `stdout` exactly, stderr staying separate with a non-zero exit, and a streaming command being stopped at its timeout — so streaming becomes a conformance property rather than something each provider tests its own way. Enabled for tensorlake and tenki.

--- a/.changeset/tensorlake-live-output.md
+++ b/.changeset/tensorlake-live-output.md
@@ -3,4 +3,4 @@
 "@computesdk/tensorlake": patch
 ---
 
-Stream a Tensorlake command's output while it runs. Providers can now implement `streamCommand` to serve `onStdout`/`onStderr` over their own API instead of the daemond SSE bridge, which needs a routable port inside the sandbox; Tensorlake does so by following the process, so a long-running command reports line by line rather than only at exit.
+Stream a command's output while it runs, over a provider's own process API. Providers can now implement `streamCommand` to serve `onStdout`/`onStderr` themselves instead of using the daemond SSE bridge, which needs a routable port inside the sandbox, and `streamCommandViaProcess` from `@computesdk/provider` does the whole lifecycle for them — deadline, best-effort kill, exit polling and recovering the tail when a follow connection drops — so a provider supplies only its start/follow/status/kill calls. Tensorlake is the first to use it, so a long-running command there reports line by line rather than only at exit.

--- a/.changeset/tensorlake-live-output.md
+++ b/.changeset/tensorlake-live-output.md
@@ -1,0 +1,6 @@
+---
+"@computesdk/provider": patch
+"@computesdk/tensorlake": patch
+---
+
+Stream a Tensorlake command's output while it runs. Providers can now implement `streamCommand` to serve `onStdout`/`onStderr` over their own API instead of the daemond SSE bridge, which needs a routable port inside the sandbox; Tensorlake does so by following the process, so a long-running command reports line by line rather than only at exit.

--- a/packages/provider/src/__tests__/factory.test.ts
+++ b/packages/provider/src/__tests__/factory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { defineProvider } from '../factory.js'
-import type { CommandResult, SandboxInfo } from '../types/index.js'
+import type { CommandResult, RunCommandOptions, SandboxInfo } from '../types/index.js'
 
 const {
   daemonSeedScriptCommand,
@@ -305,6 +305,51 @@ describe('Factory', () => {
       await expect(
         sandbox.runCommand('pwd', { onStdout: vi.fn(), background: true })
       ).rejects.toThrow('runCommand with streaming callbacks does not support background mode.')
+    })
+
+    it('should stream through the provider when it implements streamCommand', async () => {
+      const streamCommand = vi.fn(async (_sandbox: unknown, _command: string, options: RunCommandOptions) => {
+        options.onStdout?.('tick 1\n')
+        options.onStdout?.('tick 2\n')
+        return { stdout: 'tick 1\ntick 2\n', stderr: '', exitCode: 0, durationMs: 9 } as CommandResult
+      })
+      const methods = {
+        create: vi.fn().mockResolvedValue({
+          sandbox: { id: 'test-791', status: 'running' },
+          sandboxId: 'test-791'
+        }),
+        getById: vi.fn().mockResolvedValue(null),
+        list: vi.fn().mockResolvedValue([]),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn(),
+        streamCommand,
+        getInfo: vi.fn().mockResolvedValue({
+          id: 'test-791',
+          provider: 'mock',
+          status: 'running',
+          createdAt: new Date(),
+          timeout: 300000
+        } as SandboxInfo),
+        getUrl: vi.fn()
+      }
+
+      const providerFactory = defineProvider({
+        name: 'mock',
+        methods: { sandbox: methods }
+      })
+
+      const provider = providerFactory({ apiKey: 'test-key' })
+      const sandbox = await provider.sandbox.create()
+      const onStdout = vi.fn()
+      const result = await sandbox.runCommand('pwd', { onStdout })
+
+      expect(onStdout).toHaveBeenNthCalledWith(1, 'tick 1\n')
+      expect(onStdout).toHaveBeenNthCalledWith(2, 'tick 2\n')
+      expect(result.stdout).toBe('tick 1\ntick 2\n')
+      // No daemon seeded, and no port asked for: the provider's own API carried it.
+      expect(methods.runCommand).not.toHaveBeenCalled()
+      expect(methods.getUrl).not.toHaveBeenCalled()
+      expect(daemonSeedScriptCommand).not.toHaveBeenCalled()
     })
 
     it('should not fail daemon command when provider cannot expose SSE URL', async () => {

--- a/packages/provider/src/__tests__/stream-process.test.ts
+++ b/packages/provider/src/__tests__/stream-process.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  streamCommandViaProcess,
+  TIMEOUT_EXIT_CODE,
+  START_FAILURE_EXIT_CODE
+} from '../stream-process'
+import type { StreamedProcess } from '../stream-process'
+
+/**
+ * A process whose output and exit are driven by the test, so "arrived while the
+ * command was still running" is an observable fact rather than a guess.
+ */
+function fakeProcess(overrides: Partial<StreamedProcess> = {}) {
+  const queued: string[] = []
+  const waiters: Array<() => void> = []
+  let running = true
+  let exitCode: number | undefined
+
+  const wake = () => {
+    while (waiters.length > 0) (waiters.shift() as () => void)()
+  }
+
+  async function* follow(
+    buffer: string[],
+    signal: AbortSignal
+  ): AsyncIterable<string> {
+    while (true) {
+      while (buffer.length > 0) yield buffer.shift() as string
+      if (!running || signal.aborted) return
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve)
+        signal.addEventListener('abort', () => resolve(), { once: true })
+      })
+    }
+  }
+
+  const err: string[] = []
+  const process: StreamedProcess = {
+    followStdout: (signal) => follow(queued, signal),
+    followStderr: (signal) => follow(err, signal),
+    status: async () => ({ running, exitCode }),
+    kill: vi.fn(async () => {}),
+    bufferedStdout: async () => 'tick 1\ntick 2\n',
+    bufferedStderr: async () => '',
+    ...overrides
+  }
+
+  return {
+    process,
+    emit: (text: string) => {
+      queued.push(text)
+      wake()
+    },
+    emitErr: (text: string) => {
+      err.push(text)
+      wake()
+    },
+    exit: (code: number) => {
+      running = false
+      exitCode = code
+      wake()
+    }
+  }
+}
+
+describe('streamCommandViaProcess', () => {
+  it('delivers output while the command is still running', async () => {
+    const fake = fakeProcess()
+    const seen: string[] = []
+
+    const running = streamCommandViaProcess(async () => fake.process, {
+      onStdout: (text) => seen.push(text)
+    })
+
+    fake.emit('tick 1\n')
+    await vi.waitFor(() => expect(seen).toEqual(['tick 1\n']))
+    fake.emit('tick 2\n')
+    await vi.waitFor(() => expect(seen).toEqual(['tick 1\n', 'tick 2\n']))
+
+    fake.exit(0)
+    const result = await running
+    expect(result).toMatchObject({ stdout: 'tick 1\ntick 2\n', exitCode: 0 })
+  })
+
+  it('keeps stderr separate', async () => {
+    const fake = fakeProcess()
+    const running = streamCommandViaProcess(async () => fake.process, {
+      onStderr: () => {}
+    })
+    fake.emitErr('boom\n')
+    fake.exit(2)
+    await expect(running).resolves.toMatchObject({
+      stderr: 'boom\n',
+      exitCode: 2
+    })
+  })
+
+  it('recovers the tail and the real exit code after a follow drops', async () => {
+    const fake = fakeProcess({
+      // eslint-disable-next-line require-yield
+      followStdout: async function* () {
+        throw new Error('connection reset')
+      }
+    })
+    const seen: string[] = []
+
+    const running = streamCommandViaProcess(async () => fake.process, {
+      onStdout: (text) => seen.push(text)
+    })
+    fake.exit(3)
+
+    const result = await running
+    expect(seen).toEqual(['tick 1\ntick 2\n'])
+    expect(result).toMatchObject({ stdout: 'tick 1\ntick 2\n', exitCode: 3 })
+  })
+
+  it('keeps the deadline armed when a follow dropped and the process lives on', async () => {
+    // A dropped follow is not an exit, so the timeout must still be the thing
+    // that stops the command rather than being cleared with it.
+    const fake = fakeProcess({
+      // eslint-disable-next-line require-yield
+      followStdout: async function* () {
+        throw new Error('connection reset')
+      }
+    })
+
+    const result = await streamCommandViaProcess(async () => fake.process, {
+      timeout: 30,
+      onStdout: () => {}
+    })
+
+    expect(fake.process.kill).toHaveBeenCalled()
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE)
+  })
+
+  it('returns at the deadline even when the kill never answers', async () => {
+    const fake = fakeProcess({ kill: vi.fn(() => new Promise<void>(() => {})) })
+
+    const result = await streamCommandViaProcess(async () => fake.process, {
+      timeout: 10,
+      onStdout: () => {}
+    })
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE)
+  })
+
+  it('does not call a finished command timed out when its status is slow', async () => {
+    const fake = fakeProcess()
+    fake.process.status = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      return { running: false, exitCode: 0 }
+    }
+
+    const running = streamCommandViaProcess(async () => fake.process, {
+      timeout: 20,
+      onStdout: () => {}
+    })
+    fake.exit(0)
+
+    await expect(running).resolves.toMatchObject({ exitCode: 0 })
+  })
+
+  it('reports a process that could not be started', async () => {
+    const result = await streamCommandViaProcess(
+      async () => {
+        throw new Error('sandbox is not running')
+      },
+      { onStdout: () => {} }
+    )
+
+    expect(result).toMatchObject({
+      stderr: 'sandbox is not running',
+      exitCode: START_FAILURE_EXIT_CODE
+    })
+  })
+})

--- a/packages/provider/src/factory.ts
+++ b/packages/provider/src/factory.ts
@@ -167,6 +167,19 @@ export interface SandboxMethods<TSandbox = any, TConfig = any> {
 
   // Instance operations
   runCommand: (sandbox: TSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>;
+
+  /**
+   * Optional native streaming implementation, used instead of the daemond SSE
+   * bridge when the caller passes `onStdout`/`onStderr`.
+   *
+   * The bridge reaches the daemon over an HTTP port inside the sandbox, so it
+   * only works where that port is routable from the caller. A provider whose
+   * own API streams a process's output — Tensorlake's `followStdout`, for
+   * instance — should stream through it rather than expose a port, and this is
+   * where that implementation goes. Callbacks must fire while the command runs;
+   * a provider that can only deliver output at exit should leave this unset.
+   */
+  streamCommand?: (sandbox: TSandbox, command: string, options: RunCommandOptions) => Promise<CommandResult>;
   getInfo: (sandbox: TSandbox) => Promise<SandboxInfo>;
   getUrl: (sandbox: TSandbox, options: { port: number; protocol?: string }) => Promise<string>;
 
@@ -370,6 +383,12 @@ class GeneratedSandbox<TSandbox = any> implements ProviderSandbox<TSandbox> {
     if (options?.onStdout || options?.onStderr) {
       if (options.background) {
         throw new Error('runCommand with streaming callbacks does not support background mode.');
+      }
+
+      // A provider that streams over its own API needs neither the daemon nor a
+      // routable port for it, so it is asked first.
+      if (this.methods.streamCommand) {
+        return await this.methods.streamCommand(this.sandbox, command, options);
       }
 
       const forwardedOptions: RunCommandOptions = { ...options };

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -42,5 +42,13 @@ export type {
 // Export utilities
 export { calculateBackoff, escapeShellArg } from './utils';
 
+// Export the process-API streaming helper for providers that stream natively
+export {
+  streamCommandViaProcess,
+  TIMEOUT_EXIT_CODE,
+  START_FAILURE_EXIT_CODE
+} from './stream-process';
+export type { StreamedProcess } from './stream-process';
+
 // Export all types
 export type * from './types';

--- a/packages/provider/src/stream-process.ts
+++ b/packages/provider/src/stream-process.ts
@@ -1,0 +1,208 @@
+/**
+ * Streaming a command's output over a provider's own process API.
+ *
+ * The framework's default way to serve `onStdout`/`onStderr` is the daemond
+ * bridge: seed a daemon inside the sandbox and read its SSE endpoint over a port
+ * the provider exposes. Plenty of providers instead expose the whole thing on
+ * their management API — start a process, follow its output, read its exit
+ * status — which needs no routable port at all.
+ *
+ * The awkward part of using that is not the following, it is the lifecycle
+ * around it: a deadline that has to hold even when the request to stop the
+ * process never answers, an output connection that can drop while the process
+ * keeps running, and an exit code that may not be readable the instant the
+ * output ends. That part is identical for every such provider, so it lives here
+ * and a provider supplies only the four calls its API actually names.
+ */
+
+import type { CommandResult, RunCommandOptions } from './types';
+
+/** How long to keep asking for an exit code once both streams have ended. */
+const EXIT_POLL_ATTEMPTS = 25;
+const EXIT_POLL_INTERVAL_MS = 200;
+
+/** Exit code reported when the command was killed for exceeding its timeout. */
+export const TIMEOUT_EXIT_CODE = 124;
+/** Exit code reported when the process could not be started at all. */
+export const START_FAILURE_EXIT_CODE = 127;
+
+/** A process the provider has started, in the terms this helper needs. */
+export interface StreamedProcess {
+  /**
+   * Output as it arrives. Text, not lines — a line-oriented API should append
+   * its own separator so what is streamed matches what the buffer holds.
+   */
+  followStdout(signal: AbortSignal): AsyncIterable<string>;
+  followStderr(signal: AbortSignal): AsyncIterable<string>;
+  /**
+   * The process's current state. `running: true` when it is still going or when
+   * the answer is unknown — an unreadable status must not look like an exit.
+   */
+  status(): Promise<{ running: boolean; exitCode?: number }>;
+  /** Best-effort stop. May reject, and may never settle; neither is fatal. */
+  kill(): Promise<void>;
+  /**
+   * The complete output the provider buffered, used to recover the tail when a
+   * follow connection drops. Omit if the provider keeps no buffer.
+   */
+  bufferedStdout?(): Promise<string>;
+  bufferedStderr?(): Promise<string>;
+}
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Follows one stream, handing every chunk to the caller as it arrives. A follow
+ * that fails part way through is reported rather than thrown: the process is
+ * still running and its output is still retrievable, so the missing tail is
+ * backfilled from the provider's buffer once it exits.
+ */
+async function pump(
+  chunks: AsyncIterable<string>,
+  onText: (text: string) => void
+): Promise<{ failed: boolean }> {
+  try {
+    for await (const chunk of chunks) {
+      onText(chunk);
+    }
+    return { failed: false };
+  } catch {
+    return { failed: true };
+  }
+}
+
+/**
+ * Emits whatever the buffered output has beyond what was seen on the wire.
+ * Compares lengths rather than content — it is the same byte sequence, and the
+ * length is the only question a backfill has to answer.
+ */
+function backfill(
+  buffered: string,
+  streamed: string,
+  emit: (text: string) => void
+): string {
+  if (buffered.length <= streamed.length) return streamed;
+  emit(buffered.slice(streamed.length));
+  return buffered;
+}
+
+/**
+ * Runs a provider's process to completion, streaming its output through
+ * `onStdout`/`onStderr` and resolving with the same shape as a non-streaming
+ * run. `start` is the only provider-specific part; a failure to start is
+ * reported as exit 127 rather than thrown, matching the non-streaming paths.
+ */
+export async function streamCommandViaProcess(
+  start: () => Promise<StreamedProcess>,
+  options: RunCommandOptions
+): Promise<CommandResult> {
+  const startTime = Date.now();
+  const durationMs = () => Date.now() - startTime;
+
+  let process: StreamedProcess;
+  try {
+    process = await start();
+  } catch (error) {
+    return {
+      stdout: '',
+      stderr: error instanceof Error ? error.message : String(error),
+      exitCode: START_FAILURE_EXIT_CODE,
+      durationMs: durationMs()
+    };
+  }
+
+  let stdout = '';
+  let stderr = '';
+  const controller = new AbortController();
+
+  let timedOut = false;
+  let exited = false;
+  // The deadline abandons the follow streams first and only then asks for the
+  // kill, so neither a kill that fails nor one that never answers can hold the
+  // caller open past its timeout. It is disarmed once the process is known to
+  // have exited, so the exit status can be read at leisure without a late
+  // deadline claiming a finished command.
+  let timer: ReturnType<typeof setTimeout> | undefined =
+    options.timeout === undefined
+      ? undefined
+      : setTimeout(() => {
+          if (exited) return;
+          timedOut = true;
+          controller.abort();
+          void process.kill().catch(() => {});
+        }, options.timeout);
+
+  const disarm = () => {
+    exited = true;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  try {
+    const [stdoutPump, stderrPump] = await Promise.all([
+      pump(process.followStdout(controller.signal), (text) => {
+        stdout += text;
+        options.onStdout?.(text);
+      }),
+      pump(process.followStderr(controller.signal), (text) => {
+        stderr += text;
+        options.onStderr?.(text);
+      })
+    ]);
+
+    // A stream can end for two reasons, and they mean opposite things. If both
+    // ended cleanly the process has exited, so the deadline no longer applies to
+    // it. If either *failed*, the process is very likely still running — the
+    // deadline is still the only thing that will stop it, and its exit is worth
+    // waiting for however long the caller allowed.
+    const lostStream = stdoutPump.failed || stderrPump.failed;
+    if (!lostStream) disarm();
+
+    const status = () => process.status().catch(() => ({ running: true }));
+
+    let info: { running: boolean; exitCode?: number } = await status();
+    // A timed-out command's exit status is not worth waiting for: it is reported
+    // as a timeout either way, and waiting is what the deadline just refused.
+    const attempts =
+      lostStream && options.timeout !== undefined
+        ? Number.POSITIVE_INFINITY
+        : EXIT_POLL_ATTEMPTS;
+    for (
+      let attempt = 0;
+      !timedOut && attempt < attempts && info.running;
+      attempt += 1
+    ) {
+      await sleep(EXIT_POLL_INTERVAL_MS);
+      info = await status();
+    }
+    disarm();
+
+    if (stdoutPump.failed && process.bufferedStdout) {
+      const buffered = await process.bufferedStdout().catch(() => '');
+      stdout = backfill(buffered, stdout, (text) => options.onStdout?.(text));
+    }
+    if (stderrPump.failed && process.bufferedStderr) {
+      const buffered = await process.bufferedStderr().catch(() => '');
+      stderr = backfill(buffered, stderr, (text) => options.onStderr?.(text));
+    }
+
+    const exitCode = timedOut
+      ? TIMEOUT_EXIT_CODE
+      : (info.exitCode ?? (info.running ? -1 : 0));
+
+    return { stdout, stderr, exitCode, durationMs: durationMs() };
+  } catch (error) {
+    controller.abort();
+    return {
+      stdout,
+      stderr: stderr + (error instanceof Error ? error.message : String(error)),
+      exitCode: START_FAILURE_EXIT_CODE,
+      durationMs: durationMs()
+    };
+  } finally {
+    disarm();
+  }
+}

--- a/packages/tenki/src/__tests__/index.test.ts
+++ b/packages/tenki/src/__tests__/index.test.ts
@@ -9,6 +9,8 @@ runProviderTestSuite({
   }),
   supportsFilesystem: true,
   supportsGetUrl: true,
+  // Tenki serves onStdout/onStderr by tailing the command's output itself.
+  supportsStreaming: true,
   skipIntegration: !process.env.TENKI_API_KEY,
   // Tenki's data-plane filesystem API operates under the sandbox user's home.
   filesystemBasePath: '/home/tenki',

--- a/packages/tensorlake/src/__tests__/index.test.ts
+++ b/packages/tensorlake/src/__tests__/index.test.ts
@@ -5,6 +5,8 @@ runProviderTestSuite({
   name: 'tensorlake',
   provider: tensorlake({}),
   supportsFilesystem: true,
+  // Tensorlake streams over its own process API, so no exposed port is needed.
+  supportsStreaming: true,
   // Skip integration tests unless an explicit API key is provided and SKIP_INTEGRATION=false.
   // This avoids dependency on external Tensorlake infrastructure for local development.
   skipIntegration:

--- a/packages/tensorlake/src/__tests__/streaming.test.ts
+++ b/packages/tensorlake/src/__tests__/streaming.test.ts
@@ -17,22 +17,25 @@ function fakeSandbox(overrides: Partial<StreamableTensorlakeSandbox> = {}) {
     while (waiters.length > 0) waiters.pop()!();
   };
 
-  async function* follow(lines: string[]): AsyncIterable<{ line: string }> {
+  async function* follow(lines: string[], signal?: AbortSignal): AsyncIterable<{ line: string }> {
     let sent = 0;
     while (true) {
       while (sent < lines.length) {
         yield { line: lines[sent] };
         sent += 1;
       }
-      if (exited) return;
-      await new Promise<void>((resolve) => waiters.push(resolve));
+      if (exited || signal?.aborted) return;
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve);
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
     }
   }
 
   const sandbox: StreamableTensorlakeSandbox = {
     startProcess: vi.fn(async () => ({ pid: 7 })),
-    followStdout: () => follow(stdout),
-    followStderr: () => follow(stderr),
+    followStdout: (_pid, options) => follow(stdout, options?.signal),
+    followStderr: (_pid, options) => follow(stderr, options?.signal),
     getProcess: vi.fn(async () => ({
       status: exited ? 'exited' : 'running',
       exitCode,
@@ -158,6 +161,44 @@ describe('streamTensorlakeCommand', () => {
 
     const result = await running;
     expect(fake.sandbox.killProcess).toHaveBeenCalledWith(7);
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+  });
+
+  it('does not call a finished command timed out while reading its exit status', async () => {
+    const fake = fakeSandbox({
+      // Reading the exit status outlasts the deadline; the process itself did not.
+      getProcess: vi.fn(async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 40));
+        return { status: 'exited', exitCode: 0 };
+      }),
+    });
+
+    const running = streamTensorlakeCommand(fake.sandbox, 'echo hi', {
+      timeout: 5,
+      onStdout: () => {},
+    });
+    fake.emitStdout('hi');
+    fake.exit(0);
+
+    const result = await running;
+    expect(result.exitCode).toBe(0);
+    expect(fake.sandbox.killProcess).not.toHaveBeenCalled();
+  });
+
+  it('returns at the deadline even when the kill request fails', async () => {
+    const fake = fakeSandbox({
+      killProcess: vi.fn(async () => {
+        throw new Error('management API unreachable');
+      }),
+      getProcess: vi.fn(async () => ({ status: 'running' })),
+    });
+
+    // The process never exits and cannot be killed: only abandoning the follow
+    // streams gets the caller its deadline back.
+    const result = await streamTensorlakeCommand(fake.sandbox, 'sleep 600', {
+      timeout: 5,
+      onStdout: () => {},
+    });
     expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
   });
 

--- a/packages/tensorlake/src/__tests__/streaming.test.ts
+++ b/packages/tensorlake/src/__tests__/streaming.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import { streamTensorlakeCommand, TIMEOUT_EXIT_CODE, type StreamableTensorlakeSandbox } from '../streaming';
+
+/**
+ * A sandbox whose follow streams are driven by the test: each `emit` releases
+ * one line to whichever follow is waiting, so a callback firing before the
+ * command exits is observable rather than assumed.
+ */
+function fakeSandbox(overrides: Partial<StreamableTensorlakeSandbox> = {}) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exited = false;
+  let exitCode: number | undefined;
+  const waiters: Array<() => void> = [];
+
+  const release = () => {
+    while (waiters.length > 0) waiters.pop()!();
+  };
+
+  async function* follow(lines: string[]): AsyncIterable<{ line: string }> {
+    let sent = 0;
+    while (true) {
+      while (sent < lines.length) {
+        yield { line: lines[sent] };
+        sent += 1;
+      }
+      if (exited) return;
+      await new Promise<void>((resolve) => waiters.push(resolve));
+    }
+  }
+
+  const sandbox: StreamableTensorlakeSandbox = {
+    startProcess: vi.fn(async () => ({ pid: 7 })),
+    followStdout: () => follow(stdout),
+    followStderr: () => follow(stderr),
+    getProcess: vi.fn(async () => ({
+      status: exited ? 'exited' : 'running',
+      exitCode,
+    })),
+    getStdout: vi.fn(async () => ({ lines: stdout })),
+    getStderr: vi.fn(async () => ({ lines: stderr })),
+    killProcess: vi.fn(async () => {
+      exited = true;
+      exitCode = 137;
+      release();
+    }),
+    ...overrides,
+  };
+
+  return {
+    sandbox,
+    emitStdout(line: string) {
+      stdout.push(line);
+      release();
+    },
+    emitStderr(line: string) {
+      stderr.push(line);
+      release();
+    },
+    exit(code: number) {
+      exited = true;
+      exitCode = code;
+      release();
+    },
+  };
+}
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('streamTensorlakeCommand', () => {
+  it('delivers each line while the command is still running', async () => {
+    const seen: string[] = [];
+    const fake = fakeSandbox();
+
+    const running = streamTensorlakeCommand(fake.sandbox, 'for i in 1 2; do echo tick $i; done', {
+      onStdout: (text) => seen.push(text),
+    });
+
+    fake.emitStdout('tick 1');
+    await flush();
+    expect(seen).toEqual(['tick 1\n']);
+
+    fake.emitStdout('tick 2');
+    await flush();
+    expect(seen).toEqual(['tick 1\n', 'tick 2\n']);
+
+    fake.exit(0);
+    const result = await running;
+    expect(result).toMatchObject({ stdout: 'tick 1\ntick 2\n', stderr: '', exitCode: 0 });
+    expect(fake.sandbox.startProcess).toHaveBeenCalledWith('sh', expect.objectContaining({
+      args: ['-c', 'for i in 1 2; do echo tick $i; done'],
+    }));
+  });
+
+  it('keeps stderr separate and reports the exit code', async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const fake = fakeSandbox();
+
+    const running = streamTensorlakeCommand(fake.sandbox, 'sh -c "echo a; echo b >&2; exit 3"', {
+      onStdout: (text) => out.push(text),
+      onStderr: (text) => err.push(text),
+    });
+
+    fake.emitStdout('a');
+    fake.emitStderr('b');
+    await flush();
+    fake.exit(3);
+
+    const result = await running;
+    expect(out).toEqual(['a\n']);
+    expect(err).toEqual(['b\n']);
+    expect(result.exitCode).toBe(3);
+  });
+
+  it('passes the working directory and environment to the process', async () => {
+    const fake = fakeSandbox();
+    const running = streamTensorlakeCommand(fake.sandbox, 'pwd', {
+      cwd: '/tmp/ci',
+      env: { CI: 'true' },
+      onStdout: () => {},
+    });
+    fake.exit(0);
+    await running;
+
+    expect(fake.sandbox.startProcess).toHaveBeenCalledWith('sh', expect.objectContaining({
+      workingDir: '/tmp/ci',
+      env: { CI: 'true' },
+    }));
+  });
+
+  it('backfills output the wire dropped once the process has exited', async () => {
+    const seen: string[] = [];
+    const fake = fakeSandbox({
+      // eslint-disable-next-line require-yield
+      followStdout: async function* () {
+        throw new Error('connection reset');
+      },
+      getStdout: async () => ({ lines: ['tick 1', 'tick 2'] }),
+    });
+
+    const running = streamTensorlakeCommand(fake.sandbox, 'echo', {
+      onStdout: (text) => seen.push(text),
+    });
+    fake.exit(0);
+
+    const result = await running;
+    expect(seen).toEqual(['tick 1\ntick 2\n']);
+    expect(result.stdout).toBe('tick 1\ntick 2\n');
+  });
+
+  it('kills the process and reports a timeout when one is set', async () => {
+    const fake = fakeSandbox();
+    const running = streamTensorlakeCommand(fake.sandbox, 'sleep 600', {
+      timeout: 5,
+      onStdout: () => {},
+    });
+
+    const result = await running;
+    expect(fake.sandbox.killProcess).toHaveBeenCalledWith(7);
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+  });
+
+  it('reports a process that could not be started', async () => {
+    const fake = fakeSandbox({
+      startProcess: vi.fn(async () => {
+        throw new Error('sandbox is not running');
+      }),
+    });
+
+    const result = await streamTensorlakeCommand(fake.sandbox, 'echo hi', { onStdout: () => {} });
+    expect(result).toMatchObject({ exitCode: 127, stderr: 'sandbox is not running', stdout: '' });
+  });
+});

--- a/packages/tensorlake/src/__tests__/streaming.test.ts
+++ b/packages/tensorlake/src/__tests__/streaming.test.ts
@@ -202,6 +202,40 @@ describe('streamTensorlakeCommand', () => {
     expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
   });
 
+  it('returns at the deadline even when the kill request never answers', async () => {
+    const fake = fakeSandbox({
+      killProcess: vi.fn(() => new Promise<void>(() => {})),
+      getProcess: vi.fn(async () => ({ status: 'running' })),
+    });
+
+    const result = await streamTensorlakeCommand(fake.sandbox, 'sleep 600', {
+      timeout: 5,
+      onStdout: () => {},
+    });
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+  });
+
+  it('keeps the deadline armed when a follow failed and the process is still running', async () => {
+    // A dropped follow is not an exit, so the timeout is still the only thing
+    // that will stop the command.
+    const fake = fakeSandbox({
+      // eslint-disable-next-line require-yield
+      followStdout: async function* () {
+        throw new Error('connection reset');
+      },
+      getProcess: vi.fn(async () => ({ status: 'running' })),
+      getStdout: async () => ({ lines: ['tick 1'] }),
+    });
+
+    const result = await streamTensorlakeCommand(fake.sandbox, 'sleep 600', {
+      timeout: 30,
+      onStdout: () => {},
+    });
+
+    expect(fake.sandbox.killProcess).toHaveBeenCalledWith(7);
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+  });
+
   it('reports a process that could not be started', async () => {
     const fake = fakeSandbox({
       startProcess: vi.fn(async () => {

--- a/packages/tensorlake/src/index.ts
+++ b/packages/tensorlake/src/index.ts
@@ -9,6 +9,7 @@
 import { Sandbox, SandboxStatus, OutputMode } from "tensorlake";
 import type { SandboxInfo } from "tensorlake";
 import { defineProvider } from "@computesdk/provider";
+import { streamTensorlakeCommand } from "./streaming";
 import type {
   CodeResult,
   CommandResult,
@@ -221,6 +222,17 @@ export const tensorlake = defineProvider<
           };
         }
       },
+
+      // Native streaming: `run()` returns a command's output only once it has
+      // exited, so a long step would look dead until it finished. Following the
+      // process instead delivers each line as it is written, and does it over
+      // the management API rather than a port exposed on the sandbox.
+      streamCommand: async (
+        ctx: TensorlakeSandboxContext,
+        command: string,
+        options: RunCommandOptions,
+      ): Promise<CommandResult> =>
+        await streamTensorlakeCommand(ctx.sandbox, command, options),
 
       getInfo: async (
         ctx: TensorlakeSandboxContext,

--- a/packages/tensorlake/src/streaming.ts
+++ b/packages/tensorlake/src/streaming.ts
@@ -129,13 +129,30 @@ export async function streamTensorlakeCommand(
   const controller = new AbortController();
 
   let timedOut = false;
-  const timer =
+  let exited = false;
+  // The deadline kills the process and then abandons the follow streams, so a
+  // kill that never lands can't hold the caller open past its timeout. It is
+  // disarmed the moment the process is known to have exited, so the exit status
+  // can be read at leisure without a late deadline claiming a finished command.
+  let timer: ReturnType<typeof setTimeout> | undefined =
     options.timeout === undefined
       ? undefined
       : setTimeout(() => {
+          if (exited) return;
           timedOut = true;
-          void sandbox.killProcess(process.pid).catch(() => {});
+          void Promise.resolve()
+            .then(() => sandbox.killProcess(process.pid))
+            .catch(() => {})
+            .finally(() => controller.abort());
         }, options.timeout);
+
+  const disarm = () => {
+    exited = true;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
 
   try {
     const [stdoutPump, stderrPump] = await Promise.all([
@@ -149,14 +166,27 @@ export async function streamTensorlakeCommand(
       }),
     ]);
 
-    let info = await sandbox.getProcess(process.pid);
+    // Both streams have ended, so the process is gone and the deadline no longer
+    // applies to it.
+    disarm();
+
+    const status = () =>
+      sandbox
+        .getProcess(process.pid)
+        .catch(() => ({ status: ProcessStatus.RUNNING as string }));
+
+    let info: { status: string; exitCode?: number } = await status();
+    // A timed-out command's exit status is not worth waiting for: it is reported
+    // as a timeout either way, and waiting is what the deadline just refused.
     for (
       let attempt = 0;
-      attempt < EXIT_POLL_ATTEMPTS && info.status === ProcessStatus.RUNNING;
+      !timedOut &&
+      attempt < EXIT_POLL_ATTEMPTS &&
+      info.status === ProcessStatus.RUNNING;
       attempt += 1
     ) {
       await sleep(EXIT_POLL_INTERVAL_MS);
-      info = await sandbox.getProcess(process.pid);
+      info = await status();
     }
 
     if (stdoutPump.failed) {
@@ -186,6 +216,6 @@ export async function streamTensorlakeCommand(
       durationMs: durationMs(),
     };
   } finally {
-    if (timer) clearTimeout(timer);
+    disarm();
   }
 }

--- a/packages/tensorlake/src/streaming.ts
+++ b/packages/tensorlake/src/streaming.ts
@@ -10,19 +10,23 @@
  *
  * So this streams the way Tensorlake means output to be streamed: start the
  * process, follow its stdout and stderr, and read the exit status when they end.
- * Nothing is exposed, and callbacks fire line by line while the command runs
- * rather than once it exits.
+ * The lifecycle around that — deadline, kill, exit polling, recovering from a
+ * dropped follow — is the framework's `streamCommandViaProcess`; this file is
+ * only the mapping onto Tensorlake's process calls.
  */
 
 import { OutputMode, ProcessStatus } from "tensorlake";
-import type { CommandResult, RunCommandOptions } from "@computesdk/provider";
+import {
+  streamCommandViaProcess,
+  TIMEOUT_EXIT_CODE,
+} from "@computesdk/provider";
+import type {
+  CommandResult,
+  RunCommandOptions,
+  StreamedProcess,
+} from "@computesdk/provider";
 
-/** How long to keep asking for an exit code once both streams have ended. */
-const EXIT_POLL_ATTEMPTS = 25;
-const EXIT_POLL_INTERVAL_MS = 200;
-
-/** Exit code reported when the command was killed for exceeding its timeout. */
-export const TIMEOUT_EXIT_CODE = 124;
+export { TIMEOUT_EXIT_CODE };
 
 /**
  * The part of Tensorlake's `Sandbox` this needs. Structural rather than the SDK
@@ -53,45 +57,17 @@ export interface StreamableTensorlakeSandbox {
   killProcess(pid: number): Promise<void>;
 }
 
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-/**
- * Follows one stream, handing every line to the caller as it arrives. A follow
- * that fails part way through is reported rather than thrown: the process is
- * still running and its output is still retrievable, so the missing tail is
- * backfilled from the daemon's buffer once it exits.
- */
-async function pump(
+/** Tensorlake follows output by line; the helper works in text. */
+async function* lines(
   events: AsyncIterable<{ line: string }>,
-  onText: (text: string) => void,
-): Promise<{ failed: boolean }> {
-  try {
-    for await (const event of events) {
-      onText(`${event.line}\n`);
-    }
-    return { failed: false };
-  } catch {
-    return { failed: true };
+): AsyncIterable<string> {
+  for await (const event of events) {
+    yield `${event.line}\n`;
   }
 }
 
-/**
- * Emits whatever the buffered output has beyond what was seen on the wire.
- * Compares lengths rather than content — it is the same byte sequence, and the
- * length is the only question a backfill has to answer.
- */
-function backfill(
-  buffered: string[],
-  streamed: string,
-  emit: (text: string) => void,
-): string {
-  const complete = buffered.length === 0 ? "" : `${buffered.join("\n")}\n`;
-  if (complete.length <= streamed.length) return streamed;
-  const missing = complete.slice(streamed.length);
-  emit(missing);
-  return complete;
-}
+const joinLines = (buffered: string[]): string =>
+  buffered.length === 0 ? "" : `${buffered.join("\n")}\n`;
 
 /**
  * Runs `command` under `sh -c`, streaming its output through the callbacks, and
@@ -102,12 +78,8 @@ export async function streamTensorlakeCommand(
   command: string,
   options: RunCommandOptions,
 ): Promise<CommandResult> {
-  const startTime = Date.now();
-  const durationMs = () => Date.now() - startTime;
-
-  let process: { pid: number };
-  try {
-    process = await sandbox.startProcess("sh", {
+  return await streamCommandViaProcess(async (): Promise<StreamedProcess> => {
+    const { pid } = await sandbox.startProcess("sh", {
       args: ["-c", command],
       stdoutMode: OutputMode.CAPTURE,
       stderrMode: OutputMode.CAPTURE,
@@ -115,113 +87,20 @@ export async function streamTensorlakeCommand(
         Object.keys(options.env).length > 0 && { env: options.env }),
       ...(options.cwd && { workingDir: options.cwd }),
     });
-  } catch (error) {
+
     return {
-      stdout: "",
-      stderr: error instanceof Error ? error.message : String(error),
-      exitCode: 127,
-      durationMs: durationMs(),
+      followStdout: (signal) => lines(sandbox.followStdout(pid, { signal })),
+      followStderr: (signal) => lines(sandbox.followStderr(pid, { signal })),
+      status: async () => {
+        const info = await sandbox.getProcess(pid);
+        return {
+          running: info.status === ProcessStatus.RUNNING,
+          exitCode: info.exitCode,
+        };
+      },
+      kill: async () => await sandbox.killProcess(pid),
+      bufferedStdout: async () => joinLines((await sandbox.getStdout(pid)).lines),
+      bufferedStderr: async () => joinLines((await sandbox.getStderr(pid)).lines),
     };
-  }
-
-  let stdout = "";
-  let stderr = "";
-  const controller = new AbortController();
-
-  let timedOut = false;
-  let exited = false;
-  // The deadline abandons the follow streams first and only then asks for the
-  // kill, so neither a kill that fails nor one that never answers can hold the
-  // caller open past its timeout. It is disarmed once the process is known to
-  // have exited, so the exit status can be read at leisure without a late
-  // deadline claiming a finished command.
-  let timer: ReturnType<typeof setTimeout> | undefined =
-    options.timeout === undefined
-      ? undefined
-      : setTimeout(() => {
-          if (exited) return;
-          timedOut = true;
-          controller.abort();
-          void sandbox.killProcess(process.pid).catch(() => {});
-        }, options.timeout);
-
-  const disarm = () => {
-    exited = true;
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      timer = undefined;
-    }
-  };
-
-  try {
-    const [stdoutPump, stderrPump] = await Promise.all([
-      pump(sandbox.followStdout(process.pid, { signal: controller.signal }), (text) => {
-        stdout += text;
-        options.onStdout?.(text);
-      }),
-      pump(sandbox.followStderr(process.pid, { signal: controller.signal }), (text) => {
-        stderr += text;
-        options.onStderr?.(text);
-      }),
-    ]);
-
-    // A stream can end for two reasons, and they mean opposite things. If both
-    // ended cleanly the process has exited, so the deadline no longer applies to
-    // it. If either *failed*, the process is very likely still running — the
-    // deadline is still the only thing that will stop it, and its exit is worth
-    // waiting for however long the caller allowed.
-    const lostStream = stdoutPump.failed || stderrPump.failed;
-    if (!lostStream) disarm();
-
-    const status = () =>
-      sandbox
-        .getProcess(process.pid)
-        .catch(() => ({ status: ProcessStatus.RUNNING as string }));
-
-    let info: { status: string; exitCode?: number } = await status();
-    // A timed-out command's exit status is not worth waiting for: it is reported
-    // as a timeout either way, and waiting is what the deadline just refused.
-    const attempts =
-      lostStream && options.timeout !== undefined
-        ? Number.POSITIVE_INFINITY
-        : EXIT_POLL_ATTEMPTS;
-    for (
-      let attempt = 0;
-      !timedOut && attempt < attempts && info.status === ProcessStatus.RUNNING;
-      attempt += 1
-    ) {
-      await sleep(EXIT_POLL_INTERVAL_MS);
-      info = await status();
-    }
-    disarm();
-
-    if (stdoutPump.failed) {
-      const buffered = await sandbox
-        .getStdout(process.pid)
-        .catch(() => ({ lines: [] as string[] }));
-      stdout = backfill(buffered.lines, stdout, (text) => options.onStdout?.(text));
-    }
-    if (stderrPump.failed) {
-      const buffered = await sandbox
-        .getStderr(process.pid)
-        .catch(() => ({ lines: [] as string[] }));
-      stderr = backfill(buffered.lines, stderr, (text) => options.onStderr?.(text));
-    }
-
-    const exitCode = timedOut
-      ? TIMEOUT_EXIT_CODE
-      : (info.exitCode ?? (info.status === ProcessStatus.RUNNING ? -1 : 0));
-
-    return { stdout, stderr, exitCode, durationMs: durationMs() };
-  } catch (error) {
-    controller.abort();
-    return {
-      stdout,
-      stderr: stderr + (error instanceof Error ? error.message : String(error)),
-      exitCode: 127,
-      durationMs: durationMs(),
-    };
-  } finally {
-    disarm();
-  }
+  }, options);
 }

--- a/packages/tensorlake/src/streaming.ts
+++ b/packages/tensorlake/src/streaming.ts
@@ -1,0 +1,191 @@
+/**
+ * Live command output for Tensorlake, over Tensorlake's own API.
+ *
+ * The framework's default way to stream a command is the daemond bridge: it
+ * seeds a daemon inside the sandbox and reads its SSE endpoint over an HTTP port
+ * exposed by the provider. A Tensorlake sandbox reaches that port only through
+ * `<port>-<sandbox-id>.<ingress>`, which requires the port to be added to the
+ * proxy allowlist and its auth relaxed — a publicly routable port per CI job for
+ * output the management API already has.
+ *
+ * So this streams the way Tensorlake means output to be streamed: start the
+ * process, follow its stdout and stderr, and read the exit status when they end.
+ * Nothing is exposed, and callbacks fire line by line while the command runs
+ * rather than once it exits.
+ */
+
+import { OutputMode, ProcessStatus } from "tensorlake";
+import type { CommandResult, RunCommandOptions } from "@computesdk/provider";
+
+/** How long to keep asking for an exit code once both streams have ended. */
+const EXIT_POLL_ATTEMPTS = 25;
+const EXIT_POLL_INTERVAL_MS = 200;
+
+/** Exit code reported when the command was killed for exceeding its timeout. */
+export const TIMEOUT_EXIT_CODE = 124;
+
+/**
+ * The part of Tensorlake's `Sandbox` this needs. Structural rather than the SDK
+ * class so a test can hand over a fake process without a sandbox.
+ */
+export interface StreamableTensorlakeSandbox {
+  startProcess(
+    command: string,
+    options?: {
+      args?: string[];
+      env?: Record<string, string>;
+      workingDir?: string;
+      stdoutMode?: OutputMode;
+      stderrMode?: OutputMode;
+    },
+  ): Promise<{ pid: number }>;
+  followStdout(
+    pid: number,
+    options?: { signal?: AbortSignal },
+  ): AsyncIterable<{ line: string }>;
+  followStderr(
+    pid: number,
+    options?: { signal?: AbortSignal },
+  ): AsyncIterable<{ line: string }>;
+  getProcess(pid: number): Promise<{ status: string; exitCode?: number }>;
+  getStdout(pid: number): Promise<{ lines: string[] }>;
+  getStderr(pid: number): Promise<{ lines: string[] }>;
+  killProcess(pid: number): Promise<void>;
+}
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Follows one stream, handing every line to the caller as it arrives. A follow
+ * that fails part way through is reported rather than thrown: the process is
+ * still running and its output is still retrievable, so the missing tail is
+ * backfilled from the daemon's buffer once it exits.
+ */
+async function pump(
+  events: AsyncIterable<{ line: string }>,
+  onText: (text: string) => void,
+): Promise<{ failed: boolean }> {
+  try {
+    for await (const event of events) {
+      onText(`${event.line}\n`);
+    }
+    return { failed: false };
+  } catch {
+    return { failed: true };
+  }
+}
+
+/**
+ * Emits whatever the buffered output has beyond what was seen on the wire.
+ * Compares lengths rather than content — it is the same byte sequence, and the
+ * length is the only question a backfill has to answer.
+ */
+function backfill(
+  buffered: string[],
+  streamed: string,
+  emit: (text: string) => void,
+): string {
+  const complete = buffered.length === 0 ? "" : `${buffered.join("\n")}\n`;
+  if (complete.length <= streamed.length) return streamed;
+  const missing = complete.slice(streamed.length);
+  emit(missing);
+  return complete;
+}
+
+/**
+ * Runs `command` under `sh -c`, streaming its output through the callbacks, and
+ * resolves with the same shape as a non-streaming run.
+ */
+export async function streamTensorlakeCommand(
+  sandbox: StreamableTensorlakeSandbox,
+  command: string,
+  options: RunCommandOptions,
+): Promise<CommandResult> {
+  const startTime = Date.now();
+  const durationMs = () => Date.now() - startTime;
+
+  let process: { pid: number };
+  try {
+    process = await sandbox.startProcess("sh", {
+      args: ["-c", command],
+      stdoutMode: OutputMode.CAPTURE,
+      stderrMode: OutputMode.CAPTURE,
+      ...(options.env &&
+        Object.keys(options.env).length > 0 && { env: options.env }),
+      ...(options.cwd && { workingDir: options.cwd }),
+    });
+  } catch (error) {
+    return {
+      stdout: "",
+      stderr: error instanceof Error ? error.message : String(error),
+      exitCode: 127,
+      durationMs: durationMs(),
+    };
+  }
+
+  let stdout = "";
+  let stderr = "";
+  const controller = new AbortController();
+
+  let timedOut = false;
+  const timer =
+    options.timeout === undefined
+      ? undefined
+      : setTimeout(() => {
+          timedOut = true;
+          void sandbox.killProcess(process.pid).catch(() => {});
+        }, options.timeout);
+
+  try {
+    const [stdoutPump, stderrPump] = await Promise.all([
+      pump(sandbox.followStdout(process.pid, { signal: controller.signal }), (text) => {
+        stdout += text;
+        options.onStdout?.(text);
+      }),
+      pump(sandbox.followStderr(process.pid, { signal: controller.signal }), (text) => {
+        stderr += text;
+        options.onStderr?.(text);
+      }),
+    ]);
+
+    let info = await sandbox.getProcess(process.pid);
+    for (
+      let attempt = 0;
+      attempt < EXIT_POLL_ATTEMPTS && info.status === ProcessStatus.RUNNING;
+      attempt += 1
+    ) {
+      await sleep(EXIT_POLL_INTERVAL_MS);
+      info = await sandbox.getProcess(process.pid);
+    }
+
+    if (stdoutPump.failed) {
+      const buffered = await sandbox
+        .getStdout(process.pid)
+        .catch(() => ({ lines: [] as string[] }));
+      stdout = backfill(buffered.lines, stdout, (text) => options.onStdout?.(text));
+    }
+    if (stderrPump.failed) {
+      const buffered = await sandbox
+        .getStderr(process.pid)
+        .catch(() => ({ lines: [] as string[] }));
+      stderr = backfill(buffered.lines, stderr, (text) => options.onStderr?.(text));
+    }
+
+    const exitCode = timedOut
+      ? TIMEOUT_EXIT_CODE
+      : (info.exitCode ?? (info.status === ProcessStatus.RUNNING ? -1 : 0));
+
+    return { stdout, stderr, exitCode, durationMs: durationMs() };
+  } catch (error) {
+    controller.abort();
+    return {
+      stdout,
+      stderr: stderr + (error instanceof Error ? error.message : String(error)),
+      exitCode: 127,
+      durationMs: durationMs(),
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/tensorlake/src/streaming.ts
+++ b/packages/tensorlake/src/streaming.ts
@@ -130,20 +130,19 @@ export async function streamTensorlakeCommand(
 
   let timedOut = false;
   let exited = false;
-  // The deadline kills the process and then abandons the follow streams, so a
-  // kill that never lands can't hold the caller open past its timeout. It is
-  // disarmed the moment the process is known to have exited, so the exit status
-  // can be read at leisure without a late deadline claiming a finished command.
+  // The deadline abandons the follow streams first and only then asks for the
+  // kill, so neither a kill that fails nor one that never answers can hold the
+  // caller open past its timeout. It is disarmed once the process is known to
+  // have exited, so the exit status can be read at leisure without a late
+  // deadline claiming a finished command.
   let timer: ReturnType<typeof setTimeout> | undefined =
     options.timeout === undefined
       ? undefined
       : setTimeout(() => {
           if (exited) return;
           timedOut = true;
-          void Promise.resolve()
-            .then(() => sandbox.killProcess(process.pid))
-            .catch(() => {})
-            .finally(() => controller.abort());
+          controller.abort();
+          void sandbox.killProcess(process.pid).catch(() => {});
         }, options.timeout);
 
   const disarm = () => {
@@ -166,9 +165,13 @@ export async function streamTensorlakeCommand(
       }),
     ]);
 
-    // Both streams have ended, so the process is gone and the deadline no longer
-    // applies to it.
-    disarm();
+    // A stream can end for two reasons, and they mean opposite things. If both
+    // ended cleanly the process has exited, so the deadline no longer applies to
+    // it. If either *failed*, the process is very likely still running — the
+    // deadline is still the only thing that will stop it, and its exit is worth
+    // waiting for however long the caller allowed.
+    const lostStream = stdoutPump.failed || stderrPump.failed;
+    if (!lostStream) disarm();
 
     const status = () =>
       sandbox
@@ -178,16 +181,19 @@ export async function streamTensorlakeCommand(
     let info: { status: string; exitCode?: number } = await status();
     // A timed-out command's exit status is not worth waiting for: it is reported
     // as a timeout either way, and waiting is what the deadline just refused.
+    const attempts =
+      lostStream && options.timeout !== undefined
+        ? Number.POSITIVE_INFINITY
+        : EXIT_POLL_ATTEMPTS;
     for (
       let attempt = 0;
-      !timedOut &&
-      attempt < EXIT_POLL_ATTEMPTS &&
-      info.status === ProcessStatus.RUNNING;
+      !timedOut && attempt < attempts && info.status === ProcessStatus.RUNNING;
       attempt += 1
     ) {
       await sleep(EXIT_POLL_INTERVAL_MS);
       info = await status();
     }
+    disarm();
 
     if (stdoutPump.failed) {
       const buffered = await sandbox

--- a/packages/test-utils/src/provider-test-suite.ts
+++ b/packages/test-utils/src/provider-test-suite.ts
@@ -27,6 +27,13 @@ export interface ProviderTestConfig {
   supportsGetUrl?: boolean;
   /** Base path for filesystem tests (default: '/tmp') */
   filesystemBasePath?: string;
+  /**
+   * Whether to check live command output (`onStdout`/`onStderr`). Any provider
+   * can serve it — natively via `streamCommand`, otherwise through the daemond
+   * bridge — but the bridge needs a routable port inside the sandbox, so this is
+   * opt-in per provider rather than assumed.
+   */
+  supportsStreaming?: boolean;
 }
 
 /**
@@ -43,6 +50,7 @@ export function defineProviderTests(config: ProviderTestConfig) {
     ports,
     supportsGetUrl = true,
     filesystemBasePath = '/tmp',
+    supportsStreaming = false,
   } = config;
 
   return () => {
@@ -200,6 +208,74 @@ export function defineProviderTests(config: ProviderTestConfig) {
       });
     }
 
+    if (supportsStreaming) {
+      describe('Live Command Output', () => {
+        it('should deliver output while the command is still running', async () => {
+          // The point of streaming is *when* output arrives, so the assertion is
+          // about ordering against the command's own completion rather than
+          // about the final text.
+          const chunks: string[] = [];
+          const startedAt = Date.now();
+          let firstChunkAt: number | undefined;
+
+          const result = await sandbox.runCommand(
+            `sh -c 'for i in 1 2 3 4 5; do echo tick $i; sleep 1; done'`,
+            {
+              onStdout: (text: string) => {
+                firstChunkAt ??= Date.now();
+                chunks.push(text);
+              }
+            }
+          );
+
+          expect(result.exitCode).toBe(0);
+          expect(firstChunkAt).toBeDefined();
+          // The first tick is printed immediately and the last four seconds are
+          // spent sleeping, so a first chunk that arrives in the first half of
+          // the command's life could not have been buffered until exit.
+          expect((firstChunkAt as number) - startedAt).toBeLessThan(
+            result.durationMs / 2
+          );
+          // Everything streamed is exactly what the command produced: no chunk
+          // dropped, and none delivered twice.
+          expect(chunks.join('')).toBe(result.stdout);
+          for (let i = 1; i <= 5; i += 1) {
+            expect(result.stdout).toContain(`tick ${i}`);
+          }
+        }, timeout);
+
+        it('should stream stderr separately and report a non-zero exit', async () => {
+          const out: string[] = [];
+          const err: string[] = [];
+
+          const result = await sandbox.runCommand(
+            `sh -c 'echo out; echo err 1>&2; exit 3'`,
+            {
+              onStdout: (text: string) => out.push(text),
+              onStderr: (text: string) => err.push(text)
+            }
+          );
+
+          expect(result.exitCode).toBe(3);
+          expect(out.join('')).toContain('out');
+          expect(err.join('')).toContain('err');
+          expect(out.join('')).not.toContain('err');
+        }, timeout);
+
+        it('should stop a streaming command that outruns its timeout', async () => {
+          const result = await sandbox.runCommand(
+            `sh -c 'echo starting; sleep 60'`,
+            { timeout: 5000, onStdout: () => {} }
+          );
+
+          // What matters is that it came back at the deadline rather than after
+          // the full sleep, and that it is not reported as a success.
+          expect(result.exitCode).not.toBe(0);
+          expect(result.durationMs).toBeLessThan(30000);
+        }, timeout);
+      });
+    }
+
     describe('Shell Command Argument Quoting', () => {
       it('should properly quote arguments with spaces', async () => {
         const result = await sandbox.runCommand('sh -c \'echo "hello world"\'');
@@ -249,6 +325,29 @@ function createMockSandbox(config: ProviderTestConfig): ProviderSandbox {
     getInstance: <T = unknown>(): T => ({} as T),
 
     runCommand: async (command: string, options?: RunCommandOptions): Promise<CommandResult> => {
+      // Mocked streaming: the chunks are handed over before the promise settles,
+      // which is the property the streaming tests are actually checking.
+      if (command.includes('for i in 1 2 3 4 5')) {
+        const startedAt = Date.now();
+        let stdout = '';
+        for (let i = 1; i <= 5; i += 1) {
+          const text = `tick ${i}\n`;
+          stdout += text;
+          options?.onStdout?.(text);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        return { stdout, stderr: '', exitCode: 0, durationMs: Date.now() - startedAt };
+      }
+      if (command.includes('echo err 1>&2')) {
+        options?.onStdout?.('out\n');
+        options?.onStderr?.('err\n');
+        return { stdout: 'out\n', stderr: 'err\n', exitCode: 3, durationMs: 5 };
+      }
+      if (command.includes('echo starting; sleep 60')) {
+        options?.onStdout?.('starting\n');
+        await new Promise((resolve) => setTimeout(resolve, options?.timeout ? 5 : 10));
+        return { stdout: 'starting\n', stderr: '', exitCode: 124, durationMs: 5 };
+      }
       if (command.includes('echo "Hello from command"')) {
         return { stdout: 'Hello from command\n', stderr: '', exitCode: 0, durationMs: 10 };
       }


### PR DESCRIPTION
## Summary

`runCommand`'s `onStdout`/`onStderr` are served by the daemond bridge: seed a daemon in the sandbox and read its SSE endpoint over a provider-exposed port. Several providers (Tensorlake, Runloop, …) already expose start/follow/status/kill on their management API, where no routable port is needed — so a provider can now opt out of the bridge:

```ts
// packages/provider/src/factory.ts
methods.sandbox.streamCommand?: (sandbox, command, options) => Promise<CommandResult>
// preferred whenever onStdout/onStderr is set; daemond stays the fallback
```

The hard part of using a process API is the lifecycle, not the following, and it is identical for every such provider — so it lives in the framework as `streamCommandViaProcess(start, options)`, and a provider supplies only its own calls:

```ts
interface StreamedProcess {
  followStdout(signal: AbortSignal): AsyncIterable<string>  // text, not lines
  followStderr(signal: AbortSignal): AsyncIterable<string>
  status(): Promise<{ running: boolean; exitCode?: number }> // unknown ⇒ running
  kill(): Promise<void>                                      // may reject, or never settle
  bufferedStdout?(): Promise<string>                         // for tail recovery
  bufferedStderr?(): Promise<string>
}
```

What that lifecycle gets right, since each case is a way to lose a run's output or leak a sandbox:

- **The deadline can't be held open by the kill.** It aborts the followers *first*, then fires `kill()` detached — a stop request that rejects or never answers still returns `124` on time.
- **A follow ending because it *failed* is not an exit.** `pump()` reports failure instead of throwing, so the timer is only disarmed when both followers ended cleanly; if one dropped, the deadline stays armed and `status()` is polled until the process really exits (bounded by the caller's timeout, not by `EXIT_POLL_ATTEMPTS`), so a dropped connection returns the real exit code rather than abandoning a live process.
- **Output survives that drop**: after the process is final, `buffered*()` is compared by length against what was streamed and only the missing tail is emitted, so callbacks stay append-only.
- **A finished command is never called timed out** just because its exit status was slow to read.

Tensorlake becomes the mapping and nothing else — `startProcess`/`followStdout`/`followStderr`/`getProcess`/`getStdout`/`killProcess`, plus `line => line + "\n"` so streamed text matches the buffer. Runloop's `executeAsync` + `streamStdoutUpdates` is the same shape and can adopt it without repeating any of the above.

Tests: framework-level lifecycle tests driving a fake process (incremental delivery, dropped follow, never-answering kill, slow exit status), plus the Tensorlake adapter's own; a factory test that `streamCommand` wins over the daemon path.


Link to Devin session: https://app.devin.ai/sessions/cc0540c35462491eb57cee7d793c5eb7
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/computesdk/codesmith/computesdk/pr/700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789063957&installation_model_id=431880&pr_number=700&repository=computesdk%2Fcomputesdk&return_to=https%3A%2F%2Fgithub.com%2Fcomputesdk%2Fcomputesdk%2Fpull%2F700&signature=09e6f8211eeed6f594bcea7f4f9f415b68244a5f38a10b547cfc59820fd845a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->