### PR TITLE
perf(opencomputer): start the SDK import at module load, not first use

### DIFF
--- a/.changeset/opencomputer-eager-sdk-import.md
+++ b/.changeset/opencomputer-eager-sdk-import.md
@@ -1,0 +1,12 @@
+---
+"@computesdk/opencomputer": patch
+---
+
+Start the `@opencomputer/sdk` import at module load instead of at first use.
+
+The SDK initialises at import. `loadSandbox()` is first reached from
+`sandbox.create()`, so deferring the import there meant that initialisation
+happened during the first create rather than before it.
+
+The import stays dynamic: the SDK is ESM-only with top-level await, so a static
+import compiles to `require()` in this package's CJS build and fails to load.

--- a/packages/opencomputer/src/__tests__/index.test.ts
+++ b/packages/opencomputer/src/__tests__/index.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { opencomputer } from '../index';
 
-const createMock = vi.fn();
-const connectMock = vi.fn();
-const createFromCheckpointMock = vi.fn();
+// vi.hoisted: the SDK import now starts at module load, so the mock factory
+// can run before this file's own top-level consts are initialized.
+const { createMock, connectMock, createFromCheckpointMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  connectMock: vi.fn(),
+  createFromCheckpointMock: vi.fn(),
+}));
 
 vi.mock('@opencomputer/sdk', () => ({
   Sandbox: {

--- a/packages/opencomputer/src/index.ts
+++ b/packages/opencomputer/src/index.ts
@@ -106,14 +106,20 @@ interface OpenComputerSandboxStatic {
   createFromCheckpoint(checkpointId: string, opts?: Pick<OpenComputerSandboxOpts, 'apiKey' | 'apiUrl' | 'timeout' | 'envs' | 'secretStore'>): Promise<OpenComputerNativeSandbox>;
 }
 
-let _SandboxClass: OpenComputerSandboxStatic | null = null;
+// `@opencomputer/sdk` initialises at import. Starting it here rather than in
+// loadSandbox() means that happens before the first create, not during it.
+//
+// Dynamic, not static: the SDK is ESM-only with top-level await, so a static
+// import compiles to require() in the CJS build and fails to load.
+const _sdkPromise: Promise<OpenComputerSandboxStatic> = import('@opencomputer/sdk')
+  .then((mod) => (mod as { Sandbox: OpenComputerSandboxStatic }).Sandbox);
+
+// Nothing has awaited this yet, so an early failure would surface as an
+// unhandled rejection. The real error still reaches loadSandbox()'s caller.
+void _sdkPromise.catch(() => {});
 
 async function loadSandbox(): Promise<OpenComputerSandboxStatic> {
-  if (!_SandboxClass) {
-    const mod = await import('@opencomputer/sdk');
-    _SandboxClass = (mod as { Sandbox: OpenComputerSandboxStatic }).Sandbox;
-  }
-  return _SandboxClass;
+  return _sdkPromise;
 }
 
 export interface OpenComputerConfig {


### PR DESCRIPTION
`@opencomputer/sdk` initialises at import — HTTP/2 dispatcher and connection pool.

This adapter imported it lazily inside `loadSandbox()`, which only runs from `sandbox.create()` and the other operation methods, so the SDK initialised during the first operation instead of before it.

Start the import at module load; `loadSandbox()` awaits it. Call sites unchanged.

Stays a dynamic import: the SDK is ESM-only with top-level await, so a static one breaks the CJS build.
