### PR TITLE
ci(release): drop NPM_TOKEN fallback and publish via OIDC trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,12 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # --provenance generates signed attestations linking each package
-          # to this workflow run. Automatically enabled when using trusted
-          # publishers, but explicit here for clarity.
+          # Publishing uses npm Trusted Publisher OIDC. Every package in this
+          # monorepo must have a trusted publisher configured on npmjs.com
+          # (repo: computesdk/computesdk, workflow: release.yml) before it can
+          # be released. --provenance signs the attestation.
           publish: pnpm changeset publish --provenance
           title: "Version Packages"
           commit: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
-          # TODO: once every package has a trusted publisher configured on
-          # npmjs.com, remove NPM_TOKEN entirely. For now it acts as a
-          # fallback for packages not yet configured.
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The `@computesdk/miosa@1.0.2` publish failed because the legacy `NPM_TOKEN` fallback is no longer accepted by npm for writes (`E404 Not Found - PUT https://registry.npmjs.org/@computesdk%2fmiosa`). With the trusted publisher already configured for this package, the workflow should rely on npm OIDC trusted publishing instead.

```yaml
# before
- uses: changesets/action@v1
  with:
    publish: pnpm changeset publish --provenance
  env:
    GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

# after
- uses: changesets/action@v1
  with:
    publish: pnpm changeset publish --provenance
  env:
    GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
```

`NPM_TOKEN` is removed from the release step so `npm` uses the `id-token: write` permission and the configured trusted publisher. `--provenance` remains in place to generate signed publish attestations.

**Required before merge:** confirm `@computesdk/miosa` has a trusted publisher bound to `computesdk/computesdk`, workflow `release.yml`, on npmjs.com.

Link to Devin session: https://app.devin.ai/sessions/79ed129cbdba473aa7cc24348054f867
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->