### PR TITLE
docs(browseruse): add package quickstart

### DIFF
--- a/.changeset/browseruse-readme.md
+++ b/.changeset/browseruse-readme.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/browseruse": patch
+---
+
+Add an installable Browser Use Cloud quickstart with Playwright, proxy, profile, and recording examples.

--- a/packages/browseruse/README.md
+++ b/packages/browseruse/README.md
@@ -1,0 +1,81 @@
+# Browser Use for ComputeSDK
+
+Run a Browser Use Cloud browser through ComputeSDK, then control it with Playwright.
+
+## Install
+
+```bash
+pnpm add @computesdk/browseruse playwright-core
+```
+
+Create a Browser Use API key at [cloud.browser-use.com/settings?tab=api-keys](https://cloud.browser-use.com/settings?tab=api-keys), then set it in your environment:
+
+```bash
+export BROWSER_USE_API_KEY="bu_..."
+```
+
+## Quick start
+
+```ts
+import { browseruse } from '@computesdk/browseruse';
+import { chromium } from 'playwright-core';
+
+const bu = browseruse({ apiKey: process.env.BROWSER_USE_API_KEY });
+
+const session = await bu.session.create({
+  recording: true,
+  proxies: [{ type: 'residential', geolocation: { country: 'us' } }],
+});
+
+const browser = await chromium.connectOverCDP(session.connectUrl);
+const context = browser.contexts()[0]!;
+const page = context.pages()[0]!;
+
+await page.goto('https://example.com');
+console.log(await page.title());
+
+await browser.close();
+await session.destroy();
+```
+
+## Session options
+
+```ts
+const session = await bu.session.create({
+  viewport: { width: 1440, height: 900 },
+  timeout: 60 * 60, // seconds; rounded up to minutes for Browser Use
+  recording: true,
+  profileId: 'profile-id',
+  proxies: [{ type: 'residential', geolocation: { country: 'de' } }],
+});
+```
+
+Set `proxies: false` to disable the Browser Use residential proxy. Custom HTTP or SOCKS5 proxy settings are also accepted through ComputeSDK's `ProxyConfig` shape.
+
+## Profiles and recordings
+
+```ts
+const profile = await bu.profile.create({ name: 'signed-in-user' });
+const session = await bu.session.create({ profileId: profile.profileId, recording: true });
+
+// Run browser work, then stop the session.
+await session.destroy();
+
+const recording = await bu.recording.get(session.sessionId);
+console.log(recording?.url);
+```
+
+The provider supports session create/get/list/destroy, persistent profiles, residential or custom proxies, viewport sizing, session timeouts, and recording lookup.
+
+## Configuration
+
+```ts
+const bu = browseruse({
+  apiKey: process.env.BROWSER_USE_API_KEY,
+  // baseUrl: 'https://api.browser-use.com',
+  // timeout: 30_000,
+  // maxRetries: 2,
+});
+```
+
+See the runnable [example-browseruse.ts](./example-browseruse.ts) and the [Browser Use Cloud docs](https://docs.browser-use.com/cloud/quickstart).


### PR DESCRIPTION
## What

- add an installable Browser Use Cloud quickstart to `@computesdk/browseruse`
- show Playwright CDP setup plus proxy, profile, recording, viewport, and timeout options
- add a patch changeset so the README ships with the npm package

## Why

The current `@computesdk/browseruse` npm package has no README, so people who discover or install it do not get a package-level setup path. This adds a first run from install to Browser Use Cloud and Playwright, plus the provider-specific options already supported by the package.

## Validation

- Browser Use package tests: 8 passed
- Browser Use package TypeScript check
- Browser Use package build
- full repository build
- root TypeScript check
- Browser Use package lint
- npm pack dry-run; `README.md` included in the tarball
- `git diff --check`
- TruffleHog: 0 verified or unverified secrets

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->