### PR TITLE
chore(vercel): bump @vercel/sandbox to ^3.0.0

### DIFF
--- a/.changeset/vercel-sandbox-v3.md
+++ b/.changeset/vercel-sandbox-v3.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/vercel": patch
+---
+
+Bump `@vercel/sandbox` to `^3.0.0` and migrate `Sandbox.get` calls and sandbox identifiers to the `name` property introduced in v3.

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@vercel/sandbox": "^1.9.3",
+    "@vercel/sandbox": "^3.0.0",
     "computesdk": "workspace:*",
     "ms": "^2.1.3"
   },

--- a/packages/vercel/src/__tests__/snapshot-unit.test.ts
+++ b/packages/vercel/src/__tests__/snapshot-unit.test.ts
@@ -10,7 +10,7 @@ vi.mock('@vercel/sandbox', () => {
   };
 
   const mockSandboxInstance = {
-    sandboxId: 'mock-sandbox-id',
+    name: 'mock-sandbox-id',
     snapshot: vi.fn().mockResolvedValue(mockSnapshotInstance),
     stop: vi.fn().mockResolvedValue(undefined),
   };
@@ -47,7 +47,7 @@ describe('Vercel Snapshot Support', () => {
     await provider.snapshot.create('sandbox-123');
     
     expect(VercelSandbox.get).toHaveBeenCalledWith(expect.objectContaining({
-      sandboxId: 'sandbox-123',
+      name: 'sandbox-123',
       token: 'mock-token',
       teamId: 'mock-team',
       projectId: 'mock-project'

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -115,7 +115,7 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
           }
 
           const sandbox = await VercelSandbox.create(params);
-          return { sandbox, sandboxId: sandbox.sandboxId };
+          return { sandbox, sandboxId: sandbox.name };
         } catch (error) {
           if (error instanceof Error) {
             if (error.message.includes('unauthorized') || error.message.includes('token')) {
@@ -133,8 +133,8 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         const creds = resolveCredentials(config);
         try {
           const sandbox = creds.useOidc
-            ? await VercelSandbox.get({ sandboxId })
-            : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+            ? await VercelSandbox.get({ name: sandboxId })
+            : await VercelSandbox.get({ name: sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
           return { sandbox, sandboxId };
         } catch { return null; }
       },
@@ -147,8 +147,8 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         const creds = resolveCredentials(config);
         try {
           const sandbox = creds.useOidc
-            ? await VercelSandbox.get({ sandboxId })
-            : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+            ? await VercelSandbox.get({ name: sandboxId })
+            : await VercelSandbox.get({ name: sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
           await sandbox.stop();
         } catch { /* already destroyed or doesn't exist */ }
       },
@@ -227,8 +227,8 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
       create: async (config: VercelConfig, sandboxId: string) => {
         const creds = resolveCredentials(config);
         const sandbox = creds.useOidc
-          ? await VercelSandbox.get({ sandboxId })
-          : await VercelSandbox.get({ sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
+          ? await VercelSandbox.get({ name: sandboxId })
+          : await VercelSandbox.get({ name: sandboxId, token: creds.token, teamId: creds.teamId, projectId: creds.projectId });
         return await sandbox.snapshot();
       },
       list: async (_config: VercelConfig) => { throw new Error(`Vercel provider does not support listing snapshots.`); },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2340,8 +2340,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@vercel/sandbox':
-        specifier: ^1.9.3
-        version: 1.9.3
+        specifier: ^3.0.0
+        version: 3.0.0
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -5495,8 +5495,8 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vercel/sandbox@1.9.3':
-    resolution: {integrity: sha512-G6ef1izdlYftkmv2xxBfks76gm2oxIH3LgiASe8WMw7xoge6zFzyFjY91/dPMT0Pkd4UNX9nsaOedj98ywdk8Q==}
+  '@vercel/sandbox@3.0.0':
+    resolution: {integrity: sha512-1pF3id7LIG2GfjkEAZW+ZngMDdywJw7aFLOyIlry/lj8v3b4GMn3WCuBbvG4N4wTmYUfFzHaVHfdwVpqALEFkw==}
 
   '@vitest/coverage-v8@1.6.1':
     resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
@@ -8940,10 +8940,6 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  undici@7.19.0:
-    resolution: {integrity: sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -9372,9 +9368,6 @@ packages:
 
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
-
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -12991,18 +12984,19 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/sandbox@1.9.3':
+  '@vercel/sandbox@3.0.0':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2
       async-retry: 1.3.3
+      jose: 6.2.3
       jsonlines: 0.1.1
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.19.0
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
-      zod: 3.24.4
+      zod: 4.4.3
 
   '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))':
     dependencies:
@@ -17015,8 +17009,6 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@7.19.0: {}
-
   undici@7.28.0: {}
 
   undici@8.3.0: {}
@@ -17557,8 +17549,6 @@ snapshots:
       zod: 4.4.3
 
   zod@3.22.3: {}
-
-  zod@3.24.4: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Bumps `@vercel/sandbox` from `^1.9.3` to `^3.0.0` in `@computesdk/vercel` to pick up the latest major SDK improvements.

### Breaking changes addressed

Vercel Sandbox v3 replaces the `sandboxId` getter and `Sandbox.get({ sandboxId })` parameter with `name`. This PR migrates the provider accordingly:

```ts
// Before
const sandbox = await VercelSandbox.create(params);
return { sandbox, sandboxId: sandbox.sandboxId };

await VercelSandbox.get({ sandboxId, token, teamId, projectId });

// After
const sandbox = await VercelSandbox.create(params);
return { sandbox, sandboxId: sandbox.name };

await VercelSandbox.get({ name: sandboxId, token, teamId, projectId });
```

The `snapshotId`-based snapshot source object format is already v3-compatible, so no additional changes were needed there. Unit tests were updated to mock `name` instead of `sandboxId`.


Link to Devin session: https://app.devin.ai/sessions/88bc7d91241549d381b7f3e6b7714e8c
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->