### PR TITLE
chore(archil): add changeset for skip disk lookup on create

### DIFF
--- a/.changeset/archil-skip-lookup.md
+++ b/.changeset/archil-skip-lookup.md
@@ -1,0 +1,7 @@
+---
+"@computesdk/archil": patch
+---
+
+perf(archil): skip disk lookup on create
+
+`provider.sandbox.create()` no longer fetches the disk before returning, and `getInfo()` derives metadata from the disk handle when full disk metadata is not available.


### PR DESCRIPTION
## Summary

Adds a changeset for `@computesdk/archil` to release the `perf(archil): skip disk lookup on create (#729)` change.

`provider.sandbox.create()` no longer fetches the disk before returning, and `getInfo()` derives metadata from the disk handle when full disk metadata is not available.

This is a patch release per repo changeset policy.

Link to Devin session: https://app.devin.ai/sessions/ccd5eedee54142729be648e70eb1d951
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->