### PR TITLE
docs: add lead paragraph to supported providers list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ ComputeSDK is built around provider packages. Each provider ships as its own pac
 
 When you install a package like `@computesdk/e2b`, you get a factory function for that provider. Every provider returns the same sandbox interface, so you can swap infrastructure without rewriting core logic.
 
-## Supported cloud sandbox providers
+## Supported sandbox providers
 
 Providers are cloud platforms that host sandboxes. Each package under `@computesdk/{provider}` exposes the same sandbox interface, so you can swap infrastructure without rewriting application code.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ When you install a package like `@computesdk/e2b`, you get a factory function fo
 
 ## Supported sandbox providers
 
-Providers are platforms that sandboxes. Each package under `@computesdk/{provider}` exposes the same sandbox interface, so you can swap infrastructure without rewriting application code.
+Providers are platforms that provide sandboxes. Each package under `@computesdk/{provider}` exposes the same sandbox interface, so you can swap infrastructure without rewriting application code.
 
 | Package                        | Provider     |
 | ------------------------------ | ------------ |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ When you install a package like `@computesdk/e2b`, you get a factory function fo
 
 ## Supported sandbox providers
 
-Providers are cloud platforms that host sandboxes. Each package under `@computesdk/{provider}` exposes the same sandbox interface, so you can swap infrastructure without rewriting application code.
+Providers are platforms that sandboxes. Each package under `@computesdk/{provider}` exposes the same sandbox interface, so you can swap infrastructure without rewriting application code.
 
 | Package                        | Provider     |
 | ------------------------------ | ------------ |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ When you install a package like `@computesdk/e2b`, you get a factory function fo
 
 ## Supported cloud sandbox providers
 
+Providers are cloud platforms that host sandboxes. Each package under `@computesdk/{provider}` exposes the same sandbox interface, so you can swap infrastructure without rewriting application code.
+
 | Package                        | Provider     |
 | ------------------------------ | ------------ |
 | `@computesdk/archil`           | Archil       |


### PR DESCRIPTION
## Summary
The supported-provider list in the docs jumped straight to a table. Added a one-sentence lead that explains providers are cloud sandbox-hosting drivers with a common `@computesdk/{provider}` interface, so readers understand how the table relates to the SDK.

Link to Devin session: https://app.devin.ai/sessions/970efb575a3742d8b7f4863b055f69c7
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->