### PR TITLE
skip disk lookup on create sandbox for archil

### DIFF
--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -83,40 +83,17 @@ describe('archil create semantics', () => {
     await expect(provider.sandbox.create()).rejects.toThrow(/requires an existing disk id on the top-level options/i);
   });
 
-  it('resolves existing disk id without creating a new disk', async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === 'GET') {
-        return new Response(
-          JSON.stringify({
-            success: true,
-            data: {
-              id: 'disk_abc123',
-              name: 'existing-disk',
-              organization: 'org',
-              status: 'ready',
-              provider: 'archil',
-              region: 'aws-us-east-1',
-              createdAt: new Date().toISOString(),
-            },
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-
-      return new Response(JSON.stringify({ success: false, error: 'unexpected method' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    });
+  it('uses an existing disk id without fetching it', async () => {
+    const fetchMock = vi.fn();
     global.fetch = fetchMock as typeof fetch;
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const created = await provider.sandbox.create({ diskId: 'disk_abc123' });
+    const info = await created.getInfo();
 
     expect(created.sandboxId).toBe('disk_abc123');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const method = ((fetchMock.mock.calls as any[][])[0][1] as RequestInit | undefined)?.method;
-    expect(method).toBe('GET');
+    expect(info).toMatchObject({ id: 'disk_abc123', status: 'running' });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -54,6 +54,8 @@ interface DiskResponse {
   createdAt: string;
 }
 
+type DiskHandle = Pick<DiskResponse, 'id'>;
+
 interface ExecTiming {
   totalMs: number;
   queueMs: number;
@@ -73,7 +75,7 @@ interface ResolvedConfig {
 }
 
 interface ArchilSandbox {
-  disk: DiskResponse;
+  disk: DiskHandle | DiskResponse;
   resolved: ResolvedConfig;
   createdAt: Date;
 }
@@ -204,14 +206,9 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
       create: async (config: ArchilConfig, options?: ArchilCreateOptions) => {
         const resolved = resolveConfig(config);
         const diskId = resolveCreateDiskId(options);
-        const disk = await callApi<DiskResponse>(
-          resolved,
-          'GET',
-          `/api/disks/${encodeURIComponent(diskId)}`,
-        );
         return {
-          sandbox: { disk, resolved, createdAt: new Date() },
-          sandboxId: disk.id,
+          sandbox: { disk: { id: diskId }, resolved, createdAt: new Date() },
+          sandboxId: diskId,
         };
       },
 
@@ -270,18 +267,21 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
       },
 
       getInfo: async (sandbox: ArchilSandbox): Promise<SandboxInfo> => {
+        const diskInfo = 'status' in sandbox.disk ? sandbox.disk : undefined;
         return {
           id: sandbox.disk.id,
           provider: 'archil',
-          status: sandbox.disk.status === 'ready' ? 'running' : 'stopped',
-          createdAt: new Date(sandbox.disk.createdAt),
+          status: !diskInfo || diskInfo.status === 'ready' ? 'running' : 'stopped',
+          createdAt: diskInfo ? new Date(diskInfo.createdAt) : sandbox.createdAt,
           timeout: 0,
-          metadata: {
-            name: sandbox.disk.name,
-            organization: sandbox.disk.organization,
-            region: sandbox.disk.region,
-            provider: sandbox.disk.provider,
-          },
+          metadata: diskInfo
+            ? {
+                name: diskInfo.name,
+                organization: diskInfo.organization,
+                region: diskInfo.region,
+                provider: diskInfo.provider,
+              }
+            : {},
         };
       },
 


### PR DESCRIPTION
Since the disk id is already passed we can skip checking the disk existence. Other option was to create a disk on start here but that's not what we're trying to measure in this test.

## Summary

- build the Archil sandbox handle directly from the supplied `diskId`
- avoid fetching an existing disk during `sandbox.create()`
- retain hydrated disk metadata for explicit `getById()` and `list()` results

## Validation

- `pnpm build`
- `pnpm --filter @computesdk/archil test`
- `pnpm --filter @computesdk/archil typecheck`