### PR TITLE
feat(miosa): implement snapshot deletion

### DIFF
--- a/.changeset/miosa-snapshot-delete.md
+++ b/.changeset/miosa-snapshot-delete.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/miosa": patch
+---
+
+Implement snapshot deletion: resolve the owning sandbox from an in-process index populated by create/list, falling back to scanning the caller's sandboxes; idempotent on unknown or already-deleted snapshots

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -830,6 +830,7 @@ const createMiosaProvider = defineProvider<
         const auth = resolveAuth(config);
         const indexKey = snapshotIndexKey(auth, snapshotId);
         let sandboxId = snapshotSandboxIndex.get(indexKey);
+        let scanCapped = false;
         if (!sandboxId) {
           // Snapshot minted outside this process: resolve the owning sandbox
           // by scanning the caller's sandboxes. The scan is sequential and
@@ -838,7 +839,9 @@ const createMiosaProvider = defineProvider<
           const listing = await miosaRequest<{
             data?: Array<{ id: string }>;
           }>(auth, "GET", "/sandboxes");
-          const candidates = (listing.data ?? []).slice(0, SNAPSHOT_SCAN_LIMIT);
+          const all = listing.data ?? [];
+          const candidates = all.slice(0, SNAPSHOT_SCAN_LIMIT);
+          scanCapped = all.length > candidates.length;
           for (const candidate of candidates) {
             try {
               const snaps = await miosaRequest<{
@@ -856,7 +859,22 @@ const createMiosaProvider = defineProvider<
           }
         }
         if (!sandboxId) {
-          // Unknown snapshot: deletion is idempotent, treat as already gone.
+          if (scanCapped) {
+            // The scan stopped at SNAPSHOT_SCAN_LIMIT before examining every
+            // sandbox, so "not found" here does not mean "does not exist".
+            // Reporting success would leave a live snapshot billing silently.
+            throw new MiosaApiError(
+              `MIOSA could not resolve the sandbox owning snapshot ${snapshotId} ` +
+                `within the first ${SNAPSHOT_SCAN_LIMIT} sandboxes. Delete it via ` +
+                `the owning sandbox (DELETE /sandboxes/:id/snapshots/${snapshotId}), ` +
+                `or call snapshot.list({ sandboxId }) first so the provider learns ` +
+                `the mapping.`,
+              409,
+              "SNAPSHOT_OWNER_UNRESOLVED",
+            );
+          }
+          // Every sandbox was examined and none owns it: genuinely gone.
+          // Deletion is idempotent, so report success.
           return;
         }
         try {

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -68,10 +68,21 @@ interface MiosaFileListEntry {
  * Snapshot-id -> sandbox-id resolution cache. MIOSA scopes snapshot routes
  * under the owning sandbox, but ComputeSDK's snapshot.delete only carries the
  * snapshot id. Every snapshot that passes through create()/list() is
- * remembered here; delete() falls back to scanning the tenant's sandboxes
- * when the id was minted by another process.
+ * remembered here; delete() falls back to a bounded scan of the caller's
+ * sandboxes when the id was minted by another process.
+ *
+ * Entries are keyed by the resolved API credential so a shared Node.js
+ * process serving multiple tenants can never resolve (or time-observe) a
+ * mapping cached by a different tenant.
  */
 const snapshotSandboxIndex = new Map<string, string>();
+
+function snapshotIndexKey(auth: { apiKey: string }, snapshotId: string): string {
+  return `${auth.apiKey}:${snapshotId}`;
+}
+
+/** Upper bound on sandboxes examined by the delete() fallback scan. */
+const SNAPSHOT_SCAN_LIMIT = 25;
 
 export interface MiosaSnapshotRecord {
   id: string;
@@ -781,7 +792,8 @@ const createMiosaProvider = defineProvider<
           { data?: MiosaSnapshotRecord } & MiosaSnapshotRecord
         >(auth, "POST", `/sandboxes/${sandboxId}/snapshots`, body);
         const record = response.data ?? response;
-        if (record?.id) snapshotSandboxIndex.set(record.id, sandboxId);
+        if (record?.id)
+          snapshotSandboxIndex.set(snapshotIndexKey(auth, record.id), sandboxId);
         return record;
       },
 
@@ -803,7 +815,10 @@ const createMiosaProvider = defineProvider<
         const records = response.data ?? [];
         for (const record of records) {
           if (record?.id && record?.sandbox_id)
-            snapshotSandboxIndex.set(record.id, record.sandbox_id);
+            snapshotSandboxIndex.set(
+              snapshotIndexKey(auth, record.id),
+              record.sandbox_id,
+            );
         }
         return records;
       },
@@ -813,15 +828,18 @@ const createMiosaProvider = defineProvider<
         snapshotId: string,
       ): Promise<void> => {
         const auth = resolveAuth(config);
-        let sandboxId = snapshotSandboxIndex.get(snapshotId);
+        const indexKey = snapshotIndexKey(auth, snapshotId);
+        let sandboxId = snapshotSandboxIndex.get(indexKey);
         if (!sandboxId) {
           // Snapshot minted outside this process: resolve the owning sandbox
-          // by scanning the tenant's sandboxes. Bounded by the caller's own
-          // sandbox count and only paid on this cold path.
+          // by scanning the caller's sandboxes. The scan is sequential and
+          // hard-capped at SNAPSHOT_SCAN_LIMIT sandboxes so a delete() with
+          // an unknown id can never amplify into an unbounded request storm.
           const listing = await miosaRequest<{
             data?: Array<{ id: string }>;
           }>(auth, "GET", "/sandboxes");
-          for (const candidate of listing.data ?? []) {
+          const candidates = (listing.data ?? []).slice(0, SNAPSHOT_SCAN_LIMIT);
+          for (const candidate of candidates) {
             try {
               const snaps = await miosaRequest<{
                 data?: MiosaSnapshotRecord[];
@@ -847,11 +865,16 @@ const createMiosaProvider = defineProvider<
             "DELETE",
             `/sandboxes/${sandboxId}/snapshots/${snapshotId}`,
           );
+          snapshotSandboxIndex.delete(indexKey);
         } catch (error) {
-          if (error instanceof MiosaApiError && error.status === 404) return;
+          if (error instanceof MiosaApiError && error.status === 404) {
+            // Already gone server-side: the mapping is stale, drop it.
+            snapshotSandboxIndex.delete(indexKey);
+            return;
+          }
+          // Transient failure: keep the mapping so a retry can use the
+          // shortcut instead of re-running the fallback scan.
           throw error;
-        } finally {
-          snapshotSandboxIndex.delete(snapshotId);
         }
       },
     },

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -814,11 +814,12 @@ const createMiosaProvider = defineProvider<
         );
         const records = response.data ?? [];
         for (const record of records) {
-          if (record?.id && record?.sandbox_id)
-            snapshotSandboxIndex.set(
-              snapshotIndexKey(auth, record.id),
-              record.sandbox_id,
-            );
+          // The listing is already scoped to options.sandboxId, so that is the
+          // owner even when the record itself omits sandbox_id. Recording it
+          // unconditionally is what lets a later delete() skip the scan.
+          const owner = record?.sandbox_id ?? options.sandboxId;
+          if (record?.id && owner)
+            snapshotSandboxIndex.set(snapshotIndexKey(auth, record.id), owner);
         }
         return records;
       },

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -64,6 +64,15 @@ interface MiosaFileListEntry {
   modified_at?: string | null;
 }
 
+/**
+ * Snapshot-id -> sandbox-id resolution cache. MIOSA scopes snapshot routes
+ * under the owning sandbox, but ComputeSDK's snapshot.delete only carries the
+ * snapshot id. Every snapshot that passes through create()/list() is
+ * remembered here; delete() falls back to scanning the tenant's sandboxes
+ * when the id was minted by another process.
+ */
+const snapshotSandboxIndex = new Map<string, string>();
+
 export interface MiosaSnapshotRecord {
   id: string;
   sandbox_id: string;
@@ -771,7 +780,9 @@ const createMiosaProvider = defineProvider<
         const response = await miosaRequest<
           { data?: MiosaSnapshotRecord } & MiosaSnapshotRecord
         >(auth, "POST", `/sandboxes/${sandboxId}/snapshots`, body);
-        return response.data ?? response;
+        const record = response.data ?? response;
+        if (record?.id) snapshotSandboxIndex.set(record.id, sandboxId);
+        return record;
       },
 
       list: async (
@@ -789,17 +800,59 @@ const createMiosaProvider = defineProvider<
           "GET",
           `/sandboxes/${options.sandboxId}/snapshots`,
         );
-        return response.data ?? [];
+        const records = response.data ?? [];
+        for (const record of records) {
+          if (record?.id && record?.sandbox_id)
+            snapshotSandboxIndex.set(record.id, record.sandbox_id);
+        }
+        return records;
       },
 
       delete: async (
-        _config: MiosaConfig,
-        _snapshotId: string,
+        config: MiosaConfig,
+        snapshotId: string,
       ): Promise<void> => {
-        throw new Error(
-          "MIOSA snapshot deletion is scoped per sandbox (DELETE /sandboxes/:id/snapshots/:snap_id). " +
-            "Use the MIOSA SDK/API directly until ComputeSDK passes the sandbox scope.",
-        );
+        const auth = resolveAuth(config);
+        let sandboxId = snapshotSandboxIndex.get(snapshotId);
+        if (!sandboxId) {
+          // Snapshot minted outside this process: resolve the owning sandbox
+          // by scanning the tenant's sandboxes. Bounded by the caller's own
+          // sandbox count and only paid on this cold path.
+          const listing = await miosaRequest<{
+            data?: Array<{ id: string }>;
+          }>(auth, "GET", "/sandboxes");
+          for (const candidate of listing.data ?? []) {
+            try {
+              const snaps = await miosaRequest<{
+                data?: MiosaSnapshotRecord[];
+              }>(auth, "GET", `/sandboxes/${candidate.id}/snapshots`);
+              if ((snaps.data ?? []).some((snap) => snap.id === snapshotId)) {
+                sandboxId = candidate.id;
+                break;
+              }
+            } catch (error) {
+              if (error instanceof MiosaApiError && error.status === 404)
+                continue;
+              throw error;
+            }
+          }
+        }
+        if (!sandboxId) {
+          // Unknown snapshot: deletion is idempotent, treat as already gone.
+          return;
+        }
+        try {
+          await miosaRequest(
+            auth,
+            "DELETE",
+            `/sandboxes/${sandboxId}/snapshots/${snapshotId}`,
+          );
+        } catch (error) {
+          if (error instanceof MiosaApiError && error.status === 404) return;
+          throw error;
+        } finally {
+          snapshotSandboxIndex.delete(snapshotId);
+        }
       },
     },
   },


### PR DESCRIPTION
Closes the one **Partial** in MIOSA's support matrix ("ComputeSDK does not currently pass the sandbox scope required for deletion").

MIOSA scopes snapshot routes under the owning sandbox (`DELETE /sandboxes/:id/snapshots/:snap_id`). Since `snapshot.delete` only carries the snapshot id, the provider now resolves the owning sandbox from an in-process index populated by every `create()`/`list()` that sees the snapshot, with a fallback that scans the caller's sandboxes for ids minted outside the process. Deletion is idempotent — unknown or already-deleted snapshots return cleanly, matching the destroy() convention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->