### PR TITLE
ci(release): restore NPM_TOKEN fallback for packages without npm trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # Publishing uses npm Trusted Publisher OIDC. Every package in this
-          # monorepo must have a trusted publisher configured on npmjs.com
-          # (repo: computesdk/computesdk, workflow: release.yml) before it can
-          # be released. --provenance signs the attestation.
+          # Publishing uses npm Trusted Publisher OIDC where configured.
+          # Packages without a trusted publisher on npmjs.com fall back to the
+          # long-lived NPM_TOKEN. --provenance signs the attestation.
+          # TODO: once every package has a trusted publisher configured, remove
+          # NPM_TOKEN entirely.
           publish: pnpm changeset publish --provenance
           title: "Version Packages"
           commit: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow failed publishing `@computesdk/microsandbox@0.1.2` with `ENEEDAUTH` because PR #721 removed the `NPM_TOKEN` fallback and the package does not yet have a trusted publisher configured on npmjs.com. `@computesdk/miosa` and `@computesdk/workbench` published successfully in the same run, confirming OIDC trusted publishing works for packages that are configured, but `@computesdk/microsandbox` is not.

Restores `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` as a fallback so packages lacking an npm trusted publisher can still be released. The CLI will still use OIDC first when a trusted publisher is available and `--provenance` will still sign attestations. The comment is updated to clarify the fallback and preserves the TODO to remove `NPM_TOKEN` once every package is configured.

After this merges and the release re-runs, `@computesdk/microsandbox@0.1.2` should publish. The long-term fix is to add a trusted publisher for `@computesdk/microsandbox` (and any other unconfigured packages) on npmjs.com, then remove `NPM_TOKEN` again.

Link to Devin session: https://app.devin.ai/sessions/8510cb97ce4448319c922fc453e691cf
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->