### PR TITLE
feat(miosa): bounded retry on typed transient refusals (429/503 with Retry-After)

### DIFF
--- a/packages/miosa/src/__tests__/index.test.ts
+++ b/packages/miosa/src/__tests__/index.test.ts
@@ -137,6 +137,68 @@ describe("miosa provider", () => {
     });
   });
 
+  describe("transient refusal retry", () => {
+    function retryableResponse(code: string, status: number): Response {
+      return new Response(JSON.stringify({ error: { code } }), {
+        status,
+        headers: {
+          "content-type": "application/json",
+          // 0 keeps the test instant; the parser treats it as a real wait.
+          "retry-after": "0",
+        },
+      });
+    }
+
+    it("retries a 503 with Retry-After and succeeds", async () => {
+      fetchMock
+        .mockResolvedValueOnce(retryableResponse("CANARY_CLAIM_FAILED", 503))
+        .mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+
+      const sandbox = await provider.sandbox.create();
+
+      expect(sandbox.sandboxId).toBe(sandboxRecord().id);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries a 429 rate refusal and succeeds", async () => {
+      fetchMock
+        .mockResolvedValueOnce(retryableResponse("SANDBOX_LIMIT_REACHED", 429))
+        .mockResolvedValueOnce(jsonResponse(sandboxRecord(), 201));
+      const provider = miosa({ apiKey: API_KEY });
+
+      const sandbox = await provider.sandbox.create();
+
+      expect(sandbox.sandboxId).toBe(sandboxRecord().id);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up after the bounded attempts and surfaces the last error", async () => {
+      fetchMock.mockResolvedValue(
+        retryableResponse("CANARY_SHELF_EXHAUSTED", 503),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+
+      await expect(provider.sandbox.create()).rejects.toThrow(
+        /CANARY_SHELF_EXHAUSTED/,
+      );
+      // initial attempt + 3 bounded retries
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it("never retries a non-retryable status", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: { code: "SANDBOX_CREATE_FAILED" } }, 500),
+      );
+      const provider = miosa({ apiKey: API_KEY });
+
+      await expect(provider.sandbox.create()).rejects.toThrow(
+        /SANDBOX_CREATE_FAILED/,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("sandbox.getById", () => {
     it("should GET /sandboxes/:id", async () => {
       const record = sandboxRecord();

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -111,7 +111,26 @@ const DEFAULT_TIMEOUT_MS = 300_000;
 interface MiosaHttpResponse {
   readonly ok: boolean;
   readonly status: number;
+  /** Parsed Retry-After response header (delta-seconds form), when present. */
+  readonly retryAfterMs?: number;
   text(): Promise<string>;
+}
+
+// MIOSA answers transient refusals - a warm-shelf claim that lost a race, a
+// cohort with nothing eligible right now, a rate ceiling - as typed 503/429
+// responses carrying Retry-After, meaning the server did NOT perform the
+// action. Those are safe to retry for every method, bounded so a genuinely
+// unavailable service still fails within the caller's patience rather than
+// spinning forever.
+const RETRY_MAX_ATTEMPTS = 3; // retries after the initial attempt
+const RETRY_MAX_DELAY_MS = 5_000; // per-wait ceiling, Retry-After included
+
+// Both transports (fetch and node:http2) parse the header with this exact
+// contract: delta-seconds form only, anything else ignored.
+function parseRetryAfterMs(header: string | null | undefined): number | undefined {
+  if (!header) return undefined;
+  const seconds = Number.parseInt(header, 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1_000 : undefined;
 }
 
 // A bounded HTTP/2 pool prevents 100 independent TLS handshakes without
@@ -274,6 +293,7 @@ async function nodeHttp2Request(
   try {
     return await new Promise<MiosaHttpResponse>((resolve, reject) => {
       let status = 0;
+      let retryAfterMs: number | undefined;
       const chunks: Buffer[] = [];
       const request = session.request({
         ":method": method,
@@ -286,6 +306,11 @@ async function nodeHttp2Request(
 
       request.on("response", (responseHeaders) => {
         status = Number(responseHeaders[":status"] ?? 0);
+        retryAfterMs = parseRetryAfterMs(
+          typeof responseHeaders["retry-after"] === "string"
+            ? responseHeaders["retry-after"]
+            : undefined,
+        );
       });
       request.on("data", (chunk: Buffer | Uint8Array) => {
         chunks.push(Buffer.from(chunk));
@@ -296,6 +321,7 @@ async function nodeHttp2Request(
         resolve({
           ok: status >= 200 && status < 300,
           status,
+          retryAfterMs,
           text: async () => responseBody,
         });
       });
@@ -321,7 +347,14 @@ async function sendMiosaRequest(
     return nodeHttp2Request(parsedUrl, method, headers, body);
   }
 
-  return fetch(url, { method, headers, body });
+  const response = await fetch(url, { method, headers, body });
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after")),
+    text: () => response.text(),
+  };
 }
 
 function resolveAuth(config: MiosaConfig): { apiKey: string; baseUrl: string } {
@@ -358,12 +391,41 @@ async function miosaRequest<T>(
     "content-type": "application/json",
   };
   const requestBody = body === undefined ? undefined : JSON.stringify(body);
-  const response = await sendMiosaRequest(
+
+  let response = await sendMiosaRequest(
     `${auth.baseUrl}${path}`,
     method,
     headers,
     requestBody,
   );
+
+  // 429/503 are MIOSA's typed transient refusals (rate ceiling, warm-shelf
+  // claim race, cohort momentarily ineligible): the server states it did NOT
+  // perform the action, so replaying the identical request is safe for every
+  // method. Honor Retry-After when the server names a wait; back off
+  // exponentially when it does not; give up after a bounded number of
+  // attempts so a genuinely down service still fails promptly.
+  for (
+    let attempt = 0;
+    (response.status === 429 || response.status === 503) &&
+    attempt < RETRY_MAX_ATTEMPTS;
+    attempt++
+  ) {
+    const delayMs = Math.min(
+      response.retryAfterMs ?? 250 * 2 ** attempt,
+      RETRY_MAX_DELAY_MS,
+    );
+    // Executor form: this package's TS lib target predates
+    // Promise.withResolvers.
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+    response = await sendMiosaRequest(
+      `${auth.baseUrl}${path}`,
+      method,
+      headers,
+      requestBody,
+    );
+  }
 
   const text = await response.text();
   let parsed: unknown = undefined;


### PR DESCRIPTION
The MIOSA API answers transient conditions - a warm-pool claim that lost a race under concurrent load, capacity momentarily ineligible, a rate ceiling - as typed 429/503 responses carrying `Retry-After`, all meaning the server did **not** perform the action. The provider surfaced these as immediate hard failures.

This adds a bounded retry: replay on 429/503 (safe for every method - the action never happened), honor `Retry-After` when the server names a wait, exponential backoff (250ms base) otherwise, capped at 3 retries / 5s per wait so a genuinely down service still fails promptly.

Both transports (fetch and the node:http2 session pool) now expose the parsed `Retry-After` on the internal response shape.

Tests: 503 retry-to-success, 429 retry-to-success, bounded give-up surfaces the last typed error, non-retryable 500 never retried - 33/33 passing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->