### PR TITLE
Add @computesdk/sandbox-as-a-service provider

### DIFF
--- a/.changeset/tidy-donkeys-shake.md
+++ b/.changeset/tidy-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/sandbox-as-a-service": minor
+---
+
+Add the Sandbox as a Service provider: full cloud VMs with 24-hour sessions, preview URLs that open no inbound port on the sandbox, native filesystem operations, and per-second billing.

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ npm install @computesdk/mosaic           # Mosaic provider
 npm install @computesdk/northflank       # Northflank provider
 npm install @computesdk/run-cloud        # Run Cloud Firecracker sandbox provider
 npm install @computesdk/runloop          # Runloop provider
+npm install @computesdk/sandbox-as-a-service # Sandbox as a Service provider
 npm install @computesdk/sail             # Sail provider
 npm install @computesdk/sandbox0         # Sandbox0 provider
 npm install @computesdk/superserve       # Superserve provider
@@ -346,6 +347,7 @@ See individual provider READMEs for details:
 - **[@computesdk/northflank](./packages/northflank)** - Cloud sandboxes with preview URLs
 - **[@computesdk/run-cloud](./packages/run-cloud)** - Fast Firecracker microVM sandboxes with filesystem and snapshot support
 - **[@computesdk/runloop](./packages/runloop)** - Code execution, automation
+- **[@computesdk/sandbox-as-a-service](./packages/sandbox-as-a-service)** - Full cloud VMs with preview URLs, billed by the second
 - **[@computesdk/sandbox0](./packages/sandbox0)** - Fast persistent sandboxes with native filesystem access
 - **[@computesdk/superserve](./packages/superserve)** - Firecracker microVM sandboxes
 - **[@computesdk/tensorlake](./packages/tensorlake)** - Stateful MicroVM sandboxes for agentic applications, with snapshot support

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -44,6 +44,7 @@
   * [Run Cloud](providers/run-cloud.md)
   * [Runloop](providers/runloop.md)
   * [Sail](providers/sail.md)
+  * [Sandbox as a Service](providers/sandbox-as-a-service.md)
   * [Sandbox0](providers/sandbox0.md)
   * [Secure Exec](providers/secure-exec.md)
   * [Sprites](providers/sprites.md)

--- a/docs/providers/sandbox-as-a-service.md
+++ b/docs/providers/sandbox-as-a-service.md
@@ -1,0 +1,119 @@
+---
+description: >-
+  Sandbox as a Service provisions a full cloud VM per sandbox with 24-hour
+  sessions, public preview URLs that open no inbound port, and per-second
+  billing.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# Sandbox as a Service
+
+[Sandbox as a Service](https://sandbox-as-a-service.com) provider for ComputeSDK.
+
+Each sandbox is a **full cloud VM with its own kernel** — not a microVM and not a container. That is
+a real trade in both directions, and it is worth being plain about which way it cuts:
+
+- **Slower to start.** Roughly 30 seconds, against milliseconds for snapshot-restoring microVM
+  runtimes. A workload that creates and destroys a sandbox on every agent turn should use something
+  else.
+- **An ordinary Linux machine in exchange.** Sessions run up to 24 hours on any account with no
+  subscription tier, and the guest is not subject to microVM constraints.
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/sandbox-as-a-service
+```
+
+Get an API key at [sandbox-as-a-service.com](https://sandbox-as-a-service.com) — new accounts start
+with free credit and no card.
+
+```bash
+export AAS_API_KEY=aas_sk_...
+```
+
+## Usage
+
+```typescript
+import { compute } from 'computesdk';
+import { sandboxAsAService } from '@computesdk/sandbox-as-a-service';
+
+compute.setConfig({
+  defaultProvider: sandboxAsAService({ apiKey: process.env.AAS_API_KEY }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('python3', ['-c', 'print(6 * 7)']);
+console.log(result.stdout); // 42
+
+await sandbox.destroy();
+```
+
+## Preview URLs
+
+`getUrl` returns a public https address for a port inside the sandbox, so an agent can hand a person
+a link to what it just built.
+
+```typescript
+await sandbox.runCommand('sh', ['-c', 'python3 -m http.server 3000 &']);
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+The server only needs to listen on `localhost`. **No inbound port is opened on the machine** — the
+request is carried in over the control plane's existing connection, so the sandbox's inbound attack
+surface stays empty and there is no per-sandbox firewall rule to manage. WebSocket upgrades pass
+through, so a dev server with live reload works normally.
+
+## Filesystem
+
+File operations go through a dedicated endpoint rather than through the shell, so quotes, newlines
+and binary content survive without escaping.
+
+```typescript
+await sandbox.filesystem.writeFile('/workspace/app.py', "print('hello')");
+const source = await sandbox.filesystem.readFile('/workspace/app.py');
+const entries = await sandbox.filesystem.readdir('/workspace');
+```
+
+## Configuration
+
+| Option | Environment | Default | |
+|---|---|---|---|
+| `apiKey` | `AAS_API_KEY` | — | Required. From the dashboard. |
+| `baseUrl` | `AAS_BASE_URL` | `https://sandbox-as-a-service.com/v1` | |
+| `size` | — | `small` | `small` 2 vCPU / 4 GB, `medium` 4 / 8, `large` 8 / 16. |
+| `timeoutMinutes` | — | 15 | Up to 1440. The platform destroys the sandbox at expiry regardless. |
+
+## Support matrix
+
+| | |
+|---|---|
+| Create / get / list / destroy | ✅ |
+| `runCommand` | ✅ |
+| Filesystem | ✅ |
+| `getUrl` (preview URLs) | ✅ |
+| Snapshots, custom images, templates | ❌ |
+| GPUs | ❌ |
+
+## Pricing
+
+Per second from prepaid credit, from $0.09/hour for 2 vCPU / 4 GB / 40 GB. No subscription and no
+seats.

--- a/packages/sandbox-as-a-service/README.md
+++ b/packages/sandbox-as-a-service/README.md
@@ -1,0 +1,73 @@
+# @computesdk/sandbox-as-a-service
+
+[Sandbox as a Service](https://sandbox-as-a-service.com) provider for ComputeSDK.
+
+Each sandbox is a **full cloud VM with its own kernel** — not a microVM and not a container. That is
+a real trade in both directions:
+
+- **Slower to start.** Roughly 30 seconds, against milliseconds for snapshot-restoring microVM
+  runtimes. If your workload creates and destroys a sandbox on every agent turn, this is the wrong
+  provider.
+- **An ordinary Linux machine in exchange.** Sessions run up to 24 hours on any account with no
+  subscription tier, and the guest is not subject to microVM constraints.
+
+## Install
+
+```bash
+npm install @computesdk/sandbox-as-a-service
+```
+
+## Use
+
+```typescript
+import { compute } from 'computesdk';
+import { sandboxAsAService } from '@computesdk/sandbox-as-a-service';
+
+compute.setConfig({
+  defaultProvider: sandboxAsAService({ apiKey: process.env.AAS_API_KEY }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('python3', ['-c', 'print(6 * 7)']);
+console.log(result.stdout); // 42
+
+await sandbox.destroy();
+```
+
+## Preview URLs
+
+`getUrl` returns a public https address for a port inside the sandbox — so an agent can hand a person
+a link to the thing it just built.
+
+```typescript
+await sandbox.runCommand('sh', ['-c', 'python3 -m http.server 3000 &']);
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+The server only needs to listen on `localhost`. **No inbound port is opened on the machine**: the
+request is carried in over the control plane's existing connection, so the sandbox's inbound attack
+surface stays empty and there is no per-sandbox firewall rule.
+
+## Configuration
+
+| Option | Default | |
+|---|---|---|
+| `apiKey` | `AAS_API_KEY` | Key from [the dashboard](https://sandbox-as-a-service.com/dashboard/keys). |
+| `baseUrl` | `AAS_BASE_URL` | Defaults to the public API. |
+| `size` | `small` | `small` 2 vCPU / 4 GB, `medium` 4 / 8, `large` 8 / 16. |
+| `timeoutMinutes` | 15 | Up to 1440. The platform destroys the sandbox at expiry regardless. |
+
+## Support matrix
+
+| | |
+|---|---|
+| Create / get / list / destroy | ✅ |
+| `runCommand` | ✅ |
+| Filesystem | ✅ — through a dedicated endpoint, so quotes, newlines and binary survive |
+| `getUrl` (preview URLs) | ✅ |
+| Snapshots / custom images | ❌ |
+| GPUs | ❌ |
+
+Billed per second from prepaid credit, from $0.09/hour. New accounts start with free credit and no
+card.

--- a/packages/sandbox-as-a-service/package.json
+++ b/packages/sandbox-as-a-service/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@computesdk/sandbox-as-a-service",
+  "version": "1.0.0",
+  "description": "Sandbox as a Service provider for ComputeSDK - full cloud VMs with preview URLs, billed by the second",
+  "author": "Sandbox as a Service",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "sandbox-as-a-service",
+    "sandbox",
+    "code-execution",
+    "vm",
+    "preview-url",
+    "ai-agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/sandbox-as-a-service"
+  },
+  "homepage": "https://sandbox-as-a-service.com",
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/sandbox-as-a-service/src/__tests__/index.test.ts
+++ b/packages/sandbox-as-a-service/src/__tests__/index.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Sandbox as a Service provider tests.
+ *
+ * Runs the shared provider suite, which covers the sandbox lifecycle, command
+ * execution and the filesystem operations. Integration tests need AAS_API_KEY
+ * and are skipped without it.
+ */
+
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { sandboxAsAService } from '../index';
+
+runProviderTestSuite({
+  name: 'sandbox-as-a-service',
+  // Config is empty on purpose: the key comes from AAS_API_KEY, which is how
+  // the suite runs in CI.
+  provider: sandboxAsAService({}),
+  // Files move through a dedicated endpoint rather than through the shell.
+  supportsFilesystem: true,
+  skipIntegration: !process.env.AAS_API_KEY,
+});

--- a/packages/sandbox-as-a-service/src/index.ts
+++ b/packages/sandbox-as-a-service/src/index.ts
@@ -1,0 +1,329 @@
+/**
+ * Sandbox as a Service provider.
+ *
+ * Each sandbox is a full cloud VM with its own kernel, not a microVM and not a
+ * container. That trade cuts both ways and the README says so: starting one
+ * takes roughly thirty seconds rather than milliseconds, and in exchange the
+ * guest is an ordinary Linux machine, sessions run up to 24 hours on any
+ * account, and a port inside it can be given a public URL.
+ *
+ * There is no vendor SDK to depend on — the service is a small REST API, so
+ * this package talks to it with fetch.
+ */
+
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+
+import type {
+  CommandResult,
+  SandboxInfo,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+} from '@computesdk/provider';
+
+export const DEFAULT_BASE_URL = 'https://sandbox-as-a-service.com/v1';
+
+export interface SandboxAsAServiceConfig {
+  /** API key from sandbox-as-a-service.com/dashboard/keys. Falls back to `AAS_API_KEY`. */
+  apiKey?: string;
+  /** Override the API base URL. Falls back to `AAS_BASE_URL`. */
+  baseUrl?: string;
+  /** Machine size. `small` = 2 vCPU / 4 GB, `medium` = 4 / 8, `large` = 8 / 16. */
+  size?: 'small' | 'medium' | 'large';
+  /** Lifetime in minutes, up to 1440. The platform destroys the sandbox at expiry regardless. */
+  timeoutMinutes?: number;
+}
+
+/** A sandbox as the API describes it. */
+export interface SandboxRecord {
+  id: string;
+  status: string;
+  size: string;
+  created_at: string;
+  expires_at?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Instance methods receive only the sandbox, so it has to carry what it needs
+ * to talk to the API. Same shape as the other REST-backed providers here.
+ */
+export interface SandboxAsAServiceSandbox {
+  record: SandboxRecord;
+  apiKey: string;
+  baseUrl: string;
+}
+
+function resolveApiKey(config: SandboxAsAServiceConfig): string {
+  const key = config.apiKey || (typeof process !== 'undefined' ? process.env?.AAS_API_KEY : '') || '';
+  if (!key) {
+    throw new Error(
+      `Missing Sandbox as a Service API key. Provide 'apiKey' in config or set AAS_API_KEY. ` +
+        `Keys are created at https://sandbox-as-a-service.com/dashboard/keys`
+    );
+  }
+  return key;
+}
+
+function resolveBaseUrl(config: SandboxAsAServiceConfig): string {
+  const url =
+    config.baseUrl || (typeof process !== 'undefined' ? process.env?.AAS_BASE_URL : '') || DEFAULT_BASE_URL;
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * Every request goes through here so that every failure carries the API's own
+ * message. Collapsing those into "request failed" would make the caller guess
+ * at things the service already said plainly — an expired sandbox, an exhausted
+ * balance, a quota.
+ */
+async function request<T>(
+  apiKey: string,
+  baseUrl: string,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+  const text = await res.text();
+  let payload: any = {};
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      throw new Error(
+        `Sandbox as a Service returned a non-JSON response (${res.status}): ${text.slice(0, 200)}`
+      );
+    }
+  }
+
+  if (!res.ok) {
+    const err = payload?.error;
+    throw new Error(
+      err?.message
+        ? `Sandbox as a Service: ${err.message}${err.type ? ` [${err.type}]` : ''}`
+        : `Sandbox as a Service request failed with ${res.status}`
+    );
+  }
+  return payload as T;
+}
+
+function wrap(record: SandboxRecord, apiKey: string, baseUrl: string): SandboxAsAServiceSandbox {
+  return { record, apiKey, baseUrl };
+}
+
+export const sandboxAsAService = defineProvider<SandboxAsAServiceSandbox, SandboxAsAServiceConfig>({
+  name: 'sandbox-as-a-service',
+  methods: {
+    sandbox: {
+      create: async (config: SandboxAsAServiceConfig, options?: CreateSandboxOptions) => {
+        const apiKey = resolveApiKey(config);
+        const baseUrl = resolveBaseUrl(config);
+
+        // The create call blocks until the machine will accept commands, so
+        // there is no readiness loop to write here.
+        const record = await request<SandboxRecord>(apiKey, baseUrl, 'POST', '/sandboxes', {
+          size: config.size || 'small',
+          ...(config.timeoutMinutes ? { timeout_minutes: config.timeoutMinutes } : {}),
+        });
+        void options;
+        return { sandbox: wrap(record, apiKey, baseUrl), sandboxId: record.id };
+      },
+
+      getById: async (config: SandboxAsAServiceConfig, sandboxId: string) => {
+        const apiKey = resolveApiKey(config);
+        const baseUrl = resolveBaseUrl(config);
+        try {
+          const record = await request<SandboxRecord>(
+            apiKey,
+            baseUrl,
+            'GET',
+            `/sandboxes/${encodeURIComponent(sandboxId)}`
+          );
+          return { sandbox: wrap(record, apiKey, baseUrl), sandboxId };
+        } catch (err) {
+          // A sandbox that is gone is a null, not a throw.
+          if (err instanceof Error && /not_found|No sandbox/i.test(err.message)) return null;
+          throw err;
+        }
+      },
+
+      list: async (config: SandboxAsAServiceConfig) => {
+        const apiKey = resolveApiKey(config);
+        const baseUrl = resolveBaseUrl(config);
+        const res = await request<{ data: SandboxRecord[] }>(
+          apiKey,
+          baseUrl,
+          'GET',
+          '/sandboxes?limit=100'
+        );
+        return (res.data || []).map((record) => ({
+          sandbox: wrap(record, apiKey, baseUrl),
+          sandboxId: record.id,
+        }));
+      },
+
+      destroy: async (config: SandboxAsAServiceConfig, sandboxId: string) => {
+        await request(
+          resolveApiKey(config),
+          resolveBaseUrl(config),
+          'DELETE',
+          `/sandboxes/${encodeURIComponent(sandboxId)}`
+        );
+      },
+
+      runCommand: async (
+        sandbox: SandboxAsAServiceSandbox,
+        command: string,
+        options?: RunCommandOptions
+      ): Promise<CommandResult> => {
+        const result = await request<{ stdout: string; stderr: string; exit_code: number }>(
+          sandbox.apiKey,
+          sandbox.baseUrl,
+          'POST',
+          `/sandboxes/${encodeURIComponent(sandbox.record.id)}/exec`,
+          {
+            command,
+            ...(options?.cwd ? { cwd: options.cwd } : {}),
+            // The API exports these before running the command, so they survive
+            // shell chaining rather than applying to the first word only.
+            ...(options?.env && Object.keys(options.env).length ? { env: options.env } : {}),
+          }
+        );
+        return {
+          stdout: result.stdout ?? '',
+          stderr: result.stderr ?? '',
+          exitCode: result.exit_code ?? 0,
+        };
+      },
+
+      getInfo: async (sandbox: SandboxAsAServiceSandbox): Promise<SandboxInfo> => {
+        const status = sandbox.record.status;
+        return {
+          id: sandbox.record.id,
+          // The API reports provisioning, running, deleting, deleted and failed.
+          // Anything neither running nor failed is stopped rather than invented
+          // as running.
+          status: status === 'running' ? 'running' : status === 'failed' ? 'error' : 'stopped',
+          createdAt: new Date(sandbox.record.created_at),
+        };
+      },
+
+      /**
+       * A public https URL for a port inside the sandbox.
+       *
+       * The server only has to listen on localhost: no inbound port is opened on
+       * the machine, and the request is carried in over the control plane's
+       * existing connection. Asking twice for the same port returns the same URL.
+       */
+      getUrl: async (
+        sandbox: SandboxAsAServiceSandbox,
+        options: { port: number; protocol?: string }
+      ): Promise<string> => {
+        const res = await request<{ url: string }>(
+          sandbox.apiKey,
+          sandbox.baseUrl,
+          'POST',
+          `/sandboxes/${encodeURIComponent(sandbox.record.id)}/ports`,
+          { port: options.port }
+        );
+        return res.url;
+      },
+
+      filesystem: {
+        // Files move through a dedicated endpoint rather than through the shell,
+        // so quotes, newlines and binary content survive without escaping.
+        readFile: async (sandbox: SandboxAsAServiceSandbox, path: string): Promise<string> => {
+          const res = await request<{ content: string }>(
+            sandbox.apiKey,
+            sandbox.baseUrl,
+            'GET',
+            `/sandboxes/${encodeURIComponent(sandbox.record.id)}/files?path=${encodeURIComponent(path)}`
+          );
+          return res.content;
+        },
+
+        writeFile: async (
+          sandbox: SandboxAsAServiceSandbox,
+          path: string,
+          content: string
+        ): Promise<void> => {
+          await request(
+            sandbox.apiKey,
+            sandbox.baseUrl,
+            'PUT',
+            `/sandboxes/${encodeURIComponent(sandbox.record.id)}/files`,
+            { path, content }
+          );
+        },
+
+        mkdir: async (
+          sandbox: SandboxAsAServiceSandbox,
+          path: string,
+          runCommand: (
+            sandbox: SandboxAsAServiceSandbox,
+            command: string,
+            options?: RunCommandOptions
+          ) => Promise<CommandResult>
+        ): Promise<void> => {
+          const result = await runCommand(sandbox, `mkdir -p ${escapeShellArg(path)}`);
+          if (result.exitCode !== 0) {
+            throw new Error(`Could not create ${path}: ${result.stderr.trim() || 'unknown error'}`);
+          }
+        },
+
+        readdir: async (sandbox: SandboxAsAServiceSandbox, path: string): Promise<FileEntry[]> => {
+          const res = await request<{
+            entries: Array<{ name: string; type: string; size_bytes: number }>;
+          }>(
+            sandbox.apiKey,
+            sandbox.baseUrl,
+            'GET',
+            `/sandboxes/${encodeURIComponent(sandbox.record.id)}/files` +
+              `?path=${encodeURIComponent(path)}&list=true&recursive=false`
+          );
+          const base = path.replace(/\/+$/, '');
+          return (res.entries || []).map((entry) => ({
+            name: entry.name,
+            path: `${base}/${entry.name}`,
+            isDirectory: entry.type === 'dir',
+            size: entry.size_bytes ?? 0,
+          })) as FileEntry[];
+        },
+
+        exists: async (
+          sandbox: SandboxAsAServiceSandbox,
+          path: string,
+          runCommand: (
+            sandbox: SandboxAsAServiceSandbox,
+            command: string,
+            options?: RunCommandOptions
+          ) => Promise<CommandResult>
+        ): Promise<boolean> => {
+          const result = await runCommand(sandbox, `test -e ${escapeShellArg(path)}`);
+          return result.exitCode === 0;
+        },
+
+        remove: async (sandbox: SandboxAsAServiceSandbox, path: string): Promise<void> => {
+          await request(
+            sandbox.apiKey,
+            sandbox.baseUrl,
+            'DELETE',
+            `/sandboxes/${encodeURIComponent(sandbox.record.id)}/files` +
+              `?path=${encodeURIComponent(path)}&recursive=true`
+          );
+        },
+      },
+    },
+  },
+});
+
+export default sandboxAsAService;

--- a/packages/sandbox-as-a-service/tsconfig.json
+++ b/packages/sandbox-as-a-service/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sandbox-as-a-service/tsup.config.ts
+++ b/packages/sandbox-as-a-service/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/sandbox-as-a-service/vitest.config.ts
+++ b/packages/sandbox-as-a-service/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})


### PR DESCRIPTION
Adds a provider for [Sandbox as a Service](https://sandbox-as-a-service.com).

## What is different about it

It provisions a **full cloud VM per sandbox** rather than a microVM or a container. That is a real trade in both directions and the docs page says so in both:

- **Slower to start** — roughly 30 seconds, against milliseconds for snapshot-restoring microVM runtimes. A workload that creates and destroys a sandbox on every agent turn should use something else, and the docs say that outright.
- **An ordinary Linux guest in exchange** — 24-hour sessions on any account with no subscription tier, and none of the microVM constraints.

## Implemented

Everything required, plus both optional methods:

| | |
|---|---|
| `create` / `getById` / `list` / `destroy` | ✅ |
| `runCommand` | ✅ |
| `filesystem` | ✅ — through a dedicated endpoint, not shell escaping, so quotes, newlines and binary survive |
| `getUrl` | ✅ |

`getUrl` is worth a note: preview URLs are implemented **without opening any inbound port on the sandbox**. The request is carried into the guest over the control plane's existing connection, so the customer's server keeps listening on its own localhost and the machine's inbound surface stays empty — no per-sandbox firewall rule.

No vendor SDK dependency: the service is a small REST API, so the package uses `fetch` and depends only on `@computesdk/provider` and `computesdk`.

## Scope

Confined to the paths ADD-PROVIDER.md allows — `packages/sandbox-as-a-service/`, `docs/providers/sandbox-as-a-service.md`, the one `docs/SUMMARY.md` nav line, a changeset, and the two root README entries. No core changes.

## One thing I could not do

I was unable to run `pnpm install` / `pnpm build` in my environment, so the package is **not locally compiled**. I checked the implementation against `packages/provider/src/factory.ts` by hand rather than by compiler — in particular `runCommand(sandbox, command, options?)`, which differs from the `(sandbox, command, args?, options?)` signature shown in ADD-PROVIDER.md §2 (that example looks stale against the current interface). Please do let CI be the judge, and I will fix anything it turns up promptly.

Integration tests read `AAS_API_KEY` and skip without it. Happy to arrange credentials for the benchmark suite — with the caveat that our cold start is genuinely ~30s today, so the number will look like what it is.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->