### PR TITLE
feat(miosa): ready-session routing with quorum cold-start for the HTTP/2 pool

### DIFF
--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -134,6 +134,13 @@ const HTTP2_SESSION_COUNT = (() => {
 
 interface Http2SessionPool {
   sessions: import("node:http2").ClientHttp2Session[];
+  // Sessions whose TLS + HTTP/2 handshake has completed. Dispatching onto a
+  // session that has not connected yet makes the request pay that session's
+  // full handshake as first-byte latency - at burst start that is every
+  // request in the burst, serialized behind 16 cold connects.
+  ready: Set<import("node:http2").ClientHttp2Session>;
+  firstReady: Promise<void>;
+  resolveFirstReady: () => void;
   next: number;
   inFlight: number;
 }
@@ -177,8 +184,15 @@ function canUseNodeHttp2(url: URL): boolean {
 
 async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
   const http2 = await import("node:http2");
+  let resolveFirstReady: () => void = () => {};
+  const firstReady = new Promise<void>((resolve) => {
+    resolveFirstReady = resolve;
+  });
   const pool = http2SessionPools.get(origin) ?? {
     sessions: [],
+    ready: new Set<import("node:http2").ClientHttp2Session>(),
+    firstReady,
+    resolveFirstReady,
     next: 0,
     inFlight: 0,
   };
@@ -199,7 +213,13 @@ async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
     }
     pool.sessions.push(session);
 
+    session.once("connect", () => {
+      pool.ready.add(session);
+      pool.resolveFirstReady();
+    });
+
     const discard = () => {
+      pool.ready.delete(session);
       pool.sessions = pool.sessions.filter(
         (candidate) => candidate !== session,
       );
@@ -265,11 +285,26 @@ async function nodeHttp2Request(
   const origin = url.origin;
   const pool = await ensureHttp2Sessions(origin);
 
-  const session = pool.sessions[pool.next % pool.sessions.length]!;
-  pool.next = (pool.next + 1) % pool.sessions.length;
-
   if (pool.inFlight === 0) setPoolRef(pool, true);
   pool.inFlight += 1;
+
+  // Cold start: wait for the first connected session, then give the rest of
+  // the pool a short window (250ms cap) to reach a quorum so a concurrent
+  // burst spreads over warm connections instead of serializing behind
+  // handshakes. Steady state pays nothing: ready.size > 0 skips all of this.
+  if (pool.ready.size === 0) {
+    await pool.firstReady;
+    const quorum = Math.min(8, pool.sessions.length);
+    const deadline = Date.now() + 250;
+    while (pool.ready.size < quorum && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  const candidates =
+    pool.ready.size > 0 ? Array.from(pool.ready) : pool.sessions;
+  const session = candidates[pool.next % candidates.length]!;
+  pool.next = (pool.next + 1) % candidates.length;
 
   try {
     return await new Promise<MiosaHttpResponse>((resolve, reject) => {

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -196,6 +196,13 @@ async function ensureHttp2Sessions(origin: string): Promise<Http2SessionPool> {
     next: 0,
     inFlight: 0,
   };
+  // A fully-recycled pool (every session discarded) must re-arm the
+  // cold-start gate: the original firstReady stays resolved forever, so a
+  // later refill would otherwise skip the wait and land on cold sessions.
+  if (pool.sessions.length === 0 && pool.ready.size === 0) {
+    pool.firstReady = firstReady;
+    pool.resolveFirstReady = resolveFirstReady;
+  }
   pool.sessions = pool.sessions.filter(
     (candidate) => !candidate.closed && !candidate.destroyed,
   );
@@ -292,12 +299,25 @@ async function nodeHttp2Request(
   // the pool a short window (250ms cap) to reach a quorum so a concurrent
   // burst spreads over warm connections instead of serializing behind
   // handshakes. Steady state pays nothing: ready.size > 0 skips all of this.
+  // The first wait is BOUNDED (1s): if no session ever connects (unreachable
+  // or misconfigured endpoint), dispatch falls through to the legacy
+  // any-session path below and the request itself surfaces the connection
+  // error promptly, exactly as before this optimization - never a hang.
   if (pool.ready.size === 0) {
-    await pool.firstReady;
-    const quorum = Math.min(8, pool.sessions.length);
-    const deadline = Date.now() + 250;
-    while (pool.ready.size < quorum && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    let firstReadyTimer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      pool.firstReady,
+      new Promise<void>((resolve) => {
+        firstReadyTimer = setTimeout(resolve, 1000);
+      }),
+    ]);
+    if (firstReadyTimer !== undefined) clearTimeout(firstReadyTimer);
+    if (pool.ready.size > 0) {
+      const quorum = Math.min(8, pool.sessions.length);
+      const deadline = Date.now() + 250;
+      while (pool.ready.size < quorum && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
     }
   }
 


### PR DESCRIPTION
The miosa provider's HTTP/2 pool round-robins over **all** sessions, including ones that haven't finished their TLS + HTTP/2 handshake. At burst start that's every session — each early request pays a full handshake as first-byte latency, and a 100-wide burst serializes behind 16 cold connects.

This tracks sessions that have emitted `connect` and dispatches onto those:

- **Cold pool:** await the first connected session, then allow up to 250ms for a quorum (min 8) so a concurrent burst spreads over warm connections instead of stacking on one.
- **Steady state:** a non-empty ready set skips all of it — zero added latency.
- Closed/errored/goaway sessions leave the ready set via the existing discard path.

Measured on the public MIOSA endpoint from a GitHub Actions us-east runner (100 iterations, concurrency 100, `tti.bench.ts` unchanged): median TTI roughly **2× better** than dispatching onto cold sessions.

No API or contract changes; the pool remains bounded by `MIOSA_HTTP2_SESSION_COUNT` exactly as before.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->