### PR TITLE
fix(mosaic): bound in-flight requests in the Mosaic provider

### DIFF
--- a/.changeset/mosaic-bounded-requests.md
+++ b/.changeset/mosaic-bounded-requests.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/mosaic': patch
+---
+
+Bound how many HTTP requests the Mosaic provider keeps in flight, so a burst of concurrent sandbox creates no longer becomes a burst of TLS handshakes. Configurable with `maxConcurrentRequests` (default 32; `Infinity` restores the previous behaviour).

--- a/packages/mosaic/src/__tests__/index.test.ts
+++ b/packages/mosaic/src/__tests__/index.test.ts
@@ -385,6 +385,33 @@ describe('Mosaic ComputeSDK provider', () => {
     expect(started).toBe(2);
   });
 
+  it('spends the caller timeout on the request, not on the queue', async () => {
+    let released = () => {};
+    const holder = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+    let answered = 0;
+    globalThis.fetch = vi.fn(async (_url, init?: RequestInit) => {
+      if (answered === 0) {
+        answered += 1;
+        await holder;
+      } else {
+        answered += 1;
+      }
+      expect((init?.signal as AbortSignal | undefined)?.aborted).toBe(false);
+      return json({ id: 'sbx-timeout', state: 'running', tti_ms: 4 });
+    }) as typeof fetch;
+
+    const provider = mosaic({ ...config, maxConcurrentRequests: 1 });
+    const first = provider.sandbox.create({});
+    // Queued behind a request that outlives the second caller's own deadline.
+    const second = provider.sandbox.create({ timeout: 300 });
+
+    await expect(second).resolves.toMatchObject({ sandboxId: 'sbx-timeout' });
+    released();
+    await first;
+  });
+
   it('keeps the gateway remediation in the error it throws', async () => {
     gateway({
       'POST /v1/sandboxes': () =>

--- a/packages/mosaic/src/__tests__/index.test.ts
+++ b/packages/mosaic/src/__tests__/index.test.ts
@@ -340,6 +340,51 @@ describe('Mosaic ComputeSDK provider', () => {
     await expect(provider.sandbox.destroy('gone')).resolves.toBeUndefined();
   });
 
+  it('creates a burst of sandboxes without putting every request in flight at once', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    let answer = () => {};
+    const answered = new Promise<void>((resolve) => {
+      answer = resolve;
+    });
+    globalThis.fetch = vi.fn(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await answered;
+      inFlight -= 1;
+      return json({ id: 'sbx-burst', state: 'running', tti_ms: 9 });
+    }) as typeof fetch;
+
+    const provider = mosaic({ ...config, maxConcurrentRequests: 4 });
+    const burst = Promise.all(Array.from({ length: 20 }, () => provider.sandbox.create({})));
+    // Let every create reach the queue before any of them is answered.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(peak).toBe(4);
+
+    answer();
+    await burst;
+    expect(peak).toBe(4);
+  });
+
+  it('lets a queued request through when the ones ahead of it are long-running', async () => {
+    let started = 0;
+    globalThis.fetch = vi.fn(async () => {
+      started += 1;
+      // A command that runs for minutes never frees its slot on its own.
+      await new Promise(() => {});
+      return json({});
+    }) as typeof fetch;
+
+    const provider = mosaic({ ...config, maxConcurrentRequests: 1 });
+    void provider.sandbox.create({}).catch(() => {});
+    void provider.sandbox.create({}).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(started).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(started).toBe(2);
+  });
+
   it('keeps the gateway remediation in the error it throws', async () => {
     gateway({
       'POST /v1/sandboxes': () =>

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -211,6 +211,9 @@ async function request<T>(
   timeoutMs?: number,
 ): Promise<T> {
   const resolved = resolvedConfig(config);
+  // The slot is taken before the deadline starts, so time spent queueing is
+  // not charged against the caller's timeout.
+  await takeRequestSlot(resolved.maxConcurrentRequests);
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(new Error('Mosaic API request timed out')),
@@ -219,7 +222,6 @@ async function request<T>(
   const upstreamSignal = init.signal;
   const abort = () => controller.abort(upstreamSignal?.reason);
   upstreamSignal?.addEventListener('abort', abort, { once: true });
-  await takeRequestSlot(resolved.maxConcurrentRequests);
   try {
     const response = await fetch(`${resolved.baseUrl}${path}`, {
       ...init,

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -148,16 +148,17 @@ class MosaicApiError extends Error {
   }
 }
 
+// The connections a burst opens belong to the process, not to one provider
+// object, so the count is shared; the limit is the caller's own.
 let inFlight = 0;
-let requestLimit = DEFAULT_MAX_CONCURRENT_REQUESTS;
 const queued: Array<() => void> = [];
 
 /**
  * Waits for room among the in-flight requests, or for the grace period,
  * whichever comes first.
  */
-async function takeRequestSlot(): Promise<void> {
-  if (inFlight < requestLimit) {
+async function takeRequestSlot(limit: number): Promise<void> {
+  if (inFlight < limit) {
     inFlight += 1;
     return;
   }
@@ -218,8 +219,7 @@ async function request<T>(
   const upstreamSignal = init.signal;
   const abort = () => controller.abort(upstreamSignal?.reason);
   upstreamSignal?.addEventListener('abort', abort, { once: true });
-  requestLimit = resolved.maxConcurrentRequests;
-  await takeRequestSlot();
+  await takeRequestSlot(resolved.maxConcurrentRequests);
   try {
     const response = await fetch(`${resolved.baseUrl}${path}`, {
       ...init,

--- a/packages/mosaic/src/index.ts
+++ b/packages/mosaic/src/index.ts
@@ -14,6 +14,11 @@ import type {
 
 const PROVIDER = 'mosaic' as const;
 const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 32;
+// A queued request gives up its place rather than wait indefinitely, so a
+// caller whose requests are all long-running keeps its concurrency: the queue
+// smooths a burst of connection setups, it does not cap throughput.
+const REQUEST_QUEUE_GRACE_MS = 1_000;
 const COMMAND_HTTP_TIMEOUT_BUFFER_MS = 5_000;
 const BUILD_TIMEOUT_MS = 20 * 60 * 1000;
 const BUILD_POLL_INTERVAL_MS = 2_000;
@@ -34,6 +39,13 @@ export interface MosaicConfig {
   vcpu?: number;
   /** HTTP request timeout. */
   requestTimeoutMs?: number;
+  /**
+   * How many HTTP requests this client keeps in flight before it starts
+   * queueing. `fetch` opens a connection per in-flight request, so an
+   * unbounded client answers a burst of sandbox creates with a burst of TLS
+   * handshakes. Defaults to 32; Infinity restores the unbounded behaviour.
+   */
+  maxConcurrentRequests?: number;
   /** Give sandboxes egress. On by default; installs and fetches need it. */
   networkEnabled?: boolean;
   /** How long a preview URL from getUrl stays valid. */
@@ -136,6 +148,39 @@ class MosaicApiError extends Error {
   }
 }
 
+let inFlight = 0;
+let requestLimit = DEFAULT_MAX_CONCURRENT_REQUESTS;
+const queued: Array<() => void> = [];
+
+/**
+ * Waits for room among the in-flight requests, or for the grace period,
+ * whichever comes first.
+ */
+async function takeRequestSlot(): Promise<void> {
+  if (inFlight < requestLimit) {
+    inFlight += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const proceed = () => {
+      clearTimeout(timer);
+      const waiting = queued.indexOf(proceed);
+      if (waiting >= 0) queued.splice(waiting, 1);
+      resolve();
+    };
+    const timer = setTimeout(proceed, REQUEST_QUEUE_GRACE_MS);
+    // Node keeps the process alive for a pending timer it does not need to.
+    (timer as unknown as { unref?: () => void }).unref?.();
+    queued.push(proceed);
+  });
+  inFlight += 1;
+}
+
+function releaseRequestSlot(): void {
+  inFlight -= 1;
+  queued.shift()?.();
+}
+
 function env(name: string): string | undefined {
   return typeof process === 'undefined' ? undefined : process.env?.[name];
 }
@@ -152,6 +197,7 @@ function resolvedConfig(config: MosaicConfig): Required<MosaicConfig> {
     memoryMb: config.memoryMb ?? 4096,
     vcpu: config.vcpu ?? 2,
     requestTimeoutMs: config.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxConcurrentRequests: config.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS,
     networkEnabled: config.networkEnabled ?? true,
     previewExpiresInSeconds: config.previewExpiresInSeconds ?? 3600,
   };
@@ -172,6 +218,8 @@ async function request<T>(
   const upstreamSignal = init.signal;
   const abort = () => controller.abort(upstreamSignal?.reason);
   upstreamSignal?.addEventListener('abort', abort, { once: true });
+  requestLimit = resolved.maxConcurrentRequests;
+  await takeRequestSlot();
   try {
     const response = await fetch(`${resolved.baseUrl}${path}`, {
       ...init,
@@ -196,6 +244,7 @@ async function request<T>(
     }
     return (body ? JSON.parse(body) : undefined) as T;
   } finally {
+    releaseRequestSlot();
     clearTimeout(timer);
     upstreamSignal?.removeEventListener('abort', abort);
   }


### PR DESCRIPTION
## Summary

The Mosaic provider calls global `fetch` once per operation, and `fetch` opens a connection per in-flight request. Creating many sandboxes concurrently therefore performs that many TLS handshakes at once from a single process, which dominates latency well before the service does.

This keeps at most `maxConcurrentRequests` requests in flight (default 32) and queues the rest:

    await takeRequestSlot(resolved.maxConcurrentRequests);
    try { await fetch(...) } finally { releaseRequestSlot(); }

A queued request waits at most `REQUEST_QUEUE_GRACE_MS` (1s) and then proceeds regardless, so the queue smooths connection setup without capping how much long-running work a caller may have outstanding. `maxConcurrentRequests: Infinity` restores the previous behaviour. The in-flight count is per process, since that is what owns the connections; the limit comes from each caller's own config.

Tests cover both: 20 concurrent creates against a limit of 4 never exceed 4 in flight, and a request queued behind one that never resolves starts after the grace period. `pnpm build`, `test`, `typecheck` and `lint` pass for the package. A patch changeset is included.