### PR TITLE
feat(miosa): map vcpus/memory resource options onto MIOSA size contracts

### DIFF
--- a/.changeset/miosa-resource-options.md
+++ b/.changeset/miosa-resource-options.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/miosa": patch
+---
+
+Map ComputeSDK resource hints (vcpus/memory) onto MIOSA size contracts

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -501,6 +501,29 @@ const createMiosaProvider = defineProvider<
           persistent: false,
           timeout_sec: Math.ceil(timeoutMs / 1000),
         };
+        // Map ComputeSDK's provider-agnostic resource hints (vcpus / memory
+        // in MB) onto MIOSA's size contracts. MIOSA sizes are fixed shapes,
+        // so pick the smallest size that satisfies both requested dimensions
+        // (same interpretation Modal/Beam/Blaxel apply to these fields).
+        const requestedVcpus = options?.vcpus ?? options?.cpus ?? options?.cpu;
+        const requestedMemoryMb = options?.memory ?? options?.memoryMiB;
+        if (requestedVcpus !== undefined || requestedMemoryMb !== undefined) {
+          const sizes: Array<{ size: string; vcpus: number; memoryMb: number }> = [
+            { size: "xs", vcpus: 1, memoryMb: 2048 },
+            { size: "small", vcpus: 2, memoryMb: 4096 },
+            { size: "medium", vcpus: 4, memoryMb: 8192 },
+            { size: "large", vcpus: 8, memoryMb: 16384 },
+            { size: "xl", vcpus: 16, memoryMb: 32768 },
+          ];
+          const fit = sizes.find(
+            (candidate) =>
+              (requestedVcpus === undefined || candidate.vcpus >= requestedVcpus) &&
+              (requestedMemoryMb === undefined || candidate.memoryMb >= requestedMemoryMb),
+          );
+          // Oversized requests clamp to the largest shape rather than failing:
+          // the caller asked for "big", xl is the biggest big we sell.
+          body.size = (fit ?? sizes[sizes.length - 1]).size;
+        }
         if (options?.templateId !== undefined)
           body.template_id = options.templateId;
         if (options?.snapshotId !== undefined)


### PR DESCRIPTION
MIOSA sells fixed size contracts (xs / small / medium / large / xl). This maps ComputeSDK's provider-agnostic resource hints (`vcpus`, `memory` in MB — same fields Modal/Beam/Blaxel interpret) onto the smallest MIOSA size that satisfies both dimensions. Oversized requests clamp to xl.

This lets benchmark and SDK callers request a larger box per workload (e.g. the Dax build benchmark) without MIOSA changing its default shape.

No behavior change when no resource hints are passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->