### PR TITLE
chore: add changesets for opencomputer and createos-sandbox releases

### DIFF
--- a/.changeset/createos-sandbox-bump.md
+++ b/.changeset/createos-sandbox-bump.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/createos-sandbox": patch
+---
+
+Bump `@nodeops-createos/sandbox` to `^0.8.1`.

--- a/.changeset/createos-sandbox-bump.md
+++ b/.changeset/createos-sandbox-bump.md
@@ -1,5 +1,6 @@
 ---
 "@computesdk/createos-sandbox": patch
+"@computesdk/opencomputer": patch
 ---
 
-Bump `@nodeops-createos/sandbox` to `^0.8.1`.
+Bump `@nodeops-createos/sandbox` to `^0.8.1` and track `latest` for `@opencomputer/sdk`.


### PR DESCRIPTION
## Summary

Adds a patch changeset for `@computesdk/createos-sandbox` and `@computesdk/opencomputer` so the release tooling includes both dependency updates in the next release:

- `@computesdk/createos-sandbox`: `@nodeops-createos/sandbox` `^0.8.1` (from #706)
- `@computesdk/opencomputer`: `@opencomputer/sdk` `latest` (from #705)

Link to Devin session: https://app.devin.ai/sessions/f99333ce82814181b417436e989128f3
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->