### PR TITLE
chore(runloop): add changeset for runloop client update

### DIFF
--- a/.changeset/runloop-update-client.md
+++ b/.changeset/runloop-update-client.md
@@ -1,0 +1,7 @@
+---
+"@computesdk/runloop": patch
+---
+
+chore(runloop): update client to 1.30.0
+
+Bump `@runloop/api-client` to `^1.30.0` to pick up improvements to the `create_and_await_running` API that reduce latency.


### PR DESCRIPTION
## Summary

Adds a changeset for `@computesdk/runloop` to release the `chore(runloop): update client to 1.30.0 (#727)` change.

Bump `@runloop/api-client` to `^1.30.0` to pick up improvements to the `create_and_await_running` API that reduce latency.

This is a patch release per repo changeset policy.

Link to Devin session: https://app.devin.ai/sessions/3906fa1b507a4567bf92b2108accab28
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->