### PR TITLE
Modernize the Runloop adapter

### DIFF
--- a/.changeset/modern-runloop-adapter.md
+++ b/.changeset/modern-runloop-adapter.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/runloop": patch
+---
+
+Modernize Runloop command execution, streaming, filesystem operations, lifecycle handling, pagination, errors, and snapshots using `@runloop/api-client` 1.28.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "pnpm -r run clean",
     "dev": "pnpm -r --parallel run dev",
     "lint": "pnpm -r run lint",
-    "test": "pnpm --filter '@computesdk/cmd' --filter '@computesdk/provider' --filter 'computesdk' --filter '@computesdk/events' --filter '@computesdk/docker' run test && pnpm --filter daemond run test:integration",
+    "test": "pnpm --filter '@computesdk/cmd' --filter '@computesdk/provider' --filter 'computesdk' --filter '@computesdk/events' --filter '@computesdk/docker' --filter '@computesdk/runloop' run test && pnpm --filter daemond run test:integration",
     "test:watch": "pnpm -r --parallel run test:watch",
     "test:coverage": "pnpm -r run test:coverage",
     "typecheck": "pnpm --filter '@computesdk/cmd' --filter '@computesdk/provider' --filter 'computesdk' --filter '@computesdk/events' --filter '@computesdk/workbench' --filter '@computesdk/docker' --filter 'daemond' run typecheck",

--- a/packages/runloop/package.json
+++ b/packages/runloop/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@runloop/api-client": "^1.24.0",
+    "@runloop/api-client": "^1.28.0",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -487,6 +487,7 @@ describe("Runloop filesystem", () => {
       { name: names[1], type: "directory", size: 4096, modified: new Date(1_710_000_001_000) },
     ]);
     expect(mocks.command.exec.mock.calls[0][0]).toContain("find -- '/tmp/a path/'\"'\"'quoted'\"'\"'\nroot'");
+    expect(mocks.command.exec.mock.calls[0][0]).toContain("for entry; do\n");
     expect(mocks.command.exec.mock.calls[0][0]).not.toContain("ls -la");
   });
 

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -111,7 +111,12 @@ beforeEach(() => {
   mocks.executions.streamStderrUpdates.mockResolvedValue(paginated([]));
   mocks.command.exec.mockResolvedValue(result());
   mocks.file.read.mockResolvedValue("");
-  mocks.file.write.mockResolvedValue(undefined);
+  mocks.file.write.mockResolvedValue({
+    devbox_id: "devbox-1",
+    exit_status: 0,
+    stderr: "",
+    stdout: "",
+  });
   mocks.blueprints.list.mockReturnValue(paginated([]));
 });
 
@@ -468,6 +473,19 @@ describe("Runloop filesystem", () => {
     expect(mocks.file.read).toHaveBeenCalledWith({ file_path: hostilePath });
     expect(read).toBe(content);
     expect(mocks.command.exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects a failed native file write", async () => {
+    mocks.file.write.mockResolvedValueOnce({
+      devbox_id: "devbox-1",
+      exit_status: 13,
+      stderr: "permission denied",
+      stdout: "",
+    });
+    const { sandbox } = await getSandbox();
+
+    await expect(sandbox.filesystem.writeFile("/root/blocked", "content"))
+      .rejects.toThrow("Failed to write file /root/blocked: permission denied");
   });
 
   it("decodes structured directory metadata including newline-containing names", async () => {

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -222,7 +222,7 @@ describe("Runloop command execution", () => {
     expect(onStdout).toHaveBeenCalledWith("before-timeout\n");
   });
 
-  it("bounds async execution creation with the command deadline", async () => {
+  it("returns at the deadline while retaining late execution IDs for cleanup", async () => {
     vi.useFakeTimers();
     let resolveExecution!: (execution: {
       executionId: string;
@@ -231,7 +231,7 @@ describe("Runloop command execution", () => {
     mocks.command.execAsync.mockImplementation((_command, _params, requestOptions) =>
       new Promise((resolve) => {
         resolveExecution = resolve;
-        expect(requestOptions.timeout).toBe(50);
+        expect(requestOptions).toBeUndefined();
       }),
     );
     const { sandbox } = await getSandbox();
@@ -244,7 +244,6 @@ describe("Runloop command execution", () => {
       exitCode: 124,
       durationMs: 50,
     });
-    expect(mocks.command.execAsync.mock.calls[0][2].signal.aborted).toBe(true);
 
     resolveExecution({
       executionId: "exec-created-late",

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -10,6 +10,11 @@ const mocks = vi.hoisted(() => {
     write: vi.fn(),
   };
   const nativeDevbox = { command, cmd: command, file };
+  const executions = {
+    kill: vi.fn(),
+    streamStdoutUpdates: vi.fn(),
+    streamStderrUpdates: vi.fn(),
+  };
   const devboxes = {
     createAndAwaitRunning: vi.fn(),
     retrieve: vi.fn(),
@@ -19,6 +24,7 @@ const mocks = vi.hoisted(() => {
     snapshotDisk: vi.fn(),
     listDiskSnapshots: vi.fn(),
     deleteDiskSnapshot: vi.fn(),
+    executions,
   };
   const blueprints = {
     create: vi.fn(),
@@ -29,7 +35,7 @@ const mocks = vi.hoisted(() => {
     api: { devboxes, blueprints },
     devbox: { fromId: vi.fn(() => nativeDevbox) },
   };
-  return { command, file, nativeDevbox, devboxes, blueprints, client };
+  return { command, file, nativeDevbox, executions, devboxes, blueprints, client };
 });
 
 vi.mock("@runloop/api-client", () => ({
@@ -100,6 +106,9 @@ beforeEach(() => {
   mocks.devboxes.shutdown.mockResolvedValue(devbox("shutdown"));
   mocks.devboxes.snapshotDisk.mockResolvedValue(snapshot("snapshot-created"));
   mocks.devboxes.listDiskSnapshots.mockReturnValue(paginated([]));
+  mocks.executions.kill.mockResolvedValue(undefined);
+  mocks.executions.streamStdoutUpdates.mockResolvedValue(paginated([]));
+  mocks.executions.streamStderrUpdates.mockResolvedValue(paginated([]));
   mocks.command.exec.mockResolvedValue(result());
   mocks.file.read.mockResolvedValue("");
   mocks.file.write.mockResolvedValue(undefined);
@@ -167,25 +176,41 @@ describe("Runloop command execution", () => {
 
   it("cancels a timed-out async execution, returns 124, and stops callbacks", async () => {
     vi.useFakeTimers();
-    let streamingParams: { stdout?: (chunk: string) => void } = {};
-    const kill = vi.fn().mockResolvedValue(undefined);
-    const pendingResult = new Promise<never>(() => {});
-    mocks.command.execAsync.mockImplementation(async (_command, params) => {
-      streamingParams = params;
-      return { result: () => pendingResult, kill };
+    mocks.executions.kill.mockRejectedValueOnce(new Error("kill request failed"));
+    mocks.executions.streamStdoutUpdates.mockImplementation(async (
+      _devboxId,
+      _executionId,
+      _params,
+      requestOptions,
+    ) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { output: "before-timeout\n" };
+        await new Promise<void>((resolve) => {
+          requestOptions.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { output: "after-timeout\n" };
+      },
+    }));
+    mocks.command.execAsync.mockResolvedValue({
+      executionId: "exec-1",
+      result: ({ signal }: { signal: AbortSignal }) => new Promise((_, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("monitor aborted")), { once: true });
+      }),
     });
     const onStdout = vi.fn();
     const { sandbox } = await getSandbox();
 
     const running = sandbox.runCommand("sleep 60", { timeout: 50, onStdout });
     await vi.advanceTimersByTimeAsync(10);
-    streamingParams.stdout?.("before-timeout\n");
     await vi.advanceTimersByTimeAsync(40);
     const commandResult = await running;
-    streamingParams.stdout?.("after-timeout\n");
 
     expect(commandResult.exitCode).toBe(124);
-    expect(kill).toHaveBeenCalledOnce();
+    expect(mocks.executions.kill).toHaveBeenCalledWith(
+      "devbox-1",
+      "exec-1",
+      { kill_process_group: true },
+    );
     expect(onStdout).toHaveBeenCalledTimes(1);
     expect(onStdout).toHaveBeenCalledWith("before-timeout\n");
   });
@@ -214,6 +239,22 @@ describe("Runloop lifecycle and listing", () => {
         },
       }),
       { longPoll: { timeoutMs: 2_500 } },
+    );
+
+    await provider.sandbox.create({
+      launch_parameters: {
+        keep_alive_time_seconds: 999,
+        resource_size_request: "LARGE",
+      },
+    });
+    expect(mocks.devboxes.createAndAwaitRunning).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        launch_parameters: {
+          keep_alive_time_seconds: 999,
+          resource_size_request: "LARGE",
+        },
+      }),
+      undefined,
     );
   });
 

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -222,6 +222,42 @@ describe("Runloop command execution", () => {
     expect(onStdout).toHaveBeenCalledWith("before-timeout\n");
   });
 
+  it("bounds async execution creation with the command deadline", async () => {
+    vi.useFakeTimers();
+    let resolveExecution!: (execution: {
+      executionId: string;
+      result: ReturnType<typeof vi.fn>;
+    }) => void;
+    mocks.command.execAsync.mockImplementation((_command, _params, requestOptions) =>
+      new Promise((resolve) => {
+        resolveExecution = resolve;
+        expect(requestOptions.timeout).toBe(50);
+      }),
+    );
+    const { sandbox } = await getSandbox();
+
+    const running = sandbox.runCommand("slow-to-start", { timeout: 50 });
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(running).resolves.toMatchObject({
+      stdout: "",
+      stderr: "",
+      exitCode: 124,
+      durationMs: 50,
+    });
+    expect(mocks.command.execAsync.mock.calls[0][2].signal.aborted).toBe(true);
+
+    resolveExecution({
+      executionId: "exec-created-late",
+      result: vi.fn(),
+    });
+    await vi.runAllTimersAsync();
+    expect(mocks.executions.kill).toHaveBeenCalledWith(
+      "devbox-1",
+      "exec-created-late",
+      { kill_process_group: true },
+    );
+  });
+
   it("aborts monitor streams after completion and emits output missing from callbacks", async () => {
     let resolveResult!: (value: ReturnType<typeof result>) => void;
     mocks.executions.streamStdoutUpdates.mockResolvedValue({

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -206,6 +206,8 @@ describe("Runloop command execution", () => {
     const commandResult = await running;
 
     expect(commandResult.exitCode).toBe(124);
+    expect(commandResult.stdout).toBe("before-timeout\n");
+    expect(commandResult.stderr).toBe("");
     expect(mocks.executions.kill).toHaveBeenCalledWith(
       "devbox-1",
       "exec-1",
@@ -213,6 +215,33 @@ describe("Runloop command execution", () => {
     );
     expect(onStdout).toHaveBeenCalledTimes(1);
     expect(onStdout).toHaveBeenCalledWith("before-timeout\n");
+  });
+
+  it("aborts monitor streams after completion and emits output missing from callbacks", async () => {
+    let resolveResult!: (value: ReturnType<typeof result>) => void;
+    mocks.executions.streamStdoutUpdates.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { output: "streamed\n" };
+        await new Promise<void>((resolve) => {
+          const signal = mocks.executions.streamStdoutUpdates.mock.calls.at(-1)?.[3].signal;
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    });
+    mocks.command.execAsync.mockResolvedValue({
+      executionId: "exec-complete",
+      result: () => new Promise((resolve) => { resolveResult = resolve; }),
+    });
+    const onStdout = vi.fn();
+    const { sandbox } = await getSandbox();
+
+    const running = sandbox.runCommand("quick", { timeout: 10_000, onStdout });
+    await vi.waitFor(() => expect(onStdout).toHaveBeenCalledWith("streamed\n"));
+    resolveResult(result("streamed\nfinal\n", "", 0));
+    const commandResult = await running;
+
+    expect(commandResult).toMatchObject({ stdout: "streamed\nfinal\n", exitCode: 0 });
+    expect(onStdout.mock.calls.flat()).toEqual(["streamed\n", "final\n"]);
   });
 });
 
@@ -321,11 +350,11 @@ describe("Runloop lifecycle and listing", () => {
   });
 });
 
-function snapshot(id: string) {
+function snapshot(id: string, metadata: Record<string, unknown> = { purpose: "test" }) {
   return {
     id,
     create_time_ms: 1_710_000_000_000,
-    metadata: { purpose: "test" },
+    metadata,
     source_devbox_id: "devbox-1",
     source_blueprint_id: "bpt_1",
     name: "checkpoint",
@@ -337,27 +366,44 @@ function snapshot(id: string) {
 describe("Runloop snapshots", () => {
   it("normalizes created snapshots", async () => {
     const provider = runloop({ apiKey: "test-key" });
+    mocks.devboxes.snapshotDisk.mockResolvedValueOnce(snapshot("snapshot-created", {
+      purpose: "test",
+      name: "user-defined-name",
+      sizeBytes: "user-defined-size",
+    }));
 
     const created = await provider.snapshot!.create("devbox-1", {
       name: "checkpoint",
-      metadata: { purpose: "test" },
+      metadata: {
+        purpose: "test",
+        name: "user-defined-name",
+        sizeBytes: "user-defined-size",
+      },
     });
 
     expect(mocks.devboxes.snapshotDisk).toHaveBeenCalledWith("devbox-1", {
       name: "checkpoint",
-      metadata: { purpose: "test" },
+      metadata: {
+        purpose: "test",
+        name: "user-defined-name",
+        sizeBytes: "user-defined-size",
+      },
     });
     expect(created).toEqual({
       id: "snapshot-created",
       provider: "runloop",
       createdAt: new Date(1_710_000_000_000),
       metadata: {
-        purpose: "test",
         name: "checkpoint",
         sourceDevboxId: "devbox-1",
         sourceBlueprintId: "bpt_1",
         sizeBytes: 12_345,
         commitMessage: "before migration",
+        userMetadata: {
+          purpose: "test",
+          name: "user-defined-name",
+          sizeBytes: "user-defined-size",
+        },
       },
     });
   });
@@ -372,6 +418,10 @@ describe("Runloop snapshots", () => {
 
     expect(snapshots.map((item) => item.id)).toEqual(["snp_1", "snp_2"]);
     expect(snapshots.every((item) => item.provider === "runloop")).toBe(true);
+    expect(snapshots[0]?.metadata).toMatchObject({
+      name: "checkpoint",
+      userMetadata: { purpose: "test" },
+    });
     expect(mocks.devboxes.listDiskSnapshots).toHaveBeenCalledWith({
       devbox_id: "devbox-1",
       limit: 2,

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -243,10 +243,27 @@ describe("Runloop command execution", () => {
     expect(commandResult).toMatchObject({ stdout: "streamed\nfinal\n", exitCode: 0 });
     expect(onStdout.mock.calls.flat()).toEqual(["streamed\n", "final\n"]);
   });
+
+  it("kills the remote process group when result monitoring fails", async () => {
+    mocks.command.execAsync.mockResolvedValue({
+      executionId: "exec-monitor-failed",
+      result: vi.fn().mockRejectedValue(new Error("result polling failed")),
+    });
+    const { sandbox } = await getSandbox();
+
+    await expect(sandbox.runCommand("still-running", { timeout: 10_000 }))
+      .rejects.toThrow("result polling failed");
+
+    expect(mocks.executions.kill).toHaveBeenCalledWith(
+      "devbox-1",
+      "exec-monitor-failed",
+      { kill_process_group: true },
+    );
+  });
 });
 
 describe("Runloop lifecycle and listing", () => {
-  it("deep-merges launch parameters while retaining the calculated keep-alive", async () => {
+  it("deep-merges launch parameters while preserving an explicit keep-alive", async () => {
     const provider = runloop({ apiKey: "test-key" });
     await provider.sandbox.create({
       timeout: 2_500,
@@ -261,11 +278,19 @@ describe("Runloop lifecycle and listing", () => {
     expect(mocks.devboxes.createAndAwaitRunning).toHaveBeenCalledWith(
       expect.objectContaining({
         launch_parameters: {
-          keep_alive_time_seconds: 3,
+          keep_alive_time_seconds: 999,
           resource_size_request: "CUSTOM_SIZE",
           custom_cpu_cores: 4,
           lifecycle: { resume_triggers: { http: true } },
         },
+      }),
+      { longPoll: { timeoutMs: 2_500 } },
+    );
+
+    await provider.sandbox.create({ timeout: 2_500 });
+    expect(mocks.devboxes.createAndAwaitRunning).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        launch_parameters: { keep_alive_time_seconds: 3 },
       }),
       { longPoll: { timeoutMs: 2_500 } },
     );
@@ -463,6 +488,20 @@ describe("Runloop filesystem", () => {
     ]);
     expect(mocks.command.exec.mock.calls[0][0]).toContain("find -- '/tmp/a path/'\"'\"'quoted'\"'\"'\nroot'");
     expect(mocks.command.exec.mock.calls[0][0]).not.toContain("ls -la");
+  });
+
+  it("prefixes dash-leading relative readdir paths for GNU find", async () => {
+    mocks.command.exec.mockResolvedValue(result(
+      `${Buffer.from("entry.txt").toString("base64")}\tfile\t4\t1710000000\n`,
+    ));
+    const { sandbox } = await getSandbox();
+
+    await expect(sandbox.filesystem.readdir("-dir/'quoted'\nroot")).resolves.toEqual([
+      { name: "entry.txt", type: "file", size: 4, modified: new Date(1_710_000_000_000) },
+    ]);
+    expect(mocks.command.exec.mock.calls.at(-1)?.[0]).toContain(
+      `find -- './-dir/'"'"'quoted'"'"'\nroot'`,
+    );
   });
 
   it("quotes shell fallback paths, terminates options, and guards deletion roots", async () => {

--- a/packages/runloop/src/__tests__/index.test.ts
+++ b/packages/runloop/src/__tests__/index.test.ts
@@ -1,10 +1,401 @@
-import { runProviderTestSuite } from '@computesdk/test-utils';
-import { runloop } from '../index';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-runProviderTestSuite({
-  name: 'runloop',
-  provider: runloop({}),
-  supportsFilesystem: true,  // Runloop supports filesystem operations
-  ports: [3000],
-  skipIntegration: !process.env.RUNLOOP_API_KEY
+const mocks = vi.hoisted(() => {
+  const command = {
+    exec: vi.fn(),
+    execAsync: vi.fn(),
+  };
+  const file = {
+    read: vi.fn(),
+    write: vi.fn(),
+  };
+  const nativeDevbox = { command, cmd: command, file };
+  const devboxes = {
+    createAndAwaitRunning: vi.fn(),
+    retrieve: vi.fn(),
+    list: vi.fn(),
+    shutdown: vi.fn(),
+    enableTunnel: vi.fn(),
+    snapshotDisk: vi.fn(),
+    listDiskSnapshots: vi.fn(),
+    deleteDiskSnapshot: vi.fn(),
+  };
+  const blueprints = {
+    create: vi.fn(),
+    list: vi.fn(),
+    delete: vi.fn(),
+  };
+  const client = {
+    api: { devboxes, blueprints },
+    devbox: { fromId: vi.fn(() => nativeDevbox) },
+  };
+  return { command, file, nativeDevbox, devboxes, blueprints, client };
+});
+
+vi.mock("@runloop/api-client", () => ({
+  RunloopSDK: vi.fn(() => mocks.client),
+}));
+
+import { runloop } from "../index";
+
+type DevboxStatus =
+  | "scheduled"
+  | "queued"
+  | "provisioning"
+  | "initializing"
+  | "running"
+  | "suspending"
+  | "suspended"
+  | "resuming"
+  | "failure"
+  | "shutdown";
+
+function devbox(status: DevboxStatus = "running", id = "devbox-1") {
+  return {
+    id,
+    capabilities: [],
+    create_time_ms: 1_700_000_000_000,
+    end_time_ms: null,
+    launch_parameters: { keep_alive_time_seconds: 90 },
+    metadata: { team: "compute" },
+    state_transitions: [],
+    status,
+    blueprint_id: "bpt_1",
+  };
+}
+
+function result(stdout = "", stderr = "", exitCode: number | null = 0) {
+  return {
+    stdout: vi.fn().mockResolvedValue(stdout),
+    stderr: vi.fn().mockResolvedValue(stderr),
+    exitCode,
+  };
+}
+
+function paginated<T>(items: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) yield item;
+    },
+  };
+}
+
+function quote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+async function getSandbox() {
+  const provider = runloop({ apiKey: "test-key" });
+  const sandbox = await provider.sandbox.getById("devbox-1");
+  expect(sandbox).not.toBeNull();
+  return { provider, sandbox: sandbox! };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.client.devbox.fromId.mockReturnValue(mocks.nativeDevbox);
+  mocks.devboxes.retrieve.mockResolvedValue(devbox());
+  mocks.devboxes.createAndAwaitRunning.mockResolvedValue(devbox());
+  mocks.devboxes.list.mockReturnValue(paginated([]));
+  mocks.devboxes.shutdown.mockResolvedValue(devbox("shutdown"));
+  mocks.devboxes.snapshotDisk.mockResolvedValue(snapshot("snapshot-created"));
+  mocks.devboxes.listDiskSnapshots.mockReturnValue(paginated([]));
+  mocks.command.exec.mockResolvedValue(result());
+  mocks.file.read.mockResolvedValue("");
+  mocks.file.write.mockResolvedValue(undefined);
+  mocks.blueprints.list.mockReturnValue(paginated([]));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Runloop command execution", () => {
+  it("retrieves complete stdout and stderr through ExecutionResult", async () => {
+    const executionResult = result("line\n".repeat(150), "warning\n".repeat(120), 7);
+    mocks.command.exec.mockResolvedValue(executionResult);
+    const { sandbox } = await getSandbox();
+
+    const commandResult = await sandbox.runCommand("generate-output");
+
+    expect(commandResult).toMatchObject({
+      stdout: "line\n".repeat(150),
+      stderr: "warning\n".repeat(120),
+      exitCode: 7,
+    });
+    expect(executionResult.stdout).toHaveBeenCalledOnce();
+    expect(executionResult.stderr).toHaveBeenCalledOnce();
+    expect(mocks.client.devbox.fromId).toHaveBeenCalledWith("devbox-1");
+  });
+
+  it("streams native stdout and stderr callbacks and preserves missing exit status", async () => {
+    mocks.command.exec.mockImplementation(async (_command, params) => {
+      params.stdout?.("out-1\n");
+      params.stderr?.("err-1\n");
+      return result("out-1\n", "err-1\n", null);
+    });
+    const onStdout = vi.fn();
+    const onStderr = vi.fn();
+    const { sandbox } = await getSandbox();
+
+    const commandResult = await sandbox.runCommand("stream", { onStdout, onStderr });
+
+    expect(onStdout).toHaveBeenCalledWith("out-1\n");
+    expect(onStderr).toHaveBeenCalledWith("err-1\n");
+    expect(commandResult.exitCode).toBe(-1);
+  });
+
+  it("safely quotes cwd and environment values and validates environment keys", async () => {
+    const { sandbox } = await getSandbox();
+    const cwd = "/tmp/it's $HOME";
+    const envValue = "a' $(touch /tmp/pwned)\nnext";
+    await sandbox.runCommand("printf done", {
+      cwd,
+      env: { SAFE_VALUE: envValue },
+      background: true,
+    });
+
+    const foreground = `cd -- ${quote(cwd)} && SAFE_VALUE=${quote(envValue)} printf done`;
+    expect(mocks.command.exec).toHaveBeenCalledWith(
+      `nohup sh -lc ${quote(foreground)} >/dev/null 2>&1 &`,
+      {},
+    );
+
+    await expect(sandbox.runCommand("true", { env: { "BAD-NAME": "x" } }))
+      .rejects.toThrow("Invalid environment variable name");
+  });
+
+  it("cancels a timed-out async execution, returns 124, and stops callbacks", async () => {
+    vi.useFakeTimers();
+    let streamingParams: { stdout?: (chunk: string) => void } = {};
+    const kill = vi.fn().mockResolvedValue(undefined);
+    const pendingResult = new Promise<never>(() => {});
+    mocks.command.execAsync.mockImplementation(async (_command, params) => {
+      streamingParams = params;
+      return { result: () => pendingResult, kill };
+    });
+    const onStdout = vi.fn();
+    const { sandbox } = await getSandbox();
+
+    const running = sandbox.runCommand("sleep 60", { timeout: 50, onStdout });
+    await vi.advanceTimersByTimeAsync(10);
+    streamingParams.stdout?.("before-timeout\n");
+    await vi.advanceTimersByTimeAsync(40);
+    const commandResult = await running;
+    streamingParams.stdout?.("after-timeout\n");
+
+    expect(commandResult.exitCode).toBe(124);
+    expect(kill).toHaveBeenCalledOnce();
+    expect(onStdout).toHaveBeenCalledTimes(1);
+    expect(onStdout).toHaveBeenCalledWith("before-timeout\n");
+  });
+});
+
+describe("Runloop lifecycle and listing", () => {
+  it("deep-merges launch parameters while retaining the calculated keep-alive", async () => {
+    const provider = runloop({ apiKey: "test-key" });
+    await provider.sandbox.create({
+      timeout: 2_500,
+      launch_parameters: {
+        keep_alive_time_seconds: 999,
+        resource_size_request: "CUSTOM_SIZE",
+        custom_cpu_cores: 4,
+        lifecycle: { resume_triggers: { http: true } },
+      },
+    });
+
+    expect(mocks.devboxes.createAndAwaitRunning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launch_parameters: {
+          keep_alive_time_seconds: 3,
+          resource_size_request: "CUSTOM_SIZE",
+          custom_cpu_cores: 4,
+          lifecycle: { resume_triggers: { http: true } },
+        },
+      }),
+      { longPoll: { timeoutMs: 2_500 } },
+    );
+  });
+
+  it.each([
+    ["scheduled", "running"],
+    ["queued", "running"],
+    ["provisioning", "running"],
+    ["initializing", "running"],
+    ["resuming", "running"],
+    ["running", "running"],
+    ["suspending", "stopped"],
+    ["suspended", "stopped"],
+    ["shutdown", "stopped"],
+    ["failure", "error"],
+  ] as const)("refreshes and maps %s to %s", async (nativeStatus, expectedStatus) => {
+    const { sandbox } = await getSandbox();
+    mocks.devboxes.retrieve.mockResolvedValue(devbox(nativeStatus));
+
+    const info = await sandbox.getInfo();
+
+    expect(info.status).toBe(expectedStatus);
+    expect(info.timeout).toBe(90_000);
+    expect(mocks.devboxes.retrieve).toHaveBeenLastCalledWith("devbox-1");
+  });
+
+  it("suppresses only HTTP 404 for getById and destroy", async () => {
+    const provider = runloop({ apiKey: "test-key" });
+    mocks.devboxes.retrieve.mockRejectedValueOnce({ status: 404 });
+    await expect(provider.sandbox.getById("missing")).resolves.toBeNull();
+
+    mocks.devboxes.retrieve.mockRejectedValueOnce({ status: 401 });
+    await expect(provider.sandbox.getById("private")).rejects.toMatchObject({ status: 401 });
+
+    mocks.devboxes.shutdown.mockRejectedValueOnce({ status: 404 });
+    await expect(provider.sandbox.destroy("missing")).resolves.toBeUndefined();
+
+    mocks.devboxes.shutdown.mockRejectedValueOnce({ status: 503 });
+    await expect(provider.sandbox.destroy("unavailable")).rejects.toMatchObject({ status: 503 });
+  });
+
+  it("exhausts sandbox pagination and surfaces list failures", async () => {
+    const provider = runloop({ apiKey: "test-key" });
+    mocks.devboxes.list.mockReturnValue(paginated([devbox("running", "one"), devbox("suspended", "two")]));
+
+    const sandboxes = await provider.sandbox.list();
+    expect(sandboxes.map((item) => item.sandboxId)).toEqual(["one", "two"]);
+
+    mocks.devboxes.list.mockReturnValueOnce({
+      async *[Symbol.asyncIterator]() { throw new Error("network down"); },
+    });
+    await expect(provider.sandbox.list()).rejects.toThrow("network down");
+  });
+
+  it("exhausts template pagination while respecting an explicit limit", async () => {
+    const provider = runloop({ apiKey: "test-key" });
+    mocks.blueprints.list.mockReturnValue(paginated([
+      { id: "bpt_1" }, { id: "bpt_2" }, { id: "bpt_3" },
+    ]));
+
+    const templates = await provider.template!.list({ limit: 2 });
+
+    expect(templates.map((item) => item.id)).toEqual(["bpt_1", "bpt_2"]);
+    expect(mocks.blueprints.list).toHaveBeenCalledWith({ limit: 2 });
+  });
+});
+
+function snapshot(id: string) {
+  return {
+    id,
+    create_time_ms: 1_710_000_000_000,
+    metadata: { purpose: "test" },
+    source_devbox_id: "devbox-1",
+    source_blueprint_id: "bpt_1",
+    name: "checkpoint",
+    size_bytes: 12_345,
+    commit_message: "before migration",
+  };
+}
+
+describe("Runloop snapshots", () => {
+  it("normalizes created snapshots", async () => {
+    const provider = runloop({ apiKey: "test-key" });
+
+    const created = await provider.snapshot!.create("devbox-1", {
+      name: "checkpoint",
+      metadata: { purpose: "test" },
+    });
+
+    expect(mocks.devboxes.snapshotDisk).toHaveBeenCalledWith("devbox-1", {
+      name: "checkpoint",
+      metadata: { purpose: "test" },
+    });
+    expect(created).toEqual({
+      id: "snapshot-created",
+      provider: "runloop",
+      createdAt: new Date(1_710_000_000_000),
+      metadata: {
+        purpose: "test",
+        name: "checkpoint",
+        sourceDevboxId: "devbox-1",
+        sourceBlueprintId: "bpt_1",
+        sizeBytes: 12_345,
+        commitMessage: "before migration",
+      },
+    });
+  });
+
+  it("paginates, filters by devbox, normalizes, and honors list limits", async () => {
+    const provider = runloop({ apiKey: "test-key" });
+    mocks.devboxes.listDiskSnapshots.mockReturnValue(paginated([
+      snapshot("snp_1"), snapshot("snp_2"), snapshot("snp_3"),
+    ]));
+
+    const snapshots = await provider.snapshot!.list({ sandboxId: "devbox-1", limit: 2 });
+
+    expect(snapshots.map((item) => item.id)).toEqual(["snp_1", "snp_2"]);
+    expect(snapshots.every((item) => item.provider === "runloop")).toBe(true);
+    expect(mocks.devboxes.listDiskSnapshots).toHaveBeenCalledWith({
+      devbox_id: "devbox-1",
+      limit: 2,
+    });
+  });
+});
+
+describe("Runloop filesystem", () => {
+  it("uses native UTF-8 reads and writes for large hostile content", async () => {
+    const content = `large-$\{HOME\}-$(touch nope)-'\n${"x".repeat(1_000_000)}`;
+    const hostilePath = "/tmp/a path/'quote'/$(touch nope)\nfile.txt";
+    mocks.file.read.mockResolvedValue(content);
+    const { sandbox } = await getSandbox();
+
+    await sandbox.filesystem.writeFile(hostilePath, content);
+    const read = await sandbox.filesystem.readFile(hostilePath);
+
+    expect(mocks.file.write).toHaveBeenCalledWith({ file_path: hostilePath, contents: content });
+    expect(mocks.file.read).toHaveBeenCalledWith({ file_path: hostilePath });
+    expect(read).toBe(content);
+    expect(mocks.command.exec).not.toHaveBeenCalled();
+  });
+
+  it("decodes structured directory metadata including newline-containing names", async () => {
+    const names = ["space name.txt", "quote'$(touch nope)\nname"];
+    const stdout = [
+      `${Buffer.from(names[0]).toString("base64")}\tfile\t42\t1710000000`,
+      `${Buffer.from(names[1]).toString("base64")}\tdirectory\t4096\t1710000001`,
+      "",
+    ].join("\n");
+    mocks.command.exec.mockResolvedValue(result(stdout));
+    const { sandbox } = await getSandbox();
+
+    const entries = await sandbox.filesystem.readdir("/tmp/a path/'quoted'\nroot");
+
+    expect(entries).toEqual([
+      { name: names[0], type: "file", size: 42, modified: new Date(1_710_000_000_000) },
+      { name: names[1], type: "directory", size: 4096, modified: new Date(1_710_000_001_000) },
+    ]);
+    expect(mocks.command.exec.mock.calls[0][0]).toContain("find -- '/tmp/a path/'\"'\"'quoted'\"'\"'\nroot'");
+    expect(mocks.command.exec.mock.calls[0][0]).not.toContain("ls -la");
+  });
+
+  it("quotes shell fallback paths, terminates options, and guards deletion roots", async () => {
+    const hostilePath = "-dir/'quote'/$(touch nope)\nname";
+    const { sandbox } = await getSandbox();
+
+    await sandbox.filesystem.mkdir(hostilePath);
+    expect(mocks.command.exec.mock.calls.at(-1)?.[0]).toBe(
+      `mkdir -p -- '-dir/'"'"'quote'"'"'/$(touch nope)\nname'`,
+    );
+
+    await expect(sandbox.filesystem.exists(hostilePath)).resolves.toBe(true);
+    expect(mocks.command.exec.mock.calls.at(-1)?.[0]).toBe(
+      `test -e '-dir/'"'"'quote'"'"'/$(touch nope)\nname'`,
+    );
+
+    await sandbox.filesystem.remove(hostilePath);
+    expect(mocks.command.exec.mock.calls.at(-1)?.[0]).toBe(
+      `rm -rf -- '-dir/'"'"'quote'"'"'/$(touch nope)\nname'`,
+    );
+
+    await expect(sandbox.filesystem.remove("/")).rejects.toThrow("unsafe path");
+    await expect(sandbox.filesystem.remove("/tmp/..")).rejects.toThrow("unsafe path");
+    await expect(sandbox.filesystem.remove(".")).rejects.toThrow("unsafe path");
+    await expect(sandbox.filesystem.remove("")).rejects.toThrow("unsafe path");
+  });
 });

--- a/packages/runloop/src/__tests__/integration.test.ts
+++ b/packages/runloop/src/__tests__/integration.test.ts
@@ -16,6 +16,7 @@ it.runIf(runLive)("runs the modernized adapter against one shared Runloop devbox
   const root = `/tmp/computesdk hostile ' $() ${Date.now()}\nroot`;
   const fileName = `space ' quote $(touch-nope)\nfile.txt`;
   const filePath = `${root}/${fileName}`;
+  const dashRoot = `-computesdk-dash-${Date.now()}`;
   const timeoutMarker = `/tmp/computesdk-timeout-${Date.now()}`;
 
   try {
@@ -45,6 +46,12 @@ it.runIf(runLive)("runs the modernized adapter against one shared Runloop devbox
       size: Buffer.byteLength(content),
     });
 
+    await sandbox.filesystem.mkdir(dashRoot);
+    await sandbox.filesystem.writeFile(`${dashRoot}/entry.txt`, "dash-safe");
+    await expect(sandbox.filesystem.readdir(dashRoot)).resolves.toEqual([
+      expect.objectContaining({ name: "entry.txt", type: "file", size: 9 }),
+    ]);
+
     const info = await sandbox.getInfo();
     expect(info).toMatchObject({ id: sandbox.sandboxId, provider: "runloop", status: "running" });
 
@@ -58,6 +65,7 @@ it.runIf(runLive)("runs the modernized adapter against one shared Runloop devbox
     expect(cancellation.exitCode).toBe(0);
   } finally {
     await sandbox.filesystem.remove(root).catch(() => undefined);
+    await sandbox.filesystem.remove(dashRoot).catch(() => undefined);
     await sandbox.runCommand(`rm -f -- '${timeoutMarker}'`).catch(() => undefined);
     await sandbox.destroy().catch(() => undefined);
   }

--- a/packages/runloop/src/__tests__/integration.test.ts
+++ b/packages/runloop/src/__tests__/integration.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from "vitest";
+import { runloop } from "../index";
+
+const runLive = Boolean(process.env.RUNLOOP_API_KEY);
+
+it.runIf(runLive)("runs the modernized adapter against one shared Runloop devbox", async () => {
+  const provider = runloop({
+    apiKey: process.env.RUNLOOP_API_KEY,
+    timeout: 120_000,
+  });
+  const sandbox = await provider.sandbox.create({
+    name: `computesdk-adapter-${Date.now()}`,
+    timeout: 120_000,
+    metadata: { test: "modernized-runloop-adapter" },
+  });
+  const root = `/tmp/computesdk hostile ' $() ${Date.now()}\nroot`;
+  const fileName = `space ' quote $(touch-nope)\nfile.txt`;
+  const filePath = `${root}/${fileName}`;
+  const timeoutMarker = `/tmp/computesdk-timeout-${Date.now()}`;
+
+  try {
+    const longOutput = await sandbox.runCommand(
+      "for i in $(seq 1 150); do printf 'line-%s\\n' \"$i\"; done",
+    );
+    expect(longOutput.exitCode).toBe(0);
+    expect(longOutput.stdout).toContain("line-1\n");
+    expect(longOutput.stdout).toContain("line-150\n");
+
+    const streamed: string[] = [];
+    const streamedResult = await sandbox.runCommand(
+      "printf 'first\\n'; sleep 0.2; printf 'second\\n'",
+      { onStdout: (chunk) => streamed.push(chunk) },
+    );
+    expect(streamedResult.exitCode).toBe(0);
+    expect(streamed.join("")).toContain("first\n");
+    expect(streamed.join("")).toContain("second\n");
+
+    await sandbox.filesystem.mkdir(root);
+    const content = `utf8-✓-$\{HOME\}-$(touch nope)-${"x".repeat(200_000)}`;
+    await sandbox.filesystem.writeFile(filePath, content);
+    await expect(sandbox.filesystem.readFile(filePath)).resolves.toBe(content);
+    const entries = await sandbox.filesystem.readdir(root);
+    expect(entries.find((entry) => entry.name === fileName)).toMatchObject({
+      type: "file",
+      size: Buffer.byteLength(content),
+    });
+
+    const info = await sandbox.getInfo();
+    expect(info).toMatchObject({ id: sandbox.sandboxId, provider: "runloop", status: "running" });
+
+    await sandbox.runCommand(`rm -f -- '${timeoutMarker}'`);
+    const timedOut = await sandbox.runCommand(
+      `sleep 2; touch -- '${timeoutMarker}'`,
+      { timeout: 200 },
+    );
+    expect(timedOut.exitCode).toBe(124);
+    const cancellation = await sandbox.runCommand(`sleep 3; test ! -e '${timeoutMarker}'`);
+    expect(cancellation.exitCode).toBe(0);
+  } finally {
+    await sandbox.filesystem.remove(root).catch(() => undefined);
+    await sandbox.runCommand(`rm -f -- '${timeoutMarker}'`).catch(() => undefined);
+    await sandbox.destroy().catch(() => undefined);
+  }
+}, 180_000);

--- a/packages/runloop/src/__tests__/integration.test.ts
+++ b/packages/runloop/src/__tests__/integration.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import { runloop } from "../index";
 
-const runLive = Boolean(process.env.RUNLOOP_API_KEY);
+const runLive = process.env.RUNLOOP_INTEGRATION === "1" && Boolean(process.env.RUNLOOP_API_KEY);
 
 it.runIf(runLive)("runs the modernized adapter against one shared Runloop devbox", async () => {
   const provider = runloop({
@@ -50,7 +50,7 @@ it.runIf(runLive)("runs the modernized adapter against one shared Runloop devbox
 
     await sandbox.runCommand(`rm -f -- '${timeoutMarker}'`);
     const timedOut = await sandbox.runCommand(
-      `sleep 2; touch -- '${timeoutMarker}'`,
+      `(sleep 2; touch -- '${timeoutMarker}') & wait`,
       { timeout: 200 },
     );
     expect(timedOut.exitCode).toBe(124);

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -185,23 +185,37 @@ function normalizeSnapshot(snapshot: Runloop.DevboxSnapshotView): Snapshot {
     provider: "runloop",
     createdAt: new Date(snapshot.create_time_ms),
     metadata: {
-      ...snapshot.metadata,
       name: snapshot.name ?? null,
       sourceDevboxId: snapshot.source_devbox_id,
       sourceBlueprintId: snapshot.source_blueprint_id ?? null,
       sizeBytes: snapshot.size_bytes ?? null,
       commitMessage: snapshot.commit_message ?? null,
+      userMetadata: snapshot.metadata ?? {},
     },
   };
 }
 
+function emitMissingOutput(
+  emitted: string,
+  complete: string,
+  callback: ((chunk: string) => void) | undefined,
+): void {
+  if (!callback || !complete || emitted.includes(complete)) return;
+  if (!emitted) {
+    callback(complete);
+  } else if (complete.startsWith(emitted)) {
+    callback(complete.slice(emitted.length));
+  } else if (!complete.includes(emitted)) {
+    callback(complete);
+  }
+}
+
 async function streamExecutionOutput(
   openStream: () => Promise<AsyncIterable<{ output: string }>>,
-  onChunk: ((chunk: string) => void) | undefined,
+  onChunk: (chunk: string) => void,
   signal: AbortSignal,
   isActive: () => boolean,
 ): Promise<void> {
-  if (!onChunk) return;
   try {
     const stream = await openStream();
     for await (const chunk of stream) {
@@ -250,6 +264,8 @@ async function executeCommand(
   const timeoutMs = options.timeout;
   const monitorController = new AbortController();
   const execution = await devbox.cmd.execAsync(fullCommand);
+  let streamedStdout = "";
+  let streamedStderr = "";
   const streamPromises = [
     streamExecutionOutput(
       () => sandbox.client.api.devboxes.executions.streamStdoutUpdates(
@@ -258,7 +274,10 @@ async function executeCommand(
         {},
         { signal: monitorController.signal },
       ),
-      options.onStdout,
+      (chunk) => {
+        streamedStdout += chunk;
+        options.onStdout?.(chunk);
+      },
       monitorController.signal,
       () => callbacksActive,
     ),
@@ -269,7 +288,10 @@ async function executeCommand(
         {},
         { signal: monitorController.signal },
       ),
-      options.onStderr,
+      (chunk) => {
+        streamedStderr += chunk;
+        options.onStderr?.(chunk);
+      },
       monitorController.signal,
       () => callbacksActive,
     ),
@@ -308,15 +330,19 @@ async function executeCommand(
         if (killTimer) clearTimeout(killTimer);
       }
       return {
-        stdout: "",
-        stderr: "",
+        stdout: streamedStdout,
+        stderr: streamedStderr,
         exitCode: 124,
         durationMs: Date.now() - startTime,
       };
     }
 
+    monitorController.abort();
     await Promise.allSettled(streamPromises);
-    return await toCommandResult(outcome.result);
+    const commandResult = await toCommandResult(outcome.result);
+    emitMissingOutput(streamedStdout, commandResult.stdout, options.onStdout);
+    emitMissingOutput(streamedStderr, commandResult.stderr, options.onStderr);
+    return commandResult;
   } catch (error) {
     monitorController.abort();
     await Promise.allSettled(streamPromises);

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -195,6 +195,24 @@ function normalizeSnapshot(snapshot: Runloop.DevboxSnapshotView): Snapshot {
   };
 }
 
+async function streamExecutionOutput(
+  openStream: () => Promise<AsyncIterable<{ output: string }>>,
+  onChunk: ((chunk: string) => void) | undefined,
+  signal: AbortSignal,
+  isActive: () => boolean,
+): Promise<void> {
+  if (!onChunk) return;
+  try {
+    const stream = await openStream();
+    for await (const chunk of stream) {
+      if (signal.aborted) break;
+      if (isActive()) onChunk(chunk.output);
+    }
+  } catch {
+    // Streaming is best effort, matching the native SDK callback behavior.
+  }
+}
+
 async function executeCommand(
   sandbox: RunloopSandbox,
   command: string,
@@ -230,8 +248,33 @@ async function executeCommand(
   }
 
   const timeoutMs = options.timeout;
-  const execution = await devbox.cmd.execAsync(fullCommand, executionParams);
-  const resultPromise = execution.result();
+  const monitorController = new AbortController();
+  const execution = await devbox.cmd.execAsync(fullCommand);
+  const streamPromises = [
+    streamExecutionOutput(
+      () => sandbox.client.api.devboxes.executions.streamStdoutUpdates(
+        sandbox.id,
+        execution.executionId,
+        {},
+        { signal: monitorController.signal },
+      ),
+      options.onStdout,
+      monitorController.signal,
+      () => callbacksActive,
+    ),
+    streamExecutionOutput(
+      () => sandbox.client.api.devboxes.executions.streamStderrUpdates(
+        sandbox.id,
+        execution.executionId,
+        {},
+        { signal: monitorController.signal },
+      ),
+      options.onStderr,
+      monitorController.signal,
+      () => callbacksActive,
+    ),
+  ];
+  const resultPromise = execution.result({ signal: monitorController.signal });
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
     timer = setTimeout(() => resolve("timeout"), Math.max(0, timeoutMs));
@@ -245,14 +288,21 @@ async function executeCommand(
 
     if (outcome === "timeout") {
       callbacksActive = false;
-      void resultPromise.catch(() => undefined);
+      monitorController.abort();
       let killTimer: ReturnType<typeof setTimeout> | undefined;
       try {
-        await Promise.race([
-          execution.kill().catch(() => undefined),
-          new Promise<void>((resolve) => {
-            killTimer = setTimeout(resolve, 1_000);
-          }),
+        await Promise.all([
+          Promise.race([
+            sandbox.client.api.devboxes.executions.kill(
+              sandbox.id,
+              execution.executionId,
+              { kill_process_group: true },
+            ).catch(() => undefined),
+            new Promise<void>((resolve) => {
+              killTimer = setTimeout(resolve, 1_000);
+            }),
+          ]),
+          Promise.allSettled([resultPromise, ...streamPromises]),
         ]);
       } finally {
         if (killTimer) clearTimeout(killTimer);
@@ -265,10 +315,16 @@ async function executeCommand(
       };
     }
 
+    await Promise.allSettled(streamPromises);
     return await toCommandResult(outcome.result);
+  } catch (error) {
+    monitorController.abort();
+    await Promise.allSettled(streamPromises);
+    throw error;
   } finally {
     if (timer) clearTimeout(timer);
     callbacksActive = false;
+    monitorController.abort();
   }
 }
 
@@ -352,9 +408,9 @@ export const runloop = defineProvider<
           } = options || {};
 
           const effectiveTimeout = optTimeout ?? timeout;
-          const keepAliveSeconds = effectiveTimeout
+          const keepAliveSeconds = effectiveTimeout !== undefined
             ? Math.ceil(effectiveTimeout / 1000)
-            : 1800;
+            : optLaunchParameters?.keep_alive_time_seconds ?? 1800;
 
           let devboxParams: Runloop.DevboxCreateParams = {
             launch_parameters: deepMerge(

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -381,6 +381,23 @@ async function executeCommand(
   }
 }
 
+async function runCommandWithErrors(
+  sandbox: RunloopSandbox,
+  command: string,
+  options?: RunCommandOptions,
+): Promise<CommandResult> {
+  try {
+    return await executeCommand(sandbox, command, options);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Syntax error")) {
+      throw error;
+    }
+    throw new Error(
+      `Runloop execution failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 /**
  * Runloop-specific blueprint creation options
  */
@@ -542,39 +559,9 @@ export const runloop = defineProvider<
         }
       },
 
-      runCommand: async (
-        sandbox: RunloopSandbox,
-        command: string,
-        options?: RunCommandOptions
-      ): Promise<CommandResult> => {
-        try {
-          return await executeCommand(sandbox, command, options);
-        } catch (error) {
-          if (error instanceof Error && error.message.includes("Syntax error")) {
-            throw error;
-          }
-          throw new Error(
-            `Runloop execution failed: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-      },
+      runCommand: runCommandWithErrors,
 
-      streamCommand: async (
-        sandbox: RunloopSandbox,
-        command: string,
-        options: RunCommandOptions,
-      ): Promise<CommandResult> => {
-        try {
-          return await executeCommand(sandbox, command, options);
-        } catch (error) {
-          if (error instanceof Error && error.message.includes("Syntax error")) {
-            throw error;
-          }
-          throw new Error(
-            `Runloop execution failed: ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      },
+      streamCommand: runCommandWithErrors,
 
       getInfo: async (sandbox: RunloopSandbox): Promise<SandboxInfo> => {
         const devbox = await sandbox.client.api.devboxes.retrieve(sandbox.id);
@@ -619,10 +606,15 @@ export const runloop = defineProvider<
         },
 
         writeFile: async (sandbox: RunloopSandbox, path: string, content: string): Promise<void> => {
-          await sandbox.client.devbox.fromId(sandbox.id).file.write({
+          const result = await sandbox.client.devbox.fromId(sandbox.id).file.write({
             file_path: path,
             contents: content,
           });
+          if (result.exit_status !== 0) {
+            throw new Error(
+              `Failed to write file ${path}: ${result.stderr || `exit ${result.exit_status}`}`,
+            );
+          }
         },
 
         mkdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -227,6 +227,27 @@ async function streamExecutionOutput(
   }
 }
 
+async function bestEffortKillExecution(
+  sandbox: RunloopSandbox,
+  executionId: string,
+): Promise<void> {
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      sandbox.client.api.devboxes.executions.kill(
+        sandbox.id,
+        executionId,
+        { kill_process_group: true },
+      ).catch(() => undefined),
+      new Promise<void>((resolve) => {
+        killTimer = setTimeout(resolve, 1_000);
+      }),
+    ]);
+  } finally {
+    if (killTimer) clearTimeout(killTimer);
+  }
+}
+
 async function executeCommand(
   sandbox: RunloopSandbox,
   command: string,
@@ -297,6 +318,7 @@ async function executeCommand(
     ),
   ];
   const resultPromise = execution.result({ signal: monitorController.signal });
+  let executionCompleted = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
     timer = setTimeout(() => resolve("timeout"), Math.max(0, timeoutMs));
@@ -311,24 +333,10 @@ async function executeCommand(
     if (outcome === "timeout") {
       callbacksActive = false;
       monitorController.abort();
-      let killTimer: ReturnType<typeof setTimeout> | undefined;
-      try {
-        await Promise.all([
-          Promise.race([
-            sandbox.client.api.devboxes.executions.kill(
-              sandbox.id,
-              execution.executionId,
-              { kill_process_group: true },
-            ).catch(() => undefined),
-            new Promise<void>((resolve) => {
-              killTimer = setTimeout(resolve, 1_000);
-            }),
-          ]),
-          Promise.allSettled([resultPromise, ...streamPromises]),
-        ]);
-      } finally {
-        if (killTimer) clearTimeout(killTimer);
-      }
+      await Promise.all([
+        bestEffortKillExecution(sandbox, execution.executionId),
+        Promise.allSettled([resultPromise, ...streamPromises]),
+      ]);
       return {
         stdout: streamedStdout,
         stderr: streamedStderr,
@@ -337,6 +345,7 @@ async function executeCommand(
       };
     }
 
+    executionCompleted = true;
     monitorController.abort();
     await Promise.allSettled(streamPromises);
     const commandResult = await toCommandResult(outcome.result);
@@ -344,8 +353,14 @@ async function executeCommand(
     emitMissingOutput(streamedStderr, commandResult.stderr, options.onStderr);
     return commandResult;
   } catch (error) {
+    callbacksActive = false;
     monitorController.abort();
-    await Promise.allSettled(streamPromises);
+    await Promise.all([
+      executionCompleted
+        ? Promise.resolve()
+        : bestEffortKillExecution(sandbox, execution.executionId),
+      Promise.allSettled(streamPromises),
+    ]);
     throw error;
   } finally {
     if (timer) clearTimeout(timer);
@@ -434,14 +449,15 @@ export const runloop = defineProvider<
           } = options || {};
 
           const effectiveTimeout = optTimeout ?? timeout;
-          const keepAliveSeconds = effectiveTimeout !== undefined
-            ? Math.ceil(effectiveTimeout / 1000)
-            : optLaunchParameters?.keep_alive_time_seconds ?? 1800;
+          const keepAliveSeconds = optLaunchParameters?.keep_alive_time_seconds
+            ?? (effectiveTimeout !== undefined
+              ? Math.ceil(effectiveTimeout / 1000)
+              : 1800);
 
           let devboxParams: Runloop.DevboxCreateParams = {
             launch_parameters: deepMerge(
-              (optLaunchParameters ?? {}) as Record<string, unknown>,
               { keep_alive_time_seconds: keepAliveSeconds },
+              (optLaunchParameters ?? {}) as Record<string, unknown>,
             ) as Runloop.DevboxCreateParams["launch_parameters"],
             name: name || optSandboxId,
             metadata,
@@ -604,9 +620,10 @@ export const runloop = defineProvider<
         },
 
         readdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<FileEntry[]> => {
+          const findPath = path.startsWith("-") ? `./${path}` : path;
           const result = await runCommand(
             sandbox,
-            `find -- ${shellQuote(path)} -mindepth 1 -maxdepth 1 -exec sh -c ` +
+            `find -- ${shellQuote(findPath)} -mindepth 1 -maxdepth 1 -exec sh -c ` +
               `${shellQuote('for entry do name=${entry##*/}; if [ -d "$entry" ]; then type=directory; else type=file; fi; encoded=$(printf %s "$name" | base64 | tr -d "\\n"); size=$(stat -c %s -- "$entry") || exit; modified=$(stat -c %Y -- "$entry") || exit; printf "%s\\t%s\\t%s\\t%s\\n" "$encoded" "$type" "$size" "$modified"; done')} ` +
               `sh {} +`,
           );

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -295,48 +295,81 @@ async function executeCommand(
   }
 
   const timeoutMs = options.timeout;
+  const deadline = startTime + Math.max(0, timeoutMs);
   const monitorController = new AbortController();
-  const execution = await devbox.cmd.execAsync(fullCommand);
   let streamedStdout = "";
   let streamedStderr = "";
-  const streamPromises = [
-    streamExecutionOutput(
-      () => sandbox.client.api.devboxes.executions.streamStdoutUpdates(
-        sandbox.id,
-        execution.executionId,
-        {},
-        { signal: monitorController.signal },
-      ),
-      (chunk) => {
-        streamedStdout += chunk;
-        options.onStdout?.(chunk);
-      },
-      monitorController.signal,
-      () => callbacksActive,
-    ),
-    streamExecutionOutput(
-      () => sandbox.client.api.devboxes.executions.streamStderrUpdates(
-        sandbox.id,
-        execution.executionId,
-        {},
-        { signal: monitorController.signal },
-      ),
-      (chunk) => {
-        streamedStderr += chunk;
-        options.onStderr?.(chunk);
-      },
-      monitorController.signal,
-      () => callbacksActive,
-    ),
-  ];
-  const resultPromise = execution.result({ signal: monitorController.signal });
+  let execution: Awaited<ReturnType<typeof devbox.cmd.execAsync>> | undefined;
+  let resultPromise: ReturnType<Awaited<ReturnType<typeof devbox.cmd.execAsync>>["result"]> | undefined;
+  let streamPromises: Promise<void>[] = [];
   let executionCompleted = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timer = setTimeout(() => resolve("timeout"), Math.max(0, timeoutMs));
+    timer = setTimeout(() => {
+      resolve("timeout");
+      monitorController.abort();
+    }, Math.max(0, deadline - Date.now()));
+  });
+  const timeoutResult = (): CommandResult => ({
+    stdout: streamedStdout,
+    stderr: streamedStderr,
+    exitCode: 124,
+    durationMs: Date.now() - startTime,
   });
 
   try {
+    const requestTimeoutMs = Math.max(1, deadline - Date.now());
+    const executionPromise = devbox.cmd.execAsync(
+      fullCommand,
+      {},
+      { signal: monitorController.signal, timeout: requestTimeoutMs },
+    );
+    const creationOutcome = await Promise.race([
+      executionPromise.then((createdExecution) => ({ execution: createdExecution })),
+      timeoutPromise,
+    ]);
+
+    if (creationOutcome === "timeout") {
+      callbacksActive = false;
+      void executionPromise
+        .then((lateExecution) => bestEffortKillExecution(sandbox, lateExecution.executionId))
+        .catch(() => undefined);
+      return timeoutResult();
+    }
+
+    const activeExecution = creationOutcome.execution;
+    execution = activeExecution;
+    streamPromises = [
+      streamExecutionOutput(
+        () => sandbox.client.api.devboxes.executions.streamStdoutUpdates(
+          sandbox.id,
+          activeExecution.executionId,
+          {},
+          { signal: monitorController.signal },
+        ),
+        (chunk) => {
+          streamedStdout += chunk;
+          options.onStdout?.(chunk);
+        },
+        monitorController.signal,
+        () => callbacksActive,
+      ),
+      streamExecutionOutput(
+        () => sandbox.client.api.devboxes.executions.streamStderrUpdates(
+          sandbox.id,
+          activeExecution.executionId,
+          {},
+          { signal: monitorController.signal },
+        ),
+        (chunk) => {
+          streamedStderr += chunk;
+          options.onStderr?.(chunk);
+        },
+        monitorController.signal,
+        () => callbacksActive,
+      ),
+    ];
+    resultPromise = activeExecution.result({ signal: monitorController.signal });
     const outcome = await Promise.race([
       resultPromise.then((result) => ({ result })),
       timeoutPromise,
@@ -349,12 +382,7 @@ async function executeCommand(
         bestEffortKillExecution(sandbox, execution.executionId),
         Promise.allSettled([resultPromise, ...streamPromises]),
       ]);
-      return {
-        stdout: streamedStdout,
-        stderr: streamedStderr,
-        exitCode: 124,
-        durationMs: Date.now() - startTime,
-      };
+      return timeoutResult();
     }
 
     executionCompleted = true;
@@ -368,10 +396,13 @@ async function executeCommand(
     callbacksActive = false;
     monitorController.abort();
     await Promise.all([
-      executionCompleted
+      executionCompleted || !execution
         ? Promise.resolve()
         : bestEffortKillExecution(sandbox, execution.executionId),
-      Promise.allSettled(streamPromises),
+      Promise.allSettled([
+        ...(resultPromise ? [resultPromise] : []),
+        ...streamPromises,
+      ]),
     ]);
     throw error;
   } finally {

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { RunloopSDK, type Runloop } from "@runloop/api-client";
-import { defineProvider, escapeShellArg } from "@computesdk/provider";
+import { defineProvider } from "@computesdk/provider";
 import type {
   CommandResult,
   SandboxInfo,
@@ -17,14 +17,13 @@ import type {
 import type {
   CreateSandboxOptions,
   FileEntry,
+  Snapshot,
 } from "computesdk";
 
 // Define Runloop-specific types
-type RunloopSnapshot = Runloop.DevboxSnapshotView;
 type RunloopTemplate = Runloop.BlueprintView;
 type RunloopSandbox = Runloop.DevboxView & { client: RunloopSDK };
 type RunloopCreateWaitOptions = Parameters<RunloopSDK["api"]["devboxes"]["createAndAwaitRunning"]>[1];
-type RunloopExecuteWaitOptions = Parameters<RunloopSDK["api"]["devboxes"]["executeAndAwaitCompletion"]>[2];
 
 type CommandRunner = (
   sandbox: RunloopSandbox,
@@ -75,9 +74,202 @@ function longPollOptions<TOptions>(timeoutMs?: number): TOptions | undefined {
   return timeoutMs ? ({ longPoll: { timeoutMs } } as TOptions) : undefined;
 }
 
-function optimisticTimeoutSeconds(timeoutMs?: number): number {
-  if (!timeoutMs) return 25;
-  return Math.max(1, Math.min(25, Math.ceil(timeoutMs / 1000)));
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMerge<T extends Record<string, unknown>>(
+  base: T,
+  override?: Record<string, unknown>,
+): T {
+  if (!override) return { ...base };
+
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const current = merged[key];
+    merged[key] = isRecord(current) && isRecord(value)
+      ? deepMerge(current, value)
+      : value;
+  }
+  return merged as T;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function normalizePosixPath(value: string): string {
+  const absolute = value.startsWith("/");
+  const parts: string[] = [];
+  for (const part of value.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!absolute) {
+        parts.push(part);
+      }
+    } else {
+      parts.push(part);
+    }
+  }
+  if (absolute) return `/${parts.join("/")}`;
+  return parts.join("/") || ".";
+}
+
+function buildCommand(command: string, options?: RunCommandOptions): string {
+  let fullCommand = command;
+
+  if (options?.env && Object.keys(options.env).length > 0) {
+    const envPrefix = Object.entries(options.env)
+      .map(([key, value]) => {
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+          throw new Error(`Invalid environment variable name: ${JSON.stringify(key)}`);
+        }
+        return `${key}=${shellQuote(String(value))}`;
+      })
+      .join(" ");
+    fullCommand = `${envPrefix} ${fullCommand}`;
+  }
+
+  if (options?.cwd) {
+    fullCommand = `cd -- ${shellQuote(options.cwd)} && ${fullCommand}`;
+  }
+
+  if (options?.background) {
+    fullCommand = `nohup sh -lc ${shellQuote(fullCommand)} >/dev/null 2>&1 &`;
+  }
+
+  return fullCommand;
+}
+
+function isHttpNotFound(error: unknown): boolean {
+  return isRecord(error) && error.status === 404;
+}
+
+function mapStatus(status: Runloop.DevboxView["status"]): SandboxInfo["status"] {
+  switch (status) {
+    case "scheduled":
+    case "queued":
+    case "provisioning":
+    case "initializing":
+    case "resuming":
+    case "running":
+      return "running";
+    case "suspending":
+    case "suspended":
+    case "shutdown":
+      return "stopped";
+    case "failure":
+      return "error";
+  }
+}
+
+async function collectPaginated<T>(
+  source: AsyncIterable<T>,
+  limit?: number,
+): Promise<T[]> {
+  if (limit !== undefined && limit <= 0) return [];
+
+  const results: T[] = [];
+  for await (const item of source) {
+    results.push(item);
+    if (limit !== undefined && results.length >= limit) break;
+  }
+  return results;
+}
+
+function normalizeSnapshot(snapshot: Runloop.DevboxSnapshotView): Snapshot {
+  return {
+    id: snapshot.id,
+    provider: "runloop",
+    createdAt: new Date(snapshot.create_time_ms),
+    metadata: {
+      ...snapshot.metadata,
+      name: snapshot.name ?? null,
+      sourceDevboxId: snapshot.source_devbox_id,
+      sourceBlueprintId: snapshot.source_blueprint_id ?? null,
+      sizeBytes: snapshot.size_bytes ?? null,
+      commitMessage: snapshot.commit_message ?? null,
+    },
+  };
+}
+
+async function executeCommand(
+  sandbox: RunloopSandbox,
+  command: string,
+  options?: RunCommandOptions,
+): Promise<CommandResult> {
+  const startTime = Date.now();
+  const devbox = sandbox.client.devbox.fromId(sandbox.id);
+  const fullCommand = buildCommand(command, options);
+  let callbacksActive = true;
+  const executionParams = {
+    ...(options?.onStdout
+      ? { stdout: (chunk: string) => callbacksActive && options.onStdout?.(chunk) }
+      : {}),
+    ...(options?.onStderr
+      ? { stderr: (chunk: string) => callbacksActive && options.onStderr?.(chunk) }
+      : {}),
+  };
+
+  const toCommandResult = async (result: Awaited<ReturnType<typeof devbox.cmd.exec>>): Promise<CommandResult> => ({
+    stdout: await result.stdout(),
+    stderr: await result.stderr(),
+    exitCode: result.exitCode ?? -1,
+    durationMs: Date.now() - startTime,
+  });
+
+  if (options?.timeout === undefined) {
+    try {
+      const result = await devbox.cmd.exec(fullCommand, executionParams);
+      return await toCommandResult(result);
+    } finally {
+      callbacksActive = false;
+    }
+  }
+
+  const timeoutMs = options.timeout;
+  const execution = await devbox.cmd.execAsync(fullCommand, executionParams);
+  const resultPromise = execution.result();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), Math.max(0, timeoutMs));
+  });
+
+  try {
+    const outcome = await Promise.race([
+      resultPromise.then((result) => ({ result })),
+      timeoutPromise,
+    ]);
+
+    if (outcome === "timeout") {
+      callbacksActive = false;
+      void resultPromise.catch(() => undefined);
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          execution.kill().catch(() => undefined),
+          new Promise<void>((resolve) => {
+            killTimer = setTimeout(resolve, 1_000);
+          }),
+        ]);
+      } finally {
+        if (killTimer) clearTimeout(killTimer);
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        exitCode: 124,
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    return await toCommandResult(outcome.result);
+  } finally {
+    if (timer) clearTimeout(timer);
+    callbacksActive = false;
+  }
 }
 
 /**
@@ -133,7 +325,7 @@ export const runloop = defineProvider<
   RunloopSandbox,
   RunloopConfig,
   RunloopTemplate,
-  RunloopSnapshot
+  Snapshot
 >({
   name: "runloop",
   methods: {
@@ -165,10 +357,10 @@ export const runloop = defineProvider<
             : 1800;
 
           let devboxParams: Runloop.DevboxCreateParams = {
-            launch_parameters: {
-              keep_alive_time_seconds: keepAliveSeconds,
-              ...(optLaunchParameters as Partial<Runloop.DevboxCreateParams['launch_parameters']> | undefined),
-            },
+            launch_parameters: deepMerge(
+              (optLaunchParameters ?? {}) as Record<string, unknown>,
+              { keep_alive_time_seconds: keepAliveSeconds },
+            ) as Runloop.DevboxCreateParams["launch_parameters"],
             name: name || optSandboxId,
             metadata,
             environment_variables: envs,
@@ -216,32 +408,28 @@ export const runloop = defineProvider<
             sandbox: { ...devbox, client } as RunloopSandbox,
             sandboxId,
           };
-        } catch {
-          return null;
+        } catch (error) {
+          if (isHttpNotFound(error)) return null;
+          throw error;
         }
       },
 
       list: async (config: RunloopConfig) => {
-        try {
-          const client = getRunloopClient(config);
-          const response = await client.api.devboxes.list();
-          const devboxes = response.devboxes || [];
+        const client = getRunloopClient(config);
+        const devboxes = await collectPaginated(client.api.devboxes.list());
 
-          return devboxes.map((devbox) => ({
-            sandbox: { ...devbox, client } as RunloopSandbox,
-            sandboxId: devbox.id,
-          }));
-        } catch {
-          return [];
-        }
+        return devboxes.map((devbox) => ({
+          sandbox: { ...devbox, client } as RunloopSandbox,
+          sandboxId: devbox.id,
+        }));
       },
 
       destroy: async (config: RunloopConfig, sandboxId: string) => {
         try {
           const client = getRunloopClient(config);
           await client.api.devboxes.shutdown(sandboxId);
-        } catch {
-          // Devbox might already be destroyed or doesn't exist
+        } catch (error) {
+          if (!isHttpNotFound(error)) throw error;
         }
       },
 
@@ -250,40 +438,8 @@ export const runloop = defineProvider<
         command: string,
         options?: RunCommandOptions
       ): Promise<CommandResult> => {
-        const startTime = Date.now();
-        const devbox = sandbox;
-        const client = sandbox.client;
-
         try {
-          let fullCommand = command;
-
-          if (options?.env && Object.keys(options.env).length > 0) {
-            const envPrefix = Object.entries(options.env)
-              .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
-              .join(' ');
-            fullCommand = `${envPrefix} ${fullCommand}`;
-          }
-
-          if (options?.cwd) {
-            fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
-          }
-
-          if (options?.background) {
-            fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
-          }
-
-          const executionResult =
-            await client.api.devboxes.executeAndAwaitCompletion(devbox.id, {
-              command: fullCommand,
-              optimistic_timeout: optimisticTimeoutSeconds(options?.timeout),
-            }, longPollOptions<RunloopExecuteWaitOptions>(options?.timeout));
-
-          return {
-            stdout: executionResult.stdout || "",
-            stderr: executionResult.stderr || "",
-            exitCode: executionResult.exit_status || 0,
-            durationMs: Date.now() - startTime,
-          };
+          return await executeCommand(sandbox, command, options);
         } catch (error) {
           if (error instanceof Error && error.message.includes("Syntax error")) {
             throw error;
@@ -294,14 +450,31 @@ export const runloop = defineProvider<
         }
       },
 
-      getInfo: async (sandbox): Promise<SandboxInfo> => {
-        const devbox = sandbox;
-        const keepAliveSecs = devbox.launch_parameters.keep_alive_time_seconds;
+      streamCommand: async (
+        sandbox: RunloopSandbox,
+        command: string,
+        options: RunCommandOptions,
+      ): Promise<CommandResult> => {
+        try {
+          return await executeCommand(sandbox, command, options);
+        } catch (error) {
+          if (error instanceof Error && error.message.includes("Syntax error")) {
+            throw error;
+          }
+          throw new Error(
+            `Runloop execution failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+
+      getInfo: async (sandbox: RunloopSandbox): Promise<SandboxInfo> => {
+        const devbox = await sandbox.client.api.devboxes.retrieve(sandbox.id);
+        const keepAliveSecs = devbox.launch_parameters?.keep_alive_time_seconds;
 
         return {
           id: devbox.id || "runloop-unknown",
           provider: "runloop",
-          status: devbox.status as 'running' | 'stopped' | 'error',
+          status: mapStatus(devbox.status),
           createdAt: new Date(devbox.create_time_ms || Date.now()),
           // keep_alive_time_seconds is in seconds; SandboxInfo.timeout is in milliseconds
           timeout: keepAliveSecs ? keepAliveSecs * 1000 : 300000,
@@ -332,51 +505,63 @@ export const runloop = defineProvider<
       },
 
       filesystem: {
-        readFile: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<string> => {
-          const result = await runCommand(sandbox, `test -f "${path}" && base64 < "${path}" | tr -d '\\n'`);
-          if (result.exitCode !== 0) throw new Error(`File not found or unreadable: ${result.stderr}`);
-          return Buffer.from(result.stdout, 'base64').toString('utf8');
+        readFile: async (sandbox: RunloopSandbox, path: string): Promise<string> => {
+          return sandbox.client.devbox.fromId(sandbox.id).file.read({ file_path: path });
         },
 
-        writeFile: async (sandbox: RunloopSandbox, path: string, content: string, runCommand: CommandRunner): Promise<void> => {
-          const encoded = Buffer.from(content).toString('base64');
-          const result = await runCommand(sandbox, `sh -c 'echo "${encoded}" | base64 -d > "${path}"'`);
-          if (result.exitCode !== 0) throw new Error(`Failed to write file ${path}: ${result.stderr}`);
+        writeFile: async (sandbox: RunloopSandbox, path: string, content: string): Promise<void> => {
+          await sandbox.client.devbox.fromId(sandbox.id).file.write({
+            file_path: path,
+            contents: content,
+          });
         },
 
         mkdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {
-          const result = await runCommand(sandbox, `mkdir -p "${path}"`);
+          const result = await runCommand(sandbox, `mkdir -p -- ${shellQuote(path)}`);
           if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
         },
 
         readdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<FileEntry[]> => {
-          const result = await runCommand(sandbox, `ls -la "${path}"`);
+          const result = await runCommand(
+            sandbox,
+            `find -- ${shellQuote(path)} -mindepth 1 -maxdepth 1 -exec sh -c ` +
+              `${shellQuote('for entry do name=${entry##*/}; if [ -d "$entry" ]; then type=directory; else type=file; fi; encoded=$(printf %s "$name" | base64 | tr -d "\\n"); size=$(stat -c %s -- "$entry") || exit; modified=$(stat -c %Y -- "$entry") || exit; printf "%s\\t%s\\t%s\\t%s\\n" "$encoded" "$type" "$size" "$modified"; done')} ` +
+              `sh {} +`,
+          );
           if (result.exitCode !== 0) throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
 
-          const lines = (result.stdout || "")
+          return (result.stdout || "")
             .split("\n")
-            .filter((line: string) => line.trim() && !line.startsWith("total"));
-
-          return lines.map((line: string) => {
-            const parts = line.trim().split(/\s+/);
-            const name = parts[parts.length - 1];
-            const isDirectory = line.startsWith("d");
-            return {
-              name,
-              type: isDirectory ? 'directory' as const : 'file' as const,
-              size: parseInt(parts[4]) || 0,
-              modified: new Date(),
-            };
-          });
+            .filter(Boolean)
+            .map((line: string) => {
+              const [encodedName, type, rawSize, rawModified] = line.split("\t");
+              const size = Number(rawSize);
+              const modifiedSeconds = Number(rawModified);
+              if (!encodedName || (type !== "file" && type !== "directory") ||
+                  !Number.isFinite(size) || !Number.isFinite(modifiedSeconds)) {
+                throw new Error(`Malformed Runloop directory entry: ${JSON.stringify(line)}`);
+              }
+              return {
+                name: Buffer.from(encodedName, "base64").toString("utf8"),
+                type,
+                size,
+                modified: new Date(modifiedSeconds * 1000),
+              };
+            });
         },
 
         exists: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<boolean> => {
-          const result = await runCommand(sandbox, `test -e "${path}"`);
+          const result = await runCommand(sandbox, `test -e ${shellQuote(path)}`);
           return result.exitCode === 0;
         },
 
         remove: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {
-          const result = await runCommand(sandbox, `rm -rf "${path}"`);
+          const normalized = normalizePosixPath(path);
+          if (path.length === 0 || normalized === "/" || normalized === "." ||
+              normalized === ".." || normalized.startsWith("../")) {
+            throw new Error(`Refusing to remove unsafe path: ${JSON.stringify(path)}`);
+          }
+          const result = await runCommand(sandbox, `rm -rf -- ${shellQuote(path)}`);
           if (result.exitCode !== 0) throw new Error(`Failed to remove ${path}: ${result.stderr}`);
         },
       },
@@ -392,10 +577,9 @@ export const runloop = defineProvider<
 
       list: async (config: RunloopConfig, options?: { limit?: number }) => {
         const client = getRunloopClient(config);
-        const listParams: any = {};
-        if (options?.limit) listParams.limit = options.limit;
-        const response = await client.api.blueprints.list(listParams);
-        return response.blueprints || [];
+        const listParams: Runloop.BlueprintListParams = {};
+        if (options?.limit !== undefined) listParams.limit = options.limit;
+        return collectPaginated(client.api.blueprints.list(listParams), options?.limit);
       },
 
       delete: async (config: RunloopConfig, blueprintId: string) => {
@@ -407,18 +591,23 @@ export const runloop = defineProvider<
     snapshot: {
       create: async (config: RunloopConfig, sandboxId: string, options?: CreateSnapshotOptions) => {
         const client = getRunloopClient(config);
-        const snapshotParams: any = {};
+        const snapshotParams: Runloop.DevboxSnapshotDiskParams = {};
         if (options?.name) snapshotParams.name = options.name;
         if (options?.metadata) snapshotParams.metadata = options.metadata;
-        return client.api.devboxes.snapshotDisk(sandboxId, snapshotParams);
+        const snapshot = await client.api.devboxes.snapshotDisk(sandboxId, snapshotParams);
+        return normalizeSnapshot(snapshot);
       },
 
       list: async (config: RunloopConfig, options?: ListSnapshotsOptions) => {
         const client = getRunloopClient(config);
-        const listParams: any = {};
-        if (options?.limit) listParams.limit = options.limit;
-        const response = await client.api.devboxes.listDiskSnapshots(listParams);
-        return response.snapshots || [];
+        const listParams: Runloop.DevboxListDiskSnapshotsParams = {};
+        if (options?.limit !== undefined) listParams.limit = options.limit;
+        if (options?.sandboxId) listParams.devbox_id = options.sandboxId;
+        const snapshots = await collectPaginated(
+          client.api.devboxes.listDiskSnapshots(listParams),
+          options?.limit,
+        );
+        return snapshots.map(normalizeSnapshot);
       },
 
       delete: async (config: RunloopConfig, snapshotId: string) => {

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -7,6 +7,7 @@
 
 import { RunloopSDK, type Runloop } from "@runloop/api-client";
 import { defineProvider } from "@computesdk/provider";
+import { posix as posixPath } from "node:path";
 import type {
   CommandResult,
   SandboxInfo,
@@ -74,47 +75,16 @@ function longPollOptions<TOptions>(timeoutMs?: number): TOptions | undefined {
   return timeoutMs ? ({ longPoll: { timeoutMs } } as TOptions) : undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function deepMerge<T extends Record<string, unknown>>(
-  base: T,
-  override?: Record<string, unknown>,
-): T {
-  if (!override) return { ...base };
-
-  const merged: Record<string, unknown> = { ...base };
-  for (const [key, value] of Object.entries(override)) {
-    const current = merged[key];
-    merged[key] = isRecord(current) && isRecord(value)
-      ? deepMerge(current, value)
-      : value;
-  }
-  return merged as T;
-}
-
-function shellQuote(value: string): string {
+function quotePosixShellToken(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-function normalizePosixPath(value: string): string {
-  const absolute = value.startsWith("/");
-  const parts: string[] = [];
-  for (const part of value.split("/")) {
-    if (!part || part === ".") continue;
-    if (part === "..") {
-      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
-        parts.pop();
-      } else if (!absolute) {
-        parts.push(part);
-      }
-    } else {
-      parts.push(part);
-    }
+function assertSafeRemovalPath(value: string): void {
+  const normalized = posixPath.normalize(value);
+  if (value.length === 0 || normalized === "/" || normalized === "." ||
+      normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`Refusing to remove unsafe path: ${JSON.stringify(value)}`);
   }
-  if (absolute) return `/${parts.join("/")}`;
-  return parts.join("/") || ".";
 }
 
 function buildCommand(command: string, options?: RunCommandOptions): string {
@@ -126,25 +96,67 @@ function buildCommand(command: string, options?: RunCommandOptions): string {
         if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
           throw new Error(`Invalid environment variable name: ${JSON.stringify(key)}`);
         }
-        return `${key}=${shellQuote(String(value))}`;
+        return `${key}=${quotePosixShellToken(String(value))}`;
       })
       .join(" ");
     fullCommand = `${envPrefix} ${fullCommand}`;
   }
 
   if (options?.cwd) {
-    fullCommand = `cd -- ${shellQuote(options.cwd)} && ${fullCommand}`;
+    fullCommand = `cd -- ${quotePosixShellToken(options.cwd)} && ${fullCommand}`;
   }
 
   if (options?.background) {
-    fullCommand = `nohup sh -lc ${shellQuote(fullCommand)} >/dev/null 2>&1 &`;
+    fullCommand = `nohup sh -lc ${quotePosixShellToken(fullCommand)} >/dev/null 2>&1 &`;
   }
 
   return fullCommand;
 }
 
 function isHttpNotFound(error: unknown): boolean {
-  return isRecord(error) && error.status === 404;
+  return typeof error === "object" && error !== null &&
+    "status" in error && error.status === 404;
+}
+
+const READDIR_ENTRY_SCRIPT = [
+  "for entry; do",
+  '  name=${entry##*/}',
+  '  if [ -d "$entry" ]; then type=directory; else type=file; fi',
+  '  encoded=$(printf %s "$name" | base64 | tr -d "\\n")',
+  '  size=$(stat -c %s -- "$entry") || exit',
+  '  modified=$(stat -c %Y -- "$entry") || exit',
+  '  printf "%s\\t%s\\t%s\\t%s\\n" "$encoded" "$type" "$size" "$modified"',
+  "done",
+].join("\n");
+
+function buildReaddirCommand(path: string): string {
+  const findRoot = path.startsWith("-") ? `./${path}` : path;
+  return [
+    `find -- ${quotePosixShellToken(findRoot)} -mindepth 1 -maxdepth 1 -exec sh -c`,
+    quotePosixShellToken(READDIR_ENTRY_SCRIPT),
+    "sh {} +",
+  ].join(" ");
+}
+
+function parseReaddirOutput(stdout: string): FileEntry[] {
+  return stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [encodedName, type, rawSize, rawModified] = line.split("\t");
+      const size = Number(rawSize);
+      const modifiedSeconds = Number(rawModified);
+      if (!encodedName || (type !== "file" && type !== "directory") ||
+          !Number.isFinite(size) || !Number.isFinite(modifiedSeconds)) {
+        throw new Error(`Malformed Runloop directory entry: ${JSON.stringify(line)}`);
+      }
+      return {
+        name: Buffer.from(encodedName, "base64").toString("utf8"),
+        type,
+        size,
+        modified: new Date(modifiedSeconds * 1000),
+      };
+    });
 }
 
 function mapStatus(status: Runloop.DevboxView["status"]): SandboxInfo["status"] {
@@ -449,16 +461,15 @@ export const runloop = defineProvider<
           } = options || {};
 
           const effectiveTimeout = optTimeout ?? timeout;
-          const keepAliveSeconds = optLaunchParameters?.keep_alive_time_seconds
-            ?? (effectiveTimeout !== undefined
-              ? Math.ceil(effectiveTimeout / 1000)
-              : 1800);
+          const keepAliveSeconds = effectiveTimeout !== undefined
+            ? Math.ceil(effectiveTimeout / 1000)
+            : 1800;
 
           let devboxParams: Runloop.DevboxCreateParams = {
-            launch_parameters: deepMerge(
-              { keep_alive_time_seconds: keepAliveSeconds },
-              (optLaunchParameters ?? {}) as Record<string, unknown>,
-            ) as Runloop.DevboxCreateParams["launch_parameters"],
+            launch_parameters: {
+              keep_alive_time_seconds: keepAliveSeconds,
+              ...optLaunchParameters,
+            } as Runloop.DevboxCreateParams["launch_parameters"],
             name: name || optSandboxId,
             metadata,
             environment_variables: envs,
@@ -615,52 +626,25 @@ export const runloop = defineProvider<
         },
 
         mkdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {
-          const result = await runCommand(sandbox, `mkdir -p -- ${shellQuote(path)}`);
+          const result = await runCommand(sandbox, `mkdir -p -- ${quotePosixShellToken(path)}`);
           if (result.exitCode !== 0) throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
         },
 
         readdir: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<FileEntry[]> => {
-          const findPath = path.startsWith("-") ? `./${path}` : path;
-          const result = await runCommand(
-            sandbox,
-            `find -- ${shellQuote(findPath)} -mindepth 1 -maxdepth 1 -exec sh -c ` +
-              `${shellQuote('for entry do name=${entry##*/}; if [ -d "$entry" ]; then type=directory; else type=file; fi; encoded=$(printf %s "$name" | base64 | tr -d "\\n"); size=$(stat -c %s -- "$entry") || exit; modified=$(stat -c %Y -- "$entry") || exit; printf "%s\\t%s\\t%s\\t%s\\n" "$encoded" "$type" "$size" "$modified"; done')} ` +
-              `sh {} +`,
-          );
+          const result = await runCommand(sandbox, buildReaddirCommand(path));
           if (result.exitCode !== 0) throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
 
-          return (result.stdout || "")
-            .split("\n")
-            .filter(Boolean)
-            .map((line: string) => {
-              const [encodedName, type, rawSize, rawModified] = line.split("\t");
-              const size = Number(rawSize);
-              const modifiedSeconds = Number(rawModified);
-              if (!encodedName || (type !== "file" && type !== "directory") ||
-                  !Number.isFinite(size) || !Number.isFinite(modifiedSeconds)) {
-                throw new Error(`Malformed Runloop directory entry: ${JSON.stringify(line)}`);
-              }
-              return {
-                name: Buffer.from(encodedName, "base64").toString("utf8"),
-                type,
-                size,
-                modified: new Date(modifiedSeconds * 1000),
-              };
-            });
+          return parseReaddirOutput(result.stdout || "");
         },
 
         exists: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<boolean> => {
-          const result = await runCommand(sandbox, `test -e ${shellQuote(path)}`);
+          const result = await runCommand(sandbox, `test -e ${quotePosixShellToken(path)}`);
           return result.exitCode === 0;
         },
 
         remove: async (sandbox: RunloopSandbox, path: string, runCommand: CommandRunner): Promise<void> => {
-          const normalized = normalizePosixPath(path);
-          if (path.length === 0 || normalized === "/" || normalized === "." ||
-              normalized === ".." || normalized.startsWith("../")) {
-            throw new Error(`Refusing to remove unsafe path: ${JSON.stringify(path)}`);
-          }
-          const result = await runCommand(sandbox, `rm -rf -- ${shellQuote(path)}`);
+          assertSafeRemovalPath(path);
+          const result = await runCommand(sandbox, `rm -rf -- ${quotePosixShellToken(path)}`);
           if (result.exitCode !== 0) throw new Error(`Failed to remove ${path}: ${result.stderr}`);
         },
       },

--- a/packages/runloop/src/index.ts
+++ b/packages/runloop/src/index.ts
@@ -318,12 +318,11 @@ async function executeCommand(
   });
 
   try {
-    const requestTimeoutMs = Math.max(1, deadline - Date.now());
-    const executionPromise = devbox.cmd.execAsync(
-      fullCommand,
-      {},
-      { signal: monitorController.signal, timeout: requestTimeoutMs },
-    );
+    // Keep creation alive after the caller's deadline. Aborting this non-idempotent
+    // request can hide an execution that the server already accepted, leaving no ID
+    // available for cleanup. The caller still returns at the deadline; if creation
+    // resolves later, the timeout branch below kills the remote process group.
+    const executionPromise = devbox.cmd.execAsync(fullCommand);
     const creationOutcome = await Promise.race([
       executionPromise.then((createdExecution) => ({ execution: createdExecution })),
       timeoutPromise,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1840,8 +1840,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@runloop/api-client':
-        specifier: ^1.24.0
-        version: 1.24.0
+        specifier: ^1.28.0
+        version: 1.28.0
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -4992,8 +4992,8 @@ packages:
     resolution: {integrity: sha512-E0RZ0fArFX32R88mOq5w4nmBb2LOz9UB1gGgOCVo3b08Ly90IuyTYarh4VonHj5b/UtP5WA0sorWYvvIVaPtKg==}
     engines: {node: '>=20'}
 
-  '@runloop/api-client@1.24.0':
-    resolution: {integrity: sha512-A/G9l2MlBz/u0Wr2RvCEJvh0+4Pn/8p15BTq9wQt3vEgEGLEk844+9bIKsfWbDvU/4JdRvIUND79Vu5qvKQzUQ==}
+  '@runloop/api-client@1.28.0':
+    resolution: {integrity: sha512-ZQVSbSutqknTjgRpsfiiI5WXSkx5KgQvWkUpZQwGMsHR+dPCyM6QQegbAYqQaKuhIxEwxsLkJrSTm2fJkXmunw==}
 
   '@sailresearch/sdk-darwin-arm64@0.5.1':
     resolution: {integrity: sha512-ShPaFm0+9rfs0vdfKPVW74Q00xNu4IJhVIDF3oACWtkcr3SQg783E4HdgORSUpU45zavXPheRbKCVNoE8cGm4A==}
@@ -12255,7 +12255,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@runloop/api-client@1.24.0':
+  '@runloop/api-client@1.28.0':
     dependencies:
       '@types/node': 18.19.123
       '@types/node-fetch': 2.6.13
@@ -12264,8 +12264,7 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
-      tar: 7.5.9
-      undici: 7.28.0
+      tar: 7.5.22
       uuidv7: 1.1.0
       zod: 3.25.76
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- upgrade `@runloop/api-client` to 1.28 and use its high-level execution and native UTF-8 file APIs
- add native streaming, full-output reconciliation, one caller deadline across async creation and monitoring, and best-effort process-group cancellation without losing late execution IDs
- harden shell-only filesystem fallbacks with reusable quoting/removal helpers and structured base64 directory metadata
- refresh lifecycle state, surface non-404 failures, exhaust cursor pagination, normalize snapshots, and add a patch changeset
- simplify launch-parameter merging and the `readdir` fallback without adding benchmark-specific paths or behavior

## Validation

- `pnpm build`
- `pnpm test` (includes 28 deterministic Runloop adapter tests)
- `pnpm typecheck`
- `pnpm lint`
- `RUNLOOP_INTEGRATION=1 pnpm --filter @computesdk/runloop test` (28 deterministic tests plus 1 live shared-devbox fixture; 29/29 passed)
- exact upstream Sandbox Dax workload from `computesdk/benchmarks@a952896d30e10a294805b6587078f59fa06004eb` (script SHA-256 `6b2b4dcca4cdaaa220b78aa229a29492c2c376e2c9f14f6ba9045cc56583b6d3`) on an 8-vCPU/16-GiB Runloop devbox through head `43f393b3`: 7/7 phases passed, exit 0, 653 output lines / 42,844 bytes recovered
- full `review-and-fix`: fixed native write-status handling, total timeout coverage, and late creation-response cleanup; final immutable-head deep + claim-readiness result validated as approve with no findings
