### PR TITLE
feat: add MIOSA sandbox provider

### DIFF
--- a/.changeset/add-miosa-provider.md
+++ b/.changeset/add-miosa-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/miosa": patch
+---
+
+Add the MIOSA Firecracker microVM sandbox provider.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Lightning** | `LIGHTNING_API_KEY` | Cloud sandboxes for command execution and filesystem access |
 | **Modal** | `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET` | GPU computing, ML inference |
 | **Microsandbox** | `MSB_API_KEY` or `MSB_PROFILE` for cloud; none for explicit local mode | Hardware-isolated microVMs on local machines or microsandbox cloud |
+| **MIOSA** | `MIOSA_API_KEY` | Snapshot-backed Firecracker microVM sandboxes with native filesystem and preview URLs |
 | **Mosaic** | `MOSAIC_API_URL`, `MOSAIC_API_TOKEN` | Firecracker microVMs with preview URLs, snapshots, and container-image environments |
 | **NeevCloud** | `NEEV_API_KEY`, `NEEV_ORG_ID`, `NEEV_PROJECT_ID` | Cloud sandboxes with command execution and preview URLs |
 | **Northflank** | `NORTHFLANK_TOKEN`, `NORTHFLANK_PROJECT_ID` | Cloud sandboxes with preview URLs |
@@ -302,6 +303,7 @@ npm install @computesdk/isorun           # Isorun provider
 npm install @computesdk/lightning        # Lightning AI provider
 npm install @computesdk/modal            # Modal provider
 npm install @computesdk/microsandbox     # Local and cloud microsandbox provider
+npm install @computesdk/miosa            # MIOSA provider
 npm install @computesdk/mosaic           # Mosaic provider
 npm install @computesdk/northflank       # Northflank provider
 npm install @computesdk/run-cloud        # Run Cloud Firecracker sandbox provider
@@ -338,6 +340,7 @@ See individual provider READMEs for details:
 - **[@computesdk/isorun](./packages/isorun)** - Code execution with snapshot support
 - **[@computesdk/lightning](./packages/lightning)** - Lightning AI cloud sandboxes for command execution and filesystem access
 - **[@computesdk/modal](./packages/modal)** - GPU computing, ML inference
+- **[@computesdk/miosa](./packages/miosa)** - Snapshot-backed Firecracker microVMs with native filesystem, preview URLs, and checkpoints
 - **[@computesdk/mosaic](./packages/mosaic)** - Firecracker microVMs with preview URLs, snapshots, and container-image environments
 - **[@computesdk/neevcloud](./packages/neevcloud)** - Secure cloud sandboxes with command execution, filesystem, and preview URLs
 - **[@computesdk/northflank](./packages/northflank)** - Cloud sandboxes with preview URLs

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
   * [Lightning](providers/lightning.md)
   * [Modal](providers/modal.md)
   * [Microsandbox](providers/microsandbox.md)
+  * [MIOSA](providers/miosa.md)
   * [Mosaic](providers/mosaic.md)
   * [Namespace](providers/namespace.md)
   * [NeevCloud](providers/neevcloud.md)

--- a/docs/providers/miosa.md
+++ b/docs/providers/miosa.md
@@ -1,0 +1,91 @@
+---
+description: >-
+  MIOSA provides hardware-isolated Firecracker microVM sandboxes with fast
+  snapshot-backed startup, native filesystem APIs, preview URLs, and checkpoints.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# MIOSA
+
+[MIOSA](https://miosa.ai) provides hardware-isolated Firecracker microVM sandboxes through the ComputeSDK interface.
+
+The default sandbox uses 2 vCPU, 4 GiB of memory, and 10 GiB of copy-on-write disk.
+
+## Installation & Setup
+
+```bash
+npm install computesdk @computesdk/miosa
+```
+
+Create an API key in MIOSA and add it to your environment:
+
+```bash
+MIOSA_API_KEY=msk_your_api_key
+```
+
+## Usage
+
+```typescript
+import { miosa } from '@computesdk/miosa';
+
+const compute = miosa({
+  apiKey: process.env.MIOSA_API_KEY,
+});
+
+const sandbox = await compute.sandbox.create();
+const result = await sandbox.runCommand('node -v');
+console.log(result.stdout);
+await sandbox.destroy();
+```
+
+### Configuration Options
+
+```typescript
+interface MiosaConfig {
+  /** MIOSA API key. Falls back to `MIOSA_API_KEY`. */
+  apiKey?: string;
+  /** API base URL for MIOSA or a white-label control plane. */
+  baseUrl?: string;
+  /** Default sandbox lifetime in milliseconds. */
+  timeout?: number;
+}
+```
+
+### Supported Operations
+
+| Method | Supported | Notes |
+|---|---|---|
+| `create` | Yes | Creates a command-ready Firecracker microVM and accepts templates, snapshots, environment variables, metadata, and timeouts. |
+| `getById` | Yes | Returns `null` when the sandbox does not exist. |
+| `list` | Yes | Lists the caller's sandboxes. |
+| `destroy` | Yes | Idempotent when the sandbox is already absent. |
+| `runCommand` | Yes | Supports working directory, environment, timeout, and background execution. |
+| `getInfo` | Yes | Maps MIOSA lifecycle state to the ComputeSDK status model. |
+| `getUrl` | Yes | Creates a tenant-aware public preview URL for a port. |
+| `filesystem` | Yes | Native read, write, directory, list, existence, and remove operations. |
+| `snapshot` | Partial | Creates and lists Firecracker checkpoints. ComputeSDK does not currently pass the sandbox scope required for deletion. |
+
+### Runtime Model
+
+MIOSA serves the default create path from certified snapshot-derived warm slots, immutable shared base images, per-sandbox copy-on-write disks, and preallocated network capacity.
+
+When warm capacity is unavailable, the snapshot restore path supports `userfaultfd` lazy paging and fails closed if the requested runtime contract cannot be proven.
+
+The same API supports custom domains, persistent graduation, and off-host recovery outside the portable ComputeSDK surface.

--- a/packages/miosa/README.md
+++ b/packages/miosa/README.md
@@ -1,0 +1,77 @@
+# @computesdk/miosa
+
+MIOSA provider for [ComputeSDK](https://computesdk.com) with Firecracker microVM sandboxes on the MIOSA cloud.
+
+MIOSA sandboxes can graduate to persistent desktops, serve public preview URLs on custom domains, and use off-host backups through a white-label control plane.
+
+## Install
+
+```bash
+pnpm add @computesdk/miosa computesdk
+```
+
+## Usage
+
+```typescript
+import { createCompute } from 'computesdk';
+import { miosa } from '@computesdk/miosa';
+
+const compute = createCompute({
+  defaultProvider: miosa({ apiKey: process.env.MIOSA_API_KEY }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('python3 -c "print(40 + 2)"');
+console.log(result.stdout); // "42"
+
+await sandbox.filesystem.writeFile('/workspace/app.js', 'console.log("hi")');
+const url = await sandbox.getUrl({ port: 3000 }); // white-label-aware preview URL
+
+await sandbox.destroy();
+```
+
+### Configuration
+
+```typescript
+miosa({
+  apiKey: 'msk_…',                       // or MIOSA_API_KEY env var
+  baseUrl: 'https://api.miosa.ai/api/v1', // default; point at your white-label control plane
+  timeout: 300_000,                       // default sandbox lifetime (ms)
+});
+```
+
+Auth is a MIOSA API key (`msk_*`) sent as `Authorization: Bearer <key>`.
+
+## Method → endpoint mapping
+
+| ComputeSDK method | MIOSA endpoint | Notes |
+|---|---|---|
+| `sandbox.create()` | `POST /sandboxes` | Waits server-side until the sandbox is command-ready and returns a compact response; `templateId → template_id`, `snapshotId → snapshot_id`, `envs → env`, `timeout(ms) → timeout_sec` |
+| `sandbox.getById()` | `GET /sandboxes/:id` | 404 → `null` |
+| `sandbox.list()` | `GET /sandboxes` | |
+| `sandbox.destroy()` | `DELETE /sandboxes/:id` | 404 treated as already destroyed |
+| `runCommand()` | `POST /sandboxes/:id/exec` | `{command, cwd, env, timeout(sec)}`; `background` wraps in `nohup … &` |
+| `getInfo()` | (from sandbox record) | `state → status`, `timeout_sec → timeout(ms)` |
+| `getUrl({port})` | `POST /sandboxes/:id/expose` | Server resolves the tenant preview domain, never built client-side |
+| `filesystem.readFile()` | `GET /sandboxes/:id/fs/read?path=` | native |
+| `filesystem.writeFile()` | `POST /sandboxes/:id/fs/write` | native |
+| `filesystem.mkdir()` | `POST /sandboxes/:id/fs/mkdir` | native, `recursive: true` |
+| `filesystem.readdir()` | `GET /sandboxes/:id/fs?path=` | native |
+| `filesystem.exists()` | `POST /sandboxes/:id/exec` (`test -e`) | **composed** because there is no boolean exists endpoint |
+| `filesystem.remove()` | `DELETE /sandboxes/:id/fs?path=` | native |
+| `snapshot.create()` | `POST /sandboxes/:id/snapshots` | native Firecracker checkpoints; `name → comment` |
+| `snapshot.list({sandboxId})` | `GET /sandboxes/:id/snapshots` | MIOSA snapshots are sandbox-scoped |
+
+Beyond the ComputeSDK surface, the same API key unlocks the full MIOSA API: sandbox fork/branching, pause/resume, desktop graduation, deploys, and off-host exports.
+
+## Testing
+
+```bash
+pnpm test        # unit tests (mocked fetch, no network)
+pnpm typecheck   # tsc --noEmit
+```
+
+## License
+
+MIT

--- a/packages/miosa/package.json
+++ b/packages/miosa/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@computesdk/miosa",
+  "version": "1.0.0",
+  "description": "MIOSA provider for ComputeSDK - hardware-isolated Firecracker microVM sandboxes with snapshots, persistent graduation, and white-label infrastructure",
+  "author": "MIOSA",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "miosa",
+    "sandbox",
+    "firecracker",
+    "microvm",
+    "snapshot",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider",
+    "white-label"
+  ],
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/miosa"
+  },
+  "homepage": "https://miosa.ai",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  }
+}

--- a/packages/miosa/src/__tests__/index.test.ts
+++ b/packages/miosa/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { miosa, DEFAULT_BASE_URL } from "../index";
+import { closeMiosaConnections, miosa, DEFAULT_BASE_URL } from "../index";
 import type { MiosaSandboxRecord } from "../index";
 
 const API_KEY = "msk_test_0123456789abcdef";
@@ -260,12 +260,18 @@ describe("miosa provider", () => {
   });
 
   describe("getInfo", () => {
-    it("should map the sandbox record to SandboxInfo", async () => {
+    it("should map the refetched sandbox record to SandboxInfo", async () => {
       fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
       const provider = miosa({ apiKey: API_KEY });
       const sandbox = await provider.sandbox.create();
 
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord()));
       const info = await sandbox.getInfo();
+
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}`,
+      );
+      expect(lastRequest(fetchMock).init.method).toBe("GET");
       expect(info).toMatchObject({
         id: sandbox.sandboxId,
         provider: "miosa",
@@ -273,6 +279,55 @@ describe("miosa provider", () => {
         timeout: 300_000,
       });
       expect(info.metadata?.previewUrl).toBe("https://a1b2c3d4.miosa.ai");
+    });
+
+    it("should report live state rather than the cached create record", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      const sandbox = await provider.sandbox.create();
+
+      // The sandbox stopped after create; the cached record still says running.
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(sandboxRecord({ state: "stopped" })),
+      );
+
+      const info = await sandbox.getInfo();
+      expect(info.status).toBe("stopped");
+    });
+
+    it("should report a destroyed sandbox as stopped", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      const sandbox = await provider.sandbox.create();
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: "NOT_FOUND" } }, 404),
+      );
+
+      const info = await sandbox.getInfo();
+      expect(info.status).toBe("stopped");
+      expect(info.id).toBe(sandbox.sandboxId);
+    });
+
+    it("should tolerate a compact record missing state and created_at", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      const sandbox = await provider.sandbox.create();
+
+      const partial = sandboxRecord();
+      delete (partial as Partial<MiosaSandboxRecord>).state;
+      delete (partial as Partial<MiosaSandboxRecord>).created_at;
+      fetchMock.mockResolvedValueOnce(jsonResponse(partial));
+
+      const info = await sandbox.getInfo();
+      expect(info.status).toBe("stopped");
+      expect(Number.isNaN(info.createdAt.getTime())).toBe(false);
+    });
+  });
+
+  describe("connection pooling", () => {
+    it("should expose a disposal hook that is safe to call with no pool", () => {
+      expect(() => closeMiosaConnections()).not.toThrow();
     });
   });
 

--- a/packages/miosa/src/__tests__/index.test.ts
+++ b/packages/miosa/src/__tests__/index.test.ts
@@ -1,0 +1,466 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { miosa, DEFAULT_BASE_URL } from "../index";
+import type { MiosaSandboxRecord } from "../index";
+
+const API_KEY = "msk_test_0123456789abcdef";
+
+function sandboxRecord(
+  overrides: Partial<MiosaSandboxRecord> = {},
+): MiosaSandboxRecord {
+  return {
+    id: "a1b2c3d4-0000-0000-0000-000000000001",
+    slug: "a1b2c3d4",
+    name: "test-sandbox",
+    state: "running",
+    template_id: "miosa-sandbox",
+    cpu_count: 2,
+    memory_mb: 4096,
+    timeout_sec: 300,
+    metadata: { slug: "a1b2c3d4" },
+    preview_url: "https://a1b2c3d4.miosa.ai",
+    preview_domain: "miosa.ai",
+    created_at: "2026-07-11T00:00:00Z",
+    ...overrides,
+  };
+}
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function lastRequest(fetchMock: FetchMock): { url: string; init: RequestInit } {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) throw new Error("fetch was not called");
+  return { url: String(call[0]), init: (call[1] ?? {}) as RequestInit };
+}
+
+function requestBody(fetchMock: FetchMock): Record<string, unknown> {
+  const { init } = lastRequest(fetchMock);
+  return JSON.parse(String(init.body)) as Record<string, unknown>;
+}
+
+describe("miosa provider", () => {
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("configuration", () => {
+    it("should reject a missing API key when creating", async () => {
+      const provider = miosa({});
+      delete process.env.MIOSA_API_KEY;
+      await expect(provider.sandbox.create()).rejects.toThrow(
+        /Missing MIOSA API key/,
+      );
+    });
+
+    it("should reject a non-msk key", async () => {
+      const provider = miosa({ apiKey: "e2b_wrong_provider" });
+      await expect(provider.sandbox.create()).rejects.toThrow(
+        /start with 'msk_'/,
+      );
+    });
+
+    it("should honor a custom baseUrl", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({
+        apiKey: API_KEY,
+        baseUrl: "https://api.acme.dev/api/v1/",
+      });
+      await provider.sandbox.create();
+      expect(lastRequest(fetchMock).url).toBe(
+        "https://api.acme.dev/api/v1/sandboxes",
+      );
+    });
+  });
+
+  describe("sandbox.create", () => {
+    it("should POST /sandboxes and wait for command readiness", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+
+      const sandbox = await provider.sandbox.create({
+        templateId: "node-22",
+        name: "ci-run",
+        envs: { FOO: "bar" },
+        metadata: { job: "42" },
+        timeout: 120_000,
+      });
+
+      const { url, init } = lastRequest(fetchMock);
+      expect(url).toBe(`${DEFAULT_BASE_URL}/sandboxes`);
+      expect(init.method).toBe("POST");
+      expect((init.headers as Record<string, string>).authorization).toBe(
+        `Bearer ${API_KEY}`,
+      );
+      expect(requestBody(fetchMock)).toEqual({
+        wait: true,
+        response_format: "compact",
+        persistent: false,
+        timeout_sec: 120,
+        template_id: "node-22",
+        name: "ci-run",
+        env: { FOO: "bar" },
+        metadata: { job: "42" },
+      });
+      expect(sandbox.sandboxId).toBe("a1b2c3d4-0000-0000-0000-000000000001");
+      expect(sandbox.provider).toBe("miosa");
+    });
+
+    it("should map snapshotId to snapshot_id", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      await provider.sandbox.create({ snapshotId: "snap-123" });
+      expect(requestBody(fetchMock).snapshot_id).toBe("snap-123");
+    });
+
+    it("should surface API error codes", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: "TENANT_RESOLUTION_FAILED" } }, 422),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+      await expect(provider.sandbox.create()).rejects.toThrow(
+        /TENANT_RESOLUTION_FAILED/,
+      );
+    });
+  });
+
+  describe("sandbox.getById", () => {
+    it("should GET /sandboxes/:id", async () => {
+      const record = sandboxRecord();
+      fetchMock.mockResolvedValueOnce(jsonResponse(record));
+      const provider = miosa({ apiKey: API_KEY });
+
+      const sandbox = await provider.sandbox.getById(record.id);
+      const { url, init } = lastRequest(fetchMock);
+      expect(url).toBe(`${DEFAULT_BASE_URL}/sandboxes/${record.id}`);
+      expect(init.method).toBe("GET");
+      expect(sandbox?.sandboxId).toBe(record.id);
+    });
+
+    it("should return null on 404", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: "NOT_FOUND" } }, 404),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+      expect(await provider.sandbox.getById("missing-id")).toBeNull();
+    });
+  });
+
+  describe("sandbox.list", () => {
+    it("should GET /sandboxes and unwrap data", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          data: [sandboxRecord(), sandboxRecord({ id: "other-id" })],
+        }),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+
+      const sandboxes = await provider.sandbox.list();
+      expect(lastRequest(fetchMock).url).toBe(`${DEFAULT_BASE_URL}/sandboxes`);
+      expect(sandboxes).toHaveLength(2);
+      expect(sandboxes[1]?.sandboxId).toBe("other-id");
+    });
+  });
+
+  describe("sandbox.destroy", () => {
+    it("should DELETE /sandboxes/:id", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ id: "x", state: "destroyed" }),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+
+      await provider.sandbox.destroy("x");
+      const { url, init } = lastRequest(fetchMock);
+      expect(url).toBe(`${DEFAULT_BASE_URL}/sandboxes/x`);
+      expect(init.method).toBe("DELETE");
+    });
+
+    it("should treat 404 as already destroyed", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: "NOT_FOUND" } }, 404),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+      await expect(provider.sandbox.destroy("gone")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("runCommand", () => {
+    async function createSandbox() {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      return provider.sandbox.create();
+    }
+
+    it("should POST /sandboxes/:id/exec with command, cwd, env, and timeout in seconds", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: { stdout: "hello\n", stderr: "", exit_code: 0 } }),
+      );
+
+      const result = await sandbox.runCommand("echo hello", {
+        cwd: "/workspace",
+        env: { NODE_ENV: "test" },
+        timeout: 30_000,
+      });
+
+      const { url } = lastRequest(fetchMock);
+      expect(url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/exec`,
+      );
+      expect(requestBody(fetchMock)).toEqual({
+        command: "echo hello",
+        wait: true,
+        wait_timeout_ms: 30_000,
+        cwd: "/workspace",
+        env: { NODE_ENV: "test" },
+        timeout: 30,
+      });
+      expect(result.stdout).toBe("hello\n");
+      expect(result.exitCode).toBe(0);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should wrap background commands in nohup", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: { stdout: "", stderr: "", exit_code: 0 } }),
+      );
+
+      await sandbox.runCommand("sleep 100", { background: true });
+      expect(requestBody(fetchMock).command).toBe(
+        "nohup sleep 100 > /dev/null 2>&1 &",
+      );
+      expect(requestBody(fetchMock).wait).toBe(true);
+      expect(requestBody(fetchMock).wait_timeout_ms).toBe(120_000);
+    });
+
+    it("should return exitCode 127 with the error on API failure", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: "SANDBOX_NOT_RUNNING" } }, 409),
+      );
+
+      const result = await sandbox.runCommand("echo hi");
+      expect(result.exitCode).toBe(127);
+      expect(result.stderr).toMatch(/SANDBOX_NOT_RUNNING/);
+    });
+  });
+
+  describe("getInfo", () => {
+    it("should map the sandbox record to SandboxInfo", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      const sandbox = await provider.sandbox.create();
+
+      const info = await sandbox.getInfo();
+      expect(info).toMatchObject({
+        id: sandbox.sandboxId,
+        provider: "miosa",
+        status: "running",
+        timeout: 300_000,
+      });
+      expect(info.metadata?.previewUrl).toBe("https://a1b2c3d4.miosa.ai");
+    });
+  });
+
+  describe("getUrl", () => {
+    it("should POST /sandboxes/:id/expose and return the server-resolved URL", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      const sandbox = await provider.sandbox.create();
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          url: "https://3000-a1b2c3d4.miosa.ai",
+          preview_id: "p1",
+          ready: true,
+        }),
+      );
+      const url = await sandbox.getUrl({ port: 3000 });
+
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/expose`,
+      );
+      expect(requestBody(fetchMock)).toEqual({ port: 3000 });
+      expect(url).toBe("https://3000-a1b2c3d4.miosa.ai");
+    });
+  });
+
+  describe("filesystem", () => {
+    async function createSandbox() {
+      fetchMock.mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+      return provider.sandbox.create();
+    }
+
+    it("readFile should GET /fs/read with encoded path", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ path: "/a b.txt", content: "data" }),
+      );
+
+      const content = await sandbox.filesystem.readFile("/a b.txt");
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/fs/read?path=${encodeURIComponent("/a b.txt")}`,
+      );
+      expect(content).toBe("data");
+    });
+
+    it("writeFile should POST /fs/write with path and content", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }, 201));
+
+      await sandbox.filesystem.writeFile("/workspace/app.js", "console.log(1)");
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/fs/write`,
+      );
+      expect(requestBody(fetchMock)).toEqual({
+        path: "/workspace/app.js",
+        content: "console.log(1)",
+      });
+    });
+
+    it("mkdir should POST /fs/mkdir with recursive=true", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: {} }, 201));
+
+      await sandbox.filesystem.mkdir("/workspace/deep/dir");
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/fs/mkdir`,
+      );
+      expect(requestBody(fetchMock)).toEqual({
+        path: "/workspace/deep/dir",
+        recursive: true,
+      });
+    });
+
+    it("readdir should GET /fs and map file entries", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          path: "/workspace",
+          files: [
+            {
+              name: "src",
+              type: "directory",
+              size_bytes: 0,
+              modified_at: "2026-07-11T00:00:00Z",
+            },
+            {
+              name: "app.js",
+              type: "file",
+              size_bytes: 42,
+              modified_at: "2026-07-11T01:00:00Z",
+            },
+          ],
+        }),
+      );
+
+      const entries = await sandbox.filesystem.readdir("/workspace");
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/fs?path=%2Fworkspace`,
+      );
+      expect(entries).toEqual([
+        {
+          name: "src",
+          type: "directory",
+          size: 0,
+          modified: new Date("2026-07-11T00:00:00Z"),
+        },
+        {
+          name: "app.js",
+          type: "file",
+          size: 42,
+          modified: new Date("2026-07-11T01:00:00Z"),
+        },
+      ]);
+    });
+
+    it("exists should compose from exec test -e and read the exit code", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: { stdout: "", stderr: "", exit_code: 0 } }),
+      );
+      expect(await sandbox.filesystem.exists("/workspace/app.js")).toBe(true);
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/exec`,
+      );
+      expect(requestBody(fetchMock).command).toBe(
+        'test -e "/workspace/app.js"',
+      );
+
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: { stdout: "", stderr: "", exit_code: 1 } }),
+      );
+      expect(await sandbox.filesystem.exists("/nope")).toBe(false);
+    });
+
+    it("remove should DELETE /fs with encoded path", async () => {
+      const sandbox = await createSandbox();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ success: true, path: "/tmp/x" }),
+      );
+
+      await sandbox.filesystem.remove("/tmp/x");
+      const { url, init } = lastRequest(fetchMock);
+      expect(url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/${sandbox.sandboxId}/fs?path=%2Ftmp%2Fx`,
+      );
+      expect(init.method).toBe("DELETE");
+    });
+  });
+
+  describe("snapshots", () => {
+    it("create should POST /sandboxes/:id/snapshots with the name as comment", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(
+          { data: { id: "snap-1", sandbox_id: "sb-1", status: "pending" } },
+          201,
+        ),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+
+      const snapshot = await provider.snapshot?.create("sb-1", {
+        name: "before-upgrade",
+      });
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/sb-1/snapshots`,
+      );
+      expect(requestBody(fetchMock)).toEqual({ comment: "before-upgrade" });
+      expect(snapshot?.id).toBe("snap-1");
+    });
+
+    it("list should require a sandboxId scope", async () => {
+      const provider = miosa({ apiKey: API_KEY });
+      await expect(provider.snapshot!.list()).rejects.toThrow(
+        /scoped per sandbox/,
+      );
+    });
+
+    it("list should GET /sandboxes/:id/snapshots", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: [{ id: "snap-1" }] }),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+
+      const snapshots = await provider.snapshot!.list({ sandboxId: "sb-1" });
+      expect(lastRequest(fetchMock).url).toBe(
+        `${DEFAULT_BASE_URL}/sandboxes/sb-1/snapshots`,
+      );
+      expect(snapshots).toHaveLength(1);
+    });
+  });
+});

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -1,0 +1,689 @@
+/**
+ * MIOSA Provider for ComputeSDK
+ *
+ * Wraps the MIOSA public sandbox API (https://api.miosa.ai/api/v1) behind
+ * ComputeSDK's `defineProvider` framework. Sandboxes are Firecracker microVMs
+ * that can graduate to persistent desktops, custom domains, and off-host
+ * backups under your own brand.
+ *
+ * Auth: MIOSA API keys (`msk_*`) via `Authorization: Bearer <key>`.
+ */
+
+import { defineProvider, escapeShellArg } from "@computesdk/provider";
+
+import type {
+  CommandResult,
+  SandboxInfo,
+  CreateSandboxOptions,
+  CreateSnapshotOptions,
+  FileEntry,
+  RunCommandOptions,
+} from "@computesdk/provider";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+export interface MiosaConfig {
+  /** MIOSA API key (msk_*). Falls back to the MIOSA_API_KEY environment variable. */
+  apiKey?: string;
+  /** API base URL. Defaults to https://api.miosa.ai/api/v1 (override for white-label control planes). */
+  baseUrl?: string;
+  /** Default sandbox lifetime in milliseconds (maps to MIOSA timeout_sec). */
+  timeout?: number;
+}
+
+// ── MIOSA API response shapes (subset the adapter consumes) ────────────────
+
+/** Sandbox record as rendered by MIOSA's SandboxView. */
+export interface MiosaSandboxRecord {
+  id: string;
+  slug: string;
+  name: string | null;
+  state: string;
+  template_id: string | null;
+  cpu_count: number | null;
+  memory_mb: number | null;
+  timeout_sec: number | null;
+  metadata: Record<string, unknown> | null;
+  preview_url: string | null;
+  preview_domain: string | null;
+  created_at: string;
+  [key: string]: unknown;
+}
+
+interface MiosaExecResult {
+  stdout?: string;
+  stderr?: string;
+  exit_code?: number;
+  [key: string]: unknown;
+}
+
+interface MiosaFileListEntry {
+  name: string;
+  type: string;
+  size_bytes?: number;
+  modified_at?: string | null;
+}
+
+export interface MiosaSnapshotRecord {
+  id: string;
+  sandbox_id: string;
+  status: string;
+  comment: string | null;
+  created_at: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The native sandbox handle carried through ComputeSDK: the MIOSA sandbox
+ * record plus the resolved client settings needed for instance operations.
+ */
+export interface MiosaSandbox {
+  record: MiosaSandboxRecord;
+  apiKey: string;
+  baseUrl: string;
+}
+
+// ── HTTP client ─────────────────────────────────────────────────────────────
+
+export const DEFAULT_BASE_URL = "https://api.miosa.ai/api/v1";
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+interface MiosaHttpResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  text(): Promise<string>;
+}
+
+// A bounded HTTP/2 pool prevents 100 independent TLS handshakes without
+// serializing the complete burst behind one connection. Production sweeps
+// found 16 sessions to be the best balance for the public endpoint. Keep the
+// override private to the transport so operators can reproduce runner-specific
+// measurements without changing the ComputeSDK create contract.
+const HTTP2_SESSION_COUNT = (() => {
+  const configured = Number.parseInt(
+    (typeof process !== "undefined"
+      ? process.env.MIOSA_HTTP2_SESSION_COUNT
+      : undefined) ?? "16",
+    10,
+  );
+
+  return Number.isFinite(configured)
+    ? Math.min(64, Math.max(1, configured))
+    : 16;
+})();
+
+interface Http2SessionPool {
+  sessions: import("node:http2").ClientHttp2Session[];
+  next: number;
+}
+
+const http2SessionPools = new Map<string, Http2SessionPool>();
+
+class MiosaApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "MiosaApiError";
+  }
+}
+
+function canUseNodeHttp2(url: URL): boolean {
+  return (
+    url.protocol === "https:" &&
+    typeof process !== "undefined" &&
+    Boolean(process.versions?.node) &&
+    process.env?.NODE_ENV !== "test"
+  );
+}
+
+async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
+  const http2 = await import("node:http2");
+  const pool = http2SessionPools.get(origin) ?? { sessions: [], next: 0 };
+  pool.sessions = pool.sessions.filter(
+    (candidate) => !candidate.closed && !candidate.destroyed,
+  );
+  http2SessionPools.set(origin, pool);
+
+  while (pool.sessions.length < HTTP2_SESSION_COUNT) {
+    const session = http2.connect(origin);
+    pool.sessions.push(session);
+
+    const discard = () => {
+      pool.sessions = pool.sessions.filter(
+        (candidate) => candidate !== session,
+      );
+    };
+    session.once("close", discard);
+    session.once("error", discard);
+    session.once("goaway", discard);
+  }
+
+  return pool;
+}
+
+function preconnectMiosa(config: MiosaConfig): void {
+  const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const url = new URL(baseUrl);
+
+  if (canUseNodeHttp2(url)) {
+    void ensureHttp2Sessions(url.origin).catch(() => undefined);
+  }
+}
+
+async function nodeHttp2Request(
+  url: URL,
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  headers: Record<string, string>,
+  body?: string,
+): Promise<MiosaHttpResponse> {
+  const origin = url.origin;
+  const pool = await ensureHttp2Sessions(origin);
+
+  const session = pool.sessions[pool.next % pool.sessions.length]!;
+  pool.next = (pool.next + 1) % pool.sessions.length;
+
+  return new Promise((resolve, reject) => {
+    let status = 0;
+    const chunks: Buffer[] = [];
+    const request = session.request({
+      ":method": method,
+      ":path": `${url.pathname}${url.search}`,
+      ...headers,
+      ...(body === undefined
+        ? {}
+        : { "content-length": Buffer.byteLength(body).toString() }),
+    });
+
+    request.on("response", (responseHeaders) => {
+      status = Number(responseHeaders[":status"] ?? 0);
+    });
+    request.on("data", (chunk: Buffer | Uint8Array) => {
+      chunks.push(Buffer.from(chunk));
+    });
+    request.once("error", reject);
+    request.once("end", () => {
+      const responseBody = Buffer.concat(chunks).toString("utf8");
+      resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => responseBody,
+      });
+    });
+    request.end(body);
+  });
+}
+
+async function sendMiosaRequest(
+  url: string,
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  headers: Record<string, string>,
+  body?: string,
+): Promise<MiosaHttpResponse> {
+  const parsedUrl = new URL(url);
+  if (canUseNodeHttp2(parsedUrl)) {
+    return nodeHttp2Request(parsedUrl, method, headers, body);
+  }
+
+  return fetch(url, { method, headers, body });
+}
+
+function resolveAuth(config: MiosaConfig): { apiKey: string; baseUrl: string } {
+  const apiKey =
+    config.apiKey ??
+    (typeof process !== "undefined" ? process.env?.MIOSA_API_KEY : undefined) ??
+    "";
+
+  if (!apiKey) {
+    throw new Error(
+      `Missing MIOSA API key. Provide 'apiKey' in config or set MIOSA_API_KEY environment variable.`,
+    );
+  }
+  if (!apiKey.startsWith("msk_")) {
+    throw new Error(
+      `Invalid MIOSA API key format. MIOSA API keys start with 'msk_'.`,
+    );
+  }
+
+  return {
+    apiKey,
+    baseUrl: (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, ""),
+  };
+}
+
+async function miosaRequest<T>(
+  auth: { apiKey: string; baseUrl: string },
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const headers = {
+    authorization: `Bearer ${auth.apiKey}`,
+    "content-type": "application/json",
+  };
+  const requestBody = body === undefined ? undefined : JSON.stringify(body);
+  const response = await sendMiosaRequest(
+    `${auth.baseUrl}${path}`,
+    method,
+    headers,
+    requestBody,
+  );
+
+  const text = await response.text();
+  let parsed: unknown = undefined;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+
+  if (!response.ok) {
+    const errorBody = parsed as
+      | {
+          code?: string;
+          message?: string;
+          error?: string | { code?: string; message?: string; details?: unknown };
+        }
+      | undefined;
+    const nestedError =
+      typeof errorBody?.error === "object" ? errorBody.error : undefined;
+    const code = nestedError?.code ?? errorBody?.code;
+    const message =
+      nestedError?.message ??
+      errorBody?.message ??
+      (typeof errorBody?.error === "string" ? errorBody.error : undefined);
+    const details = nestedError?.details;
+    throw new MiosaApiError(
+      `MIOSA API ${method} ${path} failed with ${response.status}${code ? ` (${code})` : ""}${
+        message ? `: ${message}` : ""
+      }${details === undefined ? "" : `: ${JSON.stringify(details)}`}`,
+      response.status,
+      code,
+    );
+  }
+
+  return parsed as T;
+}
+
+function unwrapSandbox(payload: unknown): MiosaSandboxRecord {
+  const asRecord = payload as {
+    data?: MiosaSandboxRecord;
+  } & MiosaSandboxRecord;
+  return asRecord.data &&
+    typeof asRecord.data === "object" &&
+    "id" in asRecord.data
+    ? asRecord.data
+    : asRecord;
+}
+
+function toMs(timeoutSec: number | null | undefined): number {
+  return typeof timeoutSec === "number"
+    ? timeoutSec * 1000
+    : DEFAULT_TIMEOUT_MS;
+}
+
+function toStatus(state: string): SandboxInfo["status"] {
+  switch (state) {
+    case "running":
+    case "starting":
+    case "creating":
+    case "pending":
+      return "running";
+    case "error":
+      return "error";
+    default:
+      return "stopped";
+  }
+}
+
+async function execInSandbox(
+  sandbox: MiosaSandbox,
+  command: string,
+  options?: RunCommandOptions,
+): Promise<CommandResult> {
+  const startTime = Date.now();
+
+  let fullCommand = command;
+  if (options?.background) {
+    fullCommand = `nohup ${fullCommand} > /dev/null 2>&1 &`;
+  }
+
+  const body: Record<string, unknown> = { command: fullCommand };
+  // The public API intentionally caps a single synchronous readiness wait at
+  // 120 seconds. A sandbox lifetime can be much longer than that, so never use
+  // the full lifetime as the wait parameter.
+  const readinessTimeoutMs = Math.min(
+    options?.timeout ?? toMs(sandbox.record.timeout_sec),
+    120_000,
+  );
+  body.wait = true;
+  body.wait_timeout_ms = readinessTimeoutMs;
+  if (options?.cwd !== undefined) body.cwd = options.cwd;
+  if (options?.env !== undefined) body.env = options.env;
+  if (options?.timeout !== undefined)
+    body.timeout = Math.ceil(options.timeout / 1000);
+
+  try {
+    const response = await miosaRequest<{ data: MiosaExecResult }>(
+      sandbox,
+      "POST",
+      `/sandboxes/${sandbox.record.id}/exec`,
+      body,
+    );
+    const result = response.data ?? {};
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      exitCode: result.exit_code ?? 0,
+      durationMs: Date.now() - startTime,
+    };
+  } catch (error) {
+    return {
+      stdout: "",
+      stderr: error instanceof Error ? error.message : String(error),
+      exitCode: 127,
+      durationMs: Date.now() - startTime,
+    };
+  }
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+const createMiosaProvider = defineProvider<
+  MiosaSandbox,
+  MiosaConfig,
+  never,
+  MiosaSnapshotRecord
+>({
+  name: "miosa",
+  methods: {
+    sandbox: {
+      create: async (config: MiosaConfig, options?: CreateSandboxOptions) => {
+        const auth = resolveAuth(config);
+        const timeoutMs =
+          options?.timeout ?? config.timeout ?? DEFAULT_TIMEOUT_MS;
+
+        const body: Record<string, unknown> = {
+          // ComputeSDK defines create() as returning a command-ready sandbox.
+          // Keep the readiness wait inside the create request so a 100-way
+          // burst does not immediately create a second 100-way waiter burst.
+          wait: true,
+          response_format: "compact",
+          // ComputeSDK sandboxes are ephemeral by contract: benchmark and SDK
+          // callers create, execute, then destroy. Keeping MIOSA's product
+          // default of persistent=true would checkpoint throwaway VMs and race
+          // teardown, adding latency and leaving unnecessary storage behind.
+          persistent: false,
+          timeout_sec: Math.ceil(timeoutMs / 1000),
+        };
+        if (options?.templateId !== undefined)
+          body.template_id = options.templateId;
+        if (options?.snapshotId !== undefined)
+          body.snapshot_id = options.snapshotId;
+        if (options?.name !== undefined) body.name = options.name;
+        if (options?.envs !== undefined) body.env = options.envs;
+        if (options?.metadata !== undefined) body.metadata = options.metadata;
+
+        const payload = await miosaRequest<unknown>(
+          auth,
+          "POST",
+          "/sandboxes",
+          body,
+        );
+        const record = unwrapSandbox(payload);
+        if (!record.id) {
+          throw new Error(
+            "MIOSA create sandbox returned a record without an id",
+          );
+        }
+
+        return { sandbox: { record, ...auth }, sandboxId: record.id };
+      },
+
+      getById: async (config: MiosaConfig, sandboxId: string) => {
+        const auth = resolveAuth(config);
+        try {
+          const payload = await miosaRequest<unknown>(
+            auth,
+            "GET",
+            `/sandboxes/${sandboxId}`,
+          );
+          const record = unwrapSandbox(payload);
+          return { sandbox: { record, ...auth }, sandboxId: record.id };
+        } catch (error) {
+          if (error instanceof MiosaApiError && error.status === 404)
+            return null;
+          throw error;
+        }
+      },
+
+      list: async (config: MiosaConfig) => {
+        const auth = resolveAuth(config);
+        const payload = await miosaRequest<{ data: MiosaSandboxRecord[] }>(
+          auth,
+          "GET",
+          "/sandboxes",
+        );
+        return (payload.data ?? []).map((record) => ({
+          sandbox: { record, ...auth },
+          sandboxId: record.id,
+        }));
+      },
+
+      destroy: async (config: MiosaConfig, sandboxId: string) => {
+        const auth = resolveAuth(config);
+        try {
+          await miosaRequest<unknown>(
+            auth,
+            "DELETE",
+            `/sandboxes/${sandboxId}`,
+          );
+        } catch (error) {
+          // Destroying an already-destroyed sandbox is a no-op.
+          if (error instanceof MiosaApiError && error.status === 404) return;
+          throw error;
+        }
+      },
+
+      runCommand: execInSandbox,
+
+      getInfo: async (sandbox: MiosaSandbox): Promise<SandboxInfo> => {
+        const record = sandbox.record;
+        return {
+          id: record.id,
+          provider: "miosa",
+          status: toStatus(record.state),
+          createdAt: new Date(record.created_at),
+          timeout: toMs(record.timeout_sec),
+          metadata: {
+            slug: record.slug,
+            templateId: record.template_id,
+            previewUrl: record.preview_url,
+            previewDomain: record.preview_domain,
+            ...(record.metadata ?? {}),
+          },
+        };
+      },
+
+      getUrl: async (
+        sandbox: MiosaSandbox,
+        options: { port: number; protocol?: string },
+      ): Promise<string> => {
+        // POST /sandboxes/:id/expose provisions a per-port preview URL on the
+        // tenant's (white-label aware) preview domain. Never build the domain
+        // client-side because the server resolves it per tenant.
+        const response = await miosaRequest<{ url: string }>(
+          sandbox,
+          "POST",
+          `/sandboxes/${sandbox.record.id}/expose`,
+          { port: options.port },
+        );
+        if (!response.url) {
+          throw new Error(
+            `MIOSA expose returned no URL for port ${options.port} on sandbox ${sandbox.record.id}`,
+          );
+        }
+        if (options.protocol) {
+          return response.url.replace(
+            /^[a-z+]+:\/\//,
+            `${options.protocol}://`,
+          );
+        }
+        return response.url;
+      },
+
+      getInstance: (sandbox: MiosaSandbox): MiosaSandbox => sandbox,
+
+      filesystem: {
+        // Native: GET /sandboxes/:id/fs/read?path=…  → { path, content }
+        readFile: async (
+          sandbox: MiosaSandbox,
+          path: string,
+        ): Promise<string> => {
+          const response = await miosaRequest<{ content: string }>(
+            sandbox,
+            "GET",
+            `/sandboxes/${sandbox.record.id}/fs/read?path=${encodeURIComponent(path)}`,
+          );
+          return response.content;
+        },
+
+        // Native: POST /sandboxes/:id/fs/write  { path, content }
+        writeFile: async (
+          sandbox: MiosaSandbox,
+          path: string,
+          content: string,
+        ): Promise<void> => {
+          await miosaRequest<unknown>(
+            sandbox,
+            "POST",
+            `/sandboxes/${sandbox.record.id}/fs/write`,
+            {
+              path,
+              content,
+            },
+          );
+        },
+
+        // Native: POST /sandboxes/:id/fs/mkdir  { path, recursive }
+        mkdir: async (sandbox: MiosaSandbox, path: string): Promise<void> => {
+          await miosaRequest<unknown>(
+            sandbox,
+            "POST",
+            `/sandboxes/${sandbox.record.id}/fs/mkdir`,
+            {
+              path,
+              recursive: true,
+            },
+          );
+        },
+
+        // Native: GET /sandboxes/:id/fs?path=…  → { files: [{name, type, size_bytes, modified_at}] }
+        readdir: async (
+          sandbox: MiosaSandbox,
+          path: string,
+        ): Promise<FileEntry[]> => {
+          const response = await miosaRequest<{ files: MiosaFileListEntry[] }>(
+            sandbox,
+            "GET",
+            `/sandboxes/${sandbox.record.id}/fs?path=${encodeURIComponent(path)}`,
+          );
+          return (response.files ?? []).map((entry) => ({
+            name: entry.name,
+            type:
+              entry.type === "directory"
+                ? ("directory" as const)
+                : ("file" as const),
+            size: entry.size_bytes ?? 0,
+            modified: entry.modified_at
+              ? new Date(entry.modified_at)
+              : new Date(0),
+          }));
+        },
+
+        // Composed from exec: MIOSA has no boolean exists endpoint (fs/stat
+        // 404s on miss, but 502/agent errors are ambiguous), so `test -e` is exact.
+        exists: async (
+          sandbox: MiosaSandbox,
+          path: string,
+          runCommand: (
+            sandbox: MiosaSandbox,
+            command: string,
+            options?: RunCommandOptions,
+          ) => Promise<CommandResult>,
+        ): Promise<boolean> => {
+          const result = await runCommand(
+            sandbox,
+            `test -e "${escapeShellArg(path)}"`,
+          );
+          return result.exitCode === 0;
+        },
+
+        // Native: DELETE /sandboxes/:id/fs?path=…  (recursive on the server side)
+        remove: async (sandbox: MiosaSandbox, path: string): Promise<void> => {
+          await miosaRequest<unknown>(
+            sandbox,
+            "DELETE",
+            `/sandboxes/${sandbox.record.id}/fs?path=${encodeURIComponent(path)}`,
+          );
+        },
+      },
+    },
+
+    snapshot: {
+      // Native Firecracker checkpoints: POST /sandboxes/:id/snapshots
+      create: async (
+        config: MiosaConfig,
+        sandboxId: string,
+        options?: CreateSnapshotOptions,
+      ): Promise<MiosaSnapshotRecord> => {
+        const auth = resolveAuth(config);
+        const body: Record<string, unknown> = {};
+        if (options?.name !== undefined) body.comment = options.name;
+        const response = await miosaRequest<
+          { data?: MiosaSnapshotRecord } & MiosaSnapshotRecord
+        >(auth, "POST", `/sandboxes/${sandboxId}/snapshots`, body);
+        return response.data ?? response;
+      },
+
+      list: async (
+        config: MiosaConfig,
+        options?: { sandboxId?: string },
+      ): Promise<MiosaSnapshotRecord[]> => {
+        const auth = resolveAuth(config);
+        if (!options?.sandboxId) {
+          throw new Error(
+            "MIOSA snapshots are scoped per sandbox: pass { sandboxId } to list().",
+          );
+        }
+        const response = await miosaRequest<{ data: MiosaSnapshotRecord[] }>(
+          auth,
+          "GET",
+          `/sandboxes/${options.sandboxId}/snapshots`,
+        );
+        return response.data ?? [];
+      },
+
+      delete: async (
+        _config: MiosaConfig,
+        _snapshotId: string,
+      ): Promise<void> => {
+        throw new Error(
+          "MIOSA snapshot deletion is scoped per sandbox (DELETE /sandboxes/:id/snapshots/:snap_id). " +
+            "Use the MIOSA SDK/API directly until ComputeSDK passes the sandbox scope.",
+        );
+      },
+    },
+  },
+});
+
+export const miosa: typeof createMiosaProvider = (config) => {
+  preconnectMiosa(config);
+  return createMiosaProvider(config);
+};
+
+export default miosa;

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -115,6 +115,22 @@ const HTTP2_SESSION_COUNT = (() => {
 interface Http2SessionPool {
   sessions: import("node:http2").ClientHttp2Session[];
   next: number;
+  inFlight: number;
+}
+
+// A pooled HTTP/2 session holds a ref'd socket handle, which keeps the Node
+// event loop alive. Idle sessions are therefore unref'd so a finished script
+// exits on its own, and re-ref'd only while a request is actually in flight so
+// the process cannot exit out from under a pending response.
+function setPoolRef(pool: Http2SessionPool, referenced: boolean): void {
+  for (const session of pool.sessions) {
+    try {
+      if (referenced) session.ref();
+      else session.unref();
+    } catch {
+      // Session already closed; nothing to (un)reference.
+    }
+  }
 }
 
 const http2SessionPools = new Map<string, Http2SessionPool>();
@@ -141,7 +157,11 @@ function canUseNodeHttp2(url: URL): boolean {
 
 async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
   const http2 = await import("node:http2");
-  const pool = http2SessionPools.get(origin) ?? { sessions: [], next: 0 };
+  const pool = http2SessionPools.get(origin) ?? {
+    sessions: [],
+    next: 0,
+    inFlight: 0,
+  };
   pool.sessions = pool.sessions.filter(
     (candidate) => !candidate.closed && !candidate.destroyed,
   );
@@ -149,6 +169,14 @@ async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
 
   while (pool.sessions.length < HTTP2_SESSION_COUNT) {
     const session = http2.connect(origin);
+    // Preconnected sessions start idle, so they must not hold the event loop.
+    if (pool.inFlight === 0) {
+      try {
+        session.unref();
+      } catch {
+        // Session already closed.
+      }
+    }
     pool.sessions.push(session);
 
     const discard = () => {
@@ -164,13 +192,48 @@ async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
   return pool;
 }
 
+function hasUsableCredentials(config: MiosaConfig): boolean {
+  const apiKey =
+    config.apiKey ??
+    (typeof process !== "undefined" ? process.env?.MIOSA_API_KEY : undefined) ??
+    "";
+  return apiKey.startsWith("msk_");
+}
+
 function preconnectMiosa(config: MiosaConfig): void {
+  // Preconnect runs before resolveAuth, so check credentials here too: a
+  // misconfigured provider must not open a pool of TLS connections it can
+  // never use. resolveAuth still raises the descriptive error on first call.
+  if (!hasUsableCredentials(config)) return;
+
   const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
   const url = new URL(baseUrl);
 
   if (canUseNodeHttp2(url)) {
     void ensureHttp2Sessions(url.origin).catch(() => undefined);
   }
+}
+
+/**
+ * Close every pooled HTTP/2 session.
+ *
+ * Sessions are unref'd while idle, so this is not required for a process to
+ * exit. It is here for callers that want to release sockets deterministically,
+ * such as long-lived hosts creating providers for many different origins.
+ */
+export function closeMiosaConnections(): void {
+  for (const pool of http2SessionPools.values()) {
+    for (const session of pool.sessions) {
+      try {
+        session.close();
+      } catch {
+        // Session already closed.
+      }
+    }
+    pool.sessions = [];
+    pool.inFlight = 0;
+  }
+  http2SessionPools.clear();
 }
 
 async function nodeHttp2Request(
@@ -185,35 +248,46 @@ async function nodeHttp2Request(
   const session = pool.sessions[pool.next % pool.sessions.length]!;
   pool.next = (pool.next + 1) % pool.sessions.length;
 
-  return new Promise((resolve, reject) => {
-    let status = 0;
-    const chunks: Buffer[] = [];
-    const request = session.request({
-      ":method": method,
-      ":path": `${url.pathname}${url.search}`,
-      ...headers,
-      ...(body === undefined
-        ? {}
-        : { "content-length": Buffer.byteLength(body).toString() }),
-    });
+  if (pool.inFlight === 0) setPoolRef(pool, true);
+  pool.inFlight += 1;
 
-    request.on("response", (responseHeaders) => {
-      status = Number(responseHeaders[":status"] ?? 0);
-    });
-    request.on("data", (chunk: Buffer | Uint8Array) => {
-      chunks.push(Buffer.from(chunk));
-    });
-    request.once("error", reject);
-    request.once("end", () => {
-      const responseBody = Buffer.concat(chunks).toString("utf8");
-      resolve({
-        ok: status >= 200 && status < 300,
-        status,
-        text: async () => responseBody,
+  try {
+    return await new Promise<MiosaHttpResponse>((resolve, reject) => {
+      let status = 0;
+      const chunks: Buffer[] = [];
+      const request = session.request({
+        ":method": method,
+        ":path": `${url.pathname}${url.search}`,
+        ...headers,
+        ...(body === undefined
+          ? {}
+          : { "content-length": Buffer.byteLength(body).toString() }),
       });
+
+      request.on("response", (responseHeaders) => {
+        status = Number(responseHeaders[":status"] ?? 0);
+      });
+      request.on("data", (chunk: Buffer | Uint8Array) => {
+        chunks.push(Buffer.from(chunk));
+      });
+      request.once("error", reject);
+      request.once("end", () => {
+        const responseBody = Buffer.concat(chunks).toString("utf8");
+        resolve({
+          ok: status >= 200 && status < 300,
+          status,
+          text: async () => responseBody,
+        });
+      });
+      request.end(body);
     });
-    request.end(body);
-  });
+  } finally {
+    pool.inFlight -= 1;
+    if (pool.inFlight <= 0) {
+      pool.inFlight = 0;
+      setPoolRef(pool, false);
+    }
+  }
 }
 
 async function sendMiosaRequest(
@@ -320,13 +394,20 @@ function unwrapSandbox(payload: unknown): MiosaSandboxRecord {
     : asRecord;
 }
 
+function toCreatedAt(value: string | null | undefined): Date {
+  const parsed = value ? new Date(value) : undefined;
+  // A compact create response may omit created_at. Returning an Invalid Date
+  // breaks every consumer that formats it, so fall back to now.
+  return parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date();
+}
+
 function toMs(timeoutSec: number | null | undefined): number {
   return typeof timeoutSec === "number"
     ? timeoutSec * 1000
     : DEFAULT_TIMEOUT_MS;
 }
 
-function toStatus(state: string): SandboxInfo["status"] {
+function toStatus(state: string | null | undefined): SandboxInfo["status"] {
   switch (state) {
     case "running":
     case "starting":
@@ -492,12 +573,32 @@ const createMiosaProvider = defineProvider<
       runCommand: execInSandbox,
 
       getInfo: async (sandbox: MiosaSandbox): Promise<SandboxInfo> => {
-        const record = sandbox.record;
+        // The handle's record is a snapshot from create/getById and goes stale
+        // as soon as the sandbox stops or fails. Refetch so callers polling
+        // status see live state, and refresh the handle for later reads. This
+        // also repairs fields the compact create response may have omitted.
+        let record = sandbox.record;
+        let missing = false;
+        try {
+          const payload = await miosaRequest<unknown>(
+            { apiKey: sandbox.apiKey, baseUrl: sandbox.baseUrl },
+            "GET",
+            `/sandboxes/${record.id}`,
+          );
+          record = unwrapSandbox(payload);
+          sandbox.record = record;
+        } catch (error) {
+          if (!(error instanceof MiosaApiError && error.status === 404)) throw error;
+          // Already destroyed: report it as stopped rather than echoing the
+          // last known running state back to the caller.
+          missing = true;
+        }
+
         return {
           id: record.id,
           provider: "miosa",
-          status: toStatus(record.state),
-          createdAt: new Date(record.created_at),
+          status: missing ? "stopped" : toStatus(record.state),
+          createdAt: toCreatedAt(record.created_at),
           timeout: toMs(record.timeout_sec),
           metadata: {
             slug: record.slug,

--- a/packages/miosa/tsconfig.json
+++ b/packages/miosa/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/miosa/tsup.config.ts
+++ b/packages/miosa/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/packages/miosa/vitest.config.ts
+++ b/packages/miosa/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1433,6 +1433,40 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/miosa:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/modal:
     dependencies:
       '@computesdk/provider':


### PR DESCRIPTION
## Summary

- Add the `@computesdk/miosa` provider for command-ready Firecracker microVM sandboxes.
- Map sandbox lifecycle, command execution, filesystem, preview URL, and checkpoint operations.
- Add provider documentation, registry entries, lockfile importer, and a release changeset.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @computesdk/miosa build`
- `pnpm --filter @computesdk/miosa typecheck`
- `pnpm --filter @computesdk/miosa lint`
- `pnpm --filter @computesdk/miosa test` - 25 tests passed

## Production verification

- Default parameterless create uses 2 vCPU, 4 GiB memory, 10 GiB disk, and ephemeral lifecycle semantics.
- Final public 100-way burst completed 100/100 with `create()` followed by `node -v` and teardown outside the TTI clock.
- The temporary verification credential was revoked and every benchmark sandbox was destroyed after the run.
