### PR TITLE
perf(archil): optimize writeFile for exec-only disk commands

### DIFF
--- a/.changeset/archil-serialize-exec.md
+++ b/.changeset/archil-serialize-exec.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/archil": patch
+---
+
+Serialize disk exec commands so concurrent filesystem operations do not race on the shared disk state.

--- a/.changeset/archil-writefile-chunk.md
+++ b/.changeset/archil-writefile-chunk.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/archil": patch
+---
+
+Chunk base64-encoded file writes in `writeFile` so each `runCommand` stays below Archil's 102,400-byte command limit. This fixes writing files larger than ~75 KiB through the provider's filesystem API.

--- a/.changeset/archil-writefile-chunk.md
+++ b/.changeset/archil-writefile-chunk.md
@@ -3,3 +3,5 @@
 ---
 
 Chunk base64-encoded file writes in `writeFile` so each `runCommand` stays below Archil's 102,400-byte command limit. This fixes writing files larger than ~75 KiB through the provider's filesystem API.
+
+Compress writes with gzip when the compressed payload fits in a single command, reducing the number of `exec` calls for repetitive or compressible content. Checkout and checkin the target parent directory once per write (first and last chunk) instead of on every chunk.

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -79,6 +79,65 @@ describe('archil filesystem writeFile chunking', () => {
     expect(maxInFlight).toBe(1);
   });
 
+  it('does not interleave chunks from concurrent large writes', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetchMock = vi.fn(async (_input, init) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      inFlight -= 1;
+      return successExecResponse();
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    // Two concurrent writes to the same path must be atomic at the operation
+    // level; chunks from one write must not interleave with the other.
+    await Promise.all([
+      sandbox.filesystem.writeFile('/tmp/bench/collide.txt', 'a'.repeat(100 * 1024)),
+      sandbox.filesystem.writeFile('/tmp/bench/collide.txt', 'b'.repeat(100 * 1024)),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+
+    const commandBodies = (fetchMock.mock.calls as any[][])
+      .filter((call) => {
+        const init = call[1] as RequestInit | undefined;
+        return init?.method === 'POST' && String(call[0]).includes('/exec');
+      })
+      .map(([, init]) => {
+        const body = typeof init?.body === 'string' ? init.body : '';
+        return JSON.parse(body).command as string;
+      });
+
+    const writes = commandBodies.filter((cmd) => cmd.includes('base64 -d'));
+    const redirects = writes.map((cmd) => {
+      const match = cmd.match(/base64 -d (>>?) /);
+      return match ? (match[1] === '>' ? 'truncate' : 'append') : 'unknown';
+    });
+
+    // A 100 KiB raw payload base64-encodes to ~136 KB, so it is written as
+    // one truncate (>) and two appends (>>). With two concurrent writes to
+    // the same path, the command sequence must be [T, A, A, T, A, A]; any
+    // interleaving of chunks breaks that grouping.
+    const groups: string[][] = [];
+    for (const redirect of redirects) {
+      if (redirect === 'truncate') {
+        groups.push([redirect]);
+      } else {
+        expect(groups.length).toBeGreaterThan(0);
+        groups[groups.length - 1].push(redirect);
+      }
+    }
+    expect(groups.length).toBe(2);
+    for (const group of groups) {
+      expect(group).toEqual(['truncate', 'append', 'append']);
+    }
+  });
+
   it('creates or truncates the file for empty content', async () => {
     const fetchMock = vi.fn(async (_input, init) => successExecResponse());
     global.fetch = fetchMock as typeof fetch;

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -13,6 +13,69 @@ afterEach(() => {
   global.fetch = originalFetch;
 });
 
+function successExecResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      success: true,
+      data: {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        timing: { totalMs: 0, queueMs: 0, executeMs: 0 },
+      },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+describe('archil filesystem writeFile chunking', () => {
+  it('splits large writes into commands under the 102400-byte limit', async () => {
+    const fetchMock = vi.fn(async (_input, init) => successExecResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+    const content = 'x'.repeat(100 * 1024); // 100 KiB raw -> >100 KiB base64
+    await sandbox.filesystem.writeFile('/tmp/bench/file.txt', content);
+
+    const execCalls = (fetchMock.mock.calls as any[][]).filter((call) => {
+      const init = call[1] as RequestInit | undefined;
+      return init?.method === 'POST' && String(call[0]).includes('/exec');
+    });
+
+    const commandBodies = execCalls.map(([, init]) => {
+      const body = typeof init?.body === 'string' ? init.body : '';
+      return JSON.parse(body).command as string;
+    });
+
+    const writeCommands = commandBodies.filter((cmd) => cmd.includes('base64 -d'));
+    expect(writeCommands.length).toBeGreaterThan(1);
+    for (const cmd of writeCommands) {
+      expect(cmd.length).toBeLessThanOrEqual(102400);
+    }
+  });
+
+  it('creates or truncates the file for empty content', async () => {
+    const fetchMock = vi.fn(async (_input, init) => successExecResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+    await sandbox.filesystem.writeFile('/tmp/bench/empty.txt', '');
+
+    const execCalls = (fetchMock.mock.calls as any[][]).filter((call) => {
+      const init = call[1] as RequestInit | undefined;
+      return init?.method === 'POST' && String(call[0]).includes('/exec');
+    });
+    expect(execCalls.length).toBeGreaterThanOrEqual(1);
+    const commandBodies = execCalls.map(([, init]) => {
+      const body = typeof init?.body === 'string' ? init.body : '';
+      return JSON.parse(body).command as string;
+    });
+    expect(commandBodies.some((cmd) => cmd.trimEnd().endsWith(`> '/tmp/bench/empty.txt'`))).toBe(true);
+  });
+});
+
 describe('archil export shape', () => {
   it('is resolvable via camelCase conversion of the hyphenated provider name', () => {
     // Workbench resolves provider names by camelCase conversion. 'archil' is

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -55,6 +55,30 @@ describe('archil filesystem writeFile chunking', () => {
     }
   });
 
+  it('serializes concurrent disk commands so they do not race on shared state', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetchMock = vi.fn(async (_input, init) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return successExecResponse();
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    // Concurrent runCommand calls to the same disk should be queued.
+    await Promise.all([
+      sandbox.runCommand('mkdir -p /tmp/bench/dir'),
+      sandbox.runCommand('touch /tmp/bench/dir/file.txt'),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+  });
+
   it('creates or truncates the file for empty content', async () => {
     const fetchMock = vi.fn(async (_input, init) => successExecResponse());
     global.fetch = fetchMock as typeof fetch;

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -164,17 +164,11 @@ describe('archil filesystem mapping', () => {
     const mutationCommands = commands(fetchMock);
     expect(mutationCommands).toHaveLength(3);
     for (const command of mutationCommands) {
-      expect(command).toContain('archil checkout --force --yes');
-      expect(command).toContain('archil checkin');
+      expect(command).toContain("archil checkout --force --yes '/mnt/archil'");
+      expect(command).toContain("archil checkin '/mnt/archil'");
     }
     expect(mutationCommands[0]).toContain(
       "mkdir -p '/mnt/archil/tmp/data'",
-    );
-    expect(mutationCommands[0]).toContain(
-      "archil checkout --force --yes '/mnt/archil/tmp'",
-    );
-    expect(mutationCommands[0]).toContain(
-      "archil checkin '/mnt/archil/tmp'",
     );
     expect(mutationCommands[1]).toContain(
       "printf %s 'aGVsbG8=' | base64 -d > '/mnt/archil/tmp/data/hello.txt.computesdk-write-",
@@ -185,17 +179,8 @@ describe('archil filesystem mapping', () => {
     expect(mutationCommands[1]).toContain(
       "if [ -d '/mnt/archil/tmp/data/hello.txt' ]; then",
     );
-    expect(mutationCommands[1]).toContain(
-      "archil checkout --force --yes '/mnt/archil/tmp/data'",
-    );
-    expect(mutationCommands[1]).toContain(
-      "archil checkin '/mnt/archil/tmp/data'",
-    );
     expect(mutationCommands[2]).toContain(
       "rm -rf '/mnt/archil/tmp/data/hello.txt'",
-    );
-    expect(mutationCommands[2]).toContain(
-      "archil checkout --force --yes '/mnt/archil/tmp/data'",
     );
   });
 
@@ -449,6 +434,43 @@ describe('archil filesystem mapping', () => {
       expect(group[0]).toBe('truncate');
       expect(group.slice(1).every((r) => r === 'append')).toBe(true);
     }
+  });
+
+  it('recursively creates missing parents when writing a nested file', async () => {
+    const fetchMock = vi.fn(async () => execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await sandbox.filesystem.writeFile(
+      '/tmp/a/b/c/file.txt',
+      'nested content',
+    );
+
+    const writeCommands = commands(fetchMock);
+    expect(writeCommands.length).toBe(1);
+    expect(writeCommands[0]).toContain(
+      "mkdir -p '/mnt/archil/tmp/a/b/c'",
+    );
+    expect(writeCommands[0]).toContain("archil checkout --force --yes '/mnt/archil'");
+  });
+
+  it('removing a path whose parent does not exist succeeds', async () => {
+    const fetchMock = vi.fn(async () => execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await sandbox.filesystem.remove('/tmp/missing-parent/file.txt');
+
+    const removeCommands = commands(fetchMock);
+    expect(removeCommands.length).toBe(1);
+    expect(removeCommands[0]).toContain(
+      "rm -rf '/mnt/archil/tmp/missing-parent/file.txt'",
+    );
+    expect(removeCommands[0]).toContain("archil checkout --force --yes '/mnt/archil'");
   });
 });
 

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -164,11 +164,17 @@ describe('archil filesystem mapping', () => {
     const mutationCommands = commands(fetchMock);
     expect(mutationCommands).toHaveLength(3);
     for (const command of mutationCommands) {
-      expect(command).toContain("archil checkout --force --yes '/mnt/archil'");
-      expect(command).toContain("archil checkin '/mnt/archil'");
+      expect(command).toContain('archil checkout --force --yes');
+      expect(command).toContain('archil checkin');
     }
     expect(mutationCommands[0]).toContain(
       "mkdir -p '/mnt/archil/tmp/data'",
+    );
+    expect(mutationCommands[0]).toContain(
+      "archil checkout --force --yes '/mnt/archil/tmp'",
+    );
+    expect(mutationCommands[0]).toContain(
+      "archil checkin '/mnt/archil/tmp'",
     );
     expect(mutationCommands[1]).toContain(
       "printf %s 'aGVsbG8=' | base64 -d > '/mnt/archil/tmp/data/hello.txt.computesdk-write-",
@@ -179,12 +185,21 @@ describe('archil filesystem mapping', () => {
     expect(mutationCommands[1]).toContain(
       "if [ -d '/mnt/archil/tmp/data/hello.txt' ]; then",
     );
+    expect(mutationCommands[1]).toContain(
+      "archil checkout --force --yes '/mnt/archil/tmp/data'",
+    );
+    expect(mutationCommands[1]).toContain(
+      "archil checkin '/mnt/archil/tmp/data'",
+    );
     expect(mutationCommands[2]).toContain(
       "rm -rf '/mnt/archil/tmp/data/hello.txt'",
     );
+    expect(mutationCommands[2]).toContain(
+      "archil checkout --force --yes '/mnt/archil/tmp/data'",
+    );
   });
 
-  it('chunks large writes within Archil exec limits', async () => {
+  it('writes compressible large files in a single gzip command within Archil exec limits', async () => {
     const fetchMock = vi.fn(async () => execResponse());
     global.fetch = fetchMock as typeof fetch;
 
@@ -192,6 +207,32 @@ describe('archil filesystem mapping', () => {
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
 
     await sandbox.filesystem.writeFile('/tmp/large.txt', 'x'.repeat(100_000));
+
+    const writeCommands = commands(fetchMock);
+    expect(writeCommands).toHaveLength(1);
+    expect(Buffer.byteLength(writeCommands[0], 'utf8')).toBeLessThanOrEqual(
+      102_400,
+    );
+    expect(writeCommands[0]).toContain('base64 -d | gzip -d');
+    expect(writeCommands[0]).toContain(
+      "mv '/mnt/archil/tmp/large.txt.computesdk-write-",
+    );
+    expect(writeCommands[0]).toContain(" '/mnt/archil/tmp/large.txt'");
+  });
+
+  it('falls back to base64 chunks for incompressible data within Archil exec limits', async () => {
+    const fetchMock = vi.fn(async () => execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    // Incompressible random ASCII avoids the gzip short-circuit.
+    const randomContent = Array.from({ length: 200_000 }, () =>
+      String.fromCharCode(33 + Math.floor(Math.random() * 94)),
+    ).join('');
+
+    await sandbox.filesystem.writeFile('/tmp/large.bin', randomContent);
 
     const writeCommands = commands(fetchMock);
     const chunkCommands = writeCommands.filter((command) =>
@@ -204,11 +245,9 @@ describe('archil filesystem mapping', () => {
       ),
     ).toBe(true);
     expect(writeCommands.at(-1)).toContain(
-      "mv '/mnt/archil/tmp/large.txt.computesdk-write-",
+      "mv '/mnt/archil/tmp/large.bin.computesdk-write-",
     );
-    expect(writeCommands.at(-1)).toContain(
-      " '/mnt/archil/tmp/large.txt'",
-    );
+    expect(writeCommands.at(-1)).toContain(" '/mnt/archil/tmp/large.bin'");
   });
 
   it('reads files larger than the Archil response limit in chunks', async () => {
@@ -334,8 +373,13 @@ describe('archil filesystem mapping', () => {
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
 
+    // Incompressible random ASCII forces uncompressed base64 chunking.
+    const randomContent = Array.from({ length: 200_000 }, () =>
+      String.fromCharCode(33 + Math.floor(Math.random() * 94)),
+    ).join('');
+
     await expect(
-      sandbox.filesystem.writeFile('/tmp/partial.txt', 'x'.repeat(200_000)),
+      sandbox.filesystem.writeFile('/tmp/partial.txt', randomContent),
     ).rejects.toThrow('Failed to write /tmp/partial.txt: chunk failed');
 
     const writeCommands = commands(fetchMock);
@@ -375,13 +419,18 @@ describe('archil filesystem mapping', () => {
       command.includes('base64 -d'),
     );
 
-    // A 100 KiB raw payload base64-encodes to ~136 KiB. With the temp-path
-    // staging from the main implementation that is included in the chunk-size
-    // calculation, the exact number of chunks can vary; the key invariant is that
-    // every write begins with a truncate ('>') and completes all of its append
-    // ('>>') chunks before the next write's truncate begins.
+    // Composable data is gzip'd in a single command, so the key invariant is
+    // that each write is a discrete command and the two writes do not interleave.
+    expect(mutationCommands.length).toBe(2);
+    for (const command of mutationCommands) {
+      expect(command).toContain('base64 -d | gzip -d');
+      expect(command).toContain("'/mnt/archil/tmp/collide.txt'");
+    }
+
+    // Extract the redirect ('>' or '>>') used for the temp file so the test
+    // still verifies per-write isolation if chunking is ever reintroduced.
     const redirects = mutationCommands.map((command) => {
-      const match = command.match(/base64 -d (>>?) /);
+      const match = command.match(/(>>?) '\/mnt\/archil\/tmp\/collide\.txt\.computesdk-write-/);
       return match ? (match[1] === '>' ? 'truncate' : 'append') : 'unknown';
     });
 

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -167,6 +167,11 @@ function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+// Archil enforces a 102,400-byte command limit on /api/disks/{id}/exec.
+// Keep each base64 chunk well under that limit so the wrapped command string
+// (env prefix + printf + path) still fits.
+const MAX_BASE64_CHUNK_SIZE = 48 * 1024; // must be a multiple of 4
+
 function wrapCommand(command: string, options?: RunCommandOptions): string {
   let wrapped = command;
 
@@ -311,13 +316,27 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
             await runCommand(sandbox, `mkdir -p ${shellEscape(parent)}`);
           }
           // base64-pipe to avoid heredoc/quoting hazards on arbitrary content.
+          // The full base64 string can exceed Archil's 102,400-byte command limit,
+          // so split it into fixed-size chunks and write them sequentially.
           const encoded = Buffer.from(content, 'utf8').toString('base64');
-          const result = await runCommand(
-            sandbox,
-            `printf %s ${shellEscape(encoded)} | base64 -d > ${shellEscape(path)}`,
-          );
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to write ${path}: ${result.stderr}`);
+          if (encoded.length === 0) {
+            // Empty content: create or truncate the file without piping.
+            const result = await runCommand(sandbox, `> ${shellEscape(path)}`);
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to write ${path}: ${result.stderr}`);
+            }
+            return;
+          }
+          for (let i = 0; i < encoded.length; i += MAX_BASE64_CHUNK_SIZE) {
+            const chunk = encoded.slice(i, i + MAX_BASE64_CHUNK_SIZE);
+            const redirect = i === 0 ? '>' : '>>';
+            const result = await runCommand(
+              sandbox,
+              `printf %s ${shellEscape(chunk)} | base64 -d ${redirect} ${shellEscape(path)}`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to write ${path}: ${result.stderr}`);
+            }
           }
         },
 

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -8,6 +8,7 @@
  * existing disk id.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { defineProvider } from '@computesdk/provider';
 import type {
   CommandResult,
@@ -197,23 +198,45 @@ function wrapCommand(command: string, options?: RunCommandOptions): string {
 
 // Archil disks are single-writer / exec-only. Concurrent POSTs to /exec on the
 // same disk race against the filesystem state (e.g. a mkdir from one command is
-// not visible to the next), so serialize all commands per disk id.
-const execQueues = new Map<string, Promise<unknown>>();
+// not visible to the next). We therefore run every command (and every multi-
+// command filesystem operation) under a per-disk lock.
+const diskQueues = new Map<string, Promise<unknown>>();
+const diskQueueStore = new AsyncLocalStorage<{ diskId: string }>();
+
+function withDiskLock<T>(sandbox: ArchilSandbox, fn: () => Promise<T>): Promise<T> {
+  const diskId = sandbox.disk.id;
+  const prev = diskQueues.get(diskId) ?? Promise.resolve();
+  const run = async (): Promise<T> => diskQueueStore.run({ diskId }, fn);
+  const next = prev.then(run, run);
+  const settled = next.catch(() => undefined);
+  settled.then(() => {
+    if (diskQueues.get(diskId) === settled) {
+      diskQueues.delete(diskId);
+    }
+  });
+  diskQueues.set(diskId, settled);
+  return next;
+}
 
 async function execOnDisk(sandbox: ArchilSandbox, command: string): Promise<ExecResponse> {
   const diskId = sandbox.disk.id;
-  const chain = execQueues.get(diskId) ?? Promise.resolve();
-  const run = (): Promise<ExecResponse> =>
-    callApi<ExecResponse>(
+  const ctx = diskQueueStore.getStore();
+  if (ctx?.diskId === diskId) {
+    return callApi<ExecResponse>(
       sandbox.resolved,
       'POST',
       `/api/disks/${encodeURIComponent(diskId)}/exec`,
       { command },
     );
-  const next = chain.then(run, run);
-  // Keep the queue moving even if this command fails.
-  execQueues.set(diskId, next.catch(() => undefined));
-  return next;
+  }
+  return withDiskLock(sandbox, () =>
+    callApi<ExecResponse>(
+      sandbox.resolved,
+      'POST',
+      `/api/disks/${encodeURIComponent(diskId)}/exec`,
+      { command },
+    ),
+  );
 }
 
 const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
@@ -315,84 +338,96 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
 
       filesystem: {
         readFile: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `cat ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to read ${path}: ${result.stderr}`);
-          }
-          return result.stdout;
+          return withDiskLock(sandbox, async () => {
+            const result = await runCommand(sandbox, `cat ${shellEscape(path)}`);
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to read ${path}: ${result.stderr}`);
+            }
+            return result.stdout;
+          });
         },
 
         writeFile: async (sandbox, path, content, runCommand) => {
-          const parent = path.substring(0, path.lastIndexOf('/'));
-          if (parent) {
-            await runCommand(sandbox, `mkdir -p ${shellEscape(parent)}`);
-          }
-          // base64-pipe to avoid heredoc/quoting hazards on arbitrary content.
-          // The full base64 string can exceed Archil's 102,400-byte command limit,
-          // so split it into fixed-size chunks and write them sequentially.
-          const encoded = Buffer.from(content, 'utf8').toString('base64');
-          if (encoded.length === 0) {
-            // Empty content: create or truncate the file without piping.
-            const result = await runCommand(sandbox, `> ${shellEscape(path)}`);
-            if (result.exitCode !== 0) {
-              throw new Error(`Failed to write ${path}: ${result.stderr}`);
+          return withDiskLock(sandbox, async () => {
+            const parent = path.substring(0, path.lastIndexOf('/'));
+            if (parent) {
+              await runCommand(sandbox, `mkdir -p ${shellEscape(parent)}`);
             }
-            return;
-          }
-          for (let i = 0; i < encoded.length; i += MAX_BASE64_CHUNK_SIZE) {
-            const chunk = encoded.slice(i, i + MAX_BASE64_CHUNK_SIZE);
-            const redirect = i === 0 ? '>' : '>>';
-            const result = await runCommand(
-              sandbox,
-              `printf %s ${shellEscape(chunk)} | base64 -d ${redirect} ${shellEscape(path)}`,
-            );
-            if (result.exitCode !== 0) {
-              throw new Error(`Failed to write ${path}: ${result.stderr}`);
+            // base64-pipe to avoid heredoc/quoting hazards on arbitrary content.
+            // The full base64 string can exceed Archil's 102,400-byte command limit,
+            // so split it into fixed-size chunks and write them sequentially.
+            const encoded = Buffer.from(content, 'utf8').toString('base64');
+            if (encoded.length === 0) {
+              // Empty content: create or truncate the file without piping.
+              const result = await runCommand(sandbox, `> ${shellEscape(path)}`);
+              if (result.exitCode !== 0) {
+                throw new Error(`Failed to write ${path}: ${result.stderr}`);
+              }
+              return;
             }
-          }
+            for (let i = 0; i < encoded.length; i += MAX_BASE64_CHUNK_SIZE) {
+              const chunk = encoded.slice(i, i + MAX_BASE64_CHUNK_SIZE);
+              const redirect = i === 0 ? '>' : '>>';
+              const result = await runCommand(
+                sandbox,
+                `printf %s ${shellEscape(chunk)} | base64 -d ${redirect} ${shellEscape(path)}`,
+              );
+              if (result.exitCode !== 0) {
+                throw new Error(`Failed to write ${path}: ${result.stderr}`);
+              }
+            }
+          });
         },
 
         mkdir: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `mkdir -p ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
-          }
+          return withDiskLock(sandbox, async () => {
+            const result = await runCommand(sandbox, `mkdir -p ${shellEscape(path)}`);
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
+            }
+          });
         },
 
         readdir: async (sandbox, path, runCommand) => {
-          // Tab-separated: type<TAB>size<TAB>mtime-iso<TAB>name. Robust to spaces in names.
-          const result = await runCommand(
-            sandbox,
-            `find ${shellEscape(path)} -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\n'`,
-          );
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
-          }
-          const entries: FileEntry[] = [];
-          for (const line of result.stdout.split('\n')) {
-            if (!line) continue;
-            const [typeChar, sizeStr, mtimeStr, ...nameParts] = line.split('\t');
-            const name = nameParts.join('\t');
-            entries.push({
-              name,
-              type: typeChar === 'd' ? 'directory' : 'file',
-              size: parseInt(sizeStr, 10) || 0,
-              modified: new Date(parseFloat(mtimeStr) * 1000),
-            });
-          }
-          return entries;
+          return withDiskLock(sandbox, async () => {
+            // Tab-separated: type<TAB>size<TAB>mtime-iso<TAB>name. Robust to spaces in names.
+            const result = await runCommand(
+              sandbox,
+              `find ${shellEscape(path)} -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\n'`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
+            }
+            const entries: FileEntry[] = [];
+            for (const line of result.stdout.split('\n')) {
+              if (!line) continue;
+              const [typeChar, sizeStr, mtimeStr, ...nameParts] = line.split('\t');
+              const name = nameParts.join('\t');
+              entries.push({
+                name,
+                type: typeChar === 'd' ? 'directory' : 'file',
+                size: parseInt(sizeStr, 10) || 0,
+                modified: new Date(parseFloat(mtimeStr) * 1000),
+              });
+            }
+            return entries;
+          });
         },
 
         exists: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `test -e ${shellEscape(path)}`);
-          return result.exitCode === 0;
+          return withDiskLock(sandbox, async () => {
+            const result = await runCommand(sandbox, `test -e ${shellEscape(path)}`);
+            return result.exitCode === 0;
+          });
         },
 
         remove: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `rm -rf ${shellEscape(path)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to remove ${path}: ${result.stderr}`);
-          }
+          return withDiskLock(sandbox, async () => {
+            const result = await runCommand(sandbox, `rm -rf ${shellEscape(path)}`);
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to remove ${path}: ${result.stderr}`);
+            }
+          });
         },
       },
 

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -195,13 +195,25 @@ function wrapCommand(command: string, options?: RunCommandOptions): string {
   return wrapped;
 }
 
+// Archil disks are single-writer / exec-only. Concurrent POSTs to /exec on the
+// same disk race against the filesystem state (e.g. a mkdir from one command is
+// not visible to the next), so serialize all commands per disk id.
+const execQueues = new Map<string, Promise<unknown>>();
+
 async function execOnDisk(sandbox: ArchilSandbox, command: string): Promise<ExecResponse> {
-  return callApi<ExecResponse>(
-    sandbox.resolved,
-    'POST',
-    `/api/disks/${encodeURIComponent(sandbox.disk.id)}/exec`,
-    { command },
-  );
+  const diskId = sandbox.disk.id;
+  const chain = execQueues.get(diskId) ?? Promise.resolve();
+  const run = (): Promise<ExecResponse> =>
+    callApi<ExecResponse>(
+      sandbox.resolved,
+      'POST',
+      `/api/disks/${encodeURIComponent(diskId)}/exec`,
+      { command },
+    );
+  const next = chain.then(run, run);
+  // Keep the queue moving even if this command fails.
+  execQueues.set(diskId, next.catch(() => undefined));
+  return next;
 }
 
 const _provider = defineProvider<ArchilSandbox, ArchilConfig>({

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -202,8 +202,13 @@ function checkinCommand(path: string): string {
   return `archil checkin ${shellEscape(path)}`;
 }
 
-function withParentCheckout(path: string, command: string): string {
-  return `${checkoutCommand(path)} && { ${command}; status=$?; ${checkinCommand(path)}; checkin_status=$?; if [ $status -ne 0 ]; then exit $status; fi; exit $checkin_status; }`;
+function withDiskWriteLock(command: string): string {
+  const mountRoot = shellEscape(ARCHIL_MOUNT_ROOT);
+  return [
+    `archil checkout --force --yes ${mountRoot}`,
+    `{ ${command}; status=$?; archil checkin ${mountRoot}; checkin_status=$?; ` +
+      `if [ $status -ne 0 ]; then exit $status; fi; exit $checkin_status; }`,
+  ].join(' && ');
 }
 
 function execCommandBytes(command: string): number {
@@ -251,8 +256,7 @@ function maxWriteChunkSize(
 
   while (low < high) {
     const candidate = Math.ceil((low + high) / 2);
-    const command = withParentCheckout(
-      parent,
+    const command = withDiskWriteLock(
       buildWriteChunkCommand(
         parent,
         tempPath,
@@ -537,8 +541,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 started = true;
                 const result = await runCommand(
                   sandbox,
-                  withParentCheckout(
-                    parent,
+                  withDiskWriteLock(
                     writeCommand(`: > ${shellEscape(tempPath)}`),
                   ),
                 );
@@ -559,10 +562,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 const compressed = gzipSync(raw);
                 const candidate = compressed.toString('base64');
                 if (candidate.length < encoded.length) {
-                  const command = withParentCheckout(
-                    parent,
-                    gzipWriteCommand(candidate),
-                  );
+                  const command = withDiskWriteLock(gzipWriteCommand(candidate));
                   if (execCommandBytes(command) <= ARCHIL_MAX_EXEC_COMMAND_BYTES) {
                     gzipBase64 = candidate;
                   }
@@ -575,7 +575,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 started = true;
                 const result = await runCommand(
                   sandbox,
-                  withParentCheckout(parent, gzipWriteCommand(gzipBase64)),
+                  withDiskWriteLock(gzipWriteCommand(gzipBase64)),
                 );
                 if (result.exitCode !== 0) {
                   throw new Error(result.stderr);
@@ -589,8 +589,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 started = true;
                 const result = await runCommand(
                   sandbox,
-                  withParentCheckout(
-                    parent,
+                  withDiskWriteLock(
                     buildWriteChunkCommand(
                       parent,
                       tempPath,
@@ -615,7 +614,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
 
                 if (isFirst) {
                   chunks.push(
-                    `${checkoutCommand(parent)} && ${buildWriteChunkCommand(
+                    `${checkoutCommand(ARCHIL_MOUNT_ROOT)} && ${buildWriteChunkCommand(
                       parent,
                       tempPath,
                       diskPath,
@@ -633,7 +632,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                       chunk,
                       false,
                       true,
-                    )} && ${checkinCommand(parent)}`,
+                    )} && ${checkinCommand(ARCHIL_MOUNT_ROOT)}`,
                   );
                 } else {
                   chunks.push(
@@ -661,10 +660,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 try {
                   await runCommand(
                     sandbox,
-                    withParentCheckout(
-                      parent,
-                      `rm -f ${shellEscape(tempPath)}`,
-                    ),
+                    withDiskWriteLock(`rm -f ${shellEscape(tempPath)}`),
                   );
                 } catch {
                   // Preserve the original write error if cleanup fails.
@@ -682,13 +678,9 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         mkdir: async (sandbox, path, runCommand) => {
           return withDiskLock(sandbox, async () => {
             const diskPath = mapFilesystemPath(path);
-            const parent = posix.dirname(diskPath);
             const result = await runCommand(
               sandbox,
-              withParentCheckout(
-                parent,
-                `mkdir -p ${shellEscape(diskPath)}`,
-              ),
+              withDiskWriteLock(`mkdir -p ${shellEscape(diskPath)}`),
             );
             if (result.exitCode !== 0) {
               throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
@@ -737,13 +729,9 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
             if (diskPath === ARCHIL_MOUNT_ROOT) {
               throw new Error('Refusing to remove the Archil disk mount root.');
             }
-            const parent = posix.dirname(diskPath);
             const result = await runCommand(
               sandbox,
-              withParentCheckout(
-                parent,
-                `rm -rf ${shellEscape(diskPath)}`,
-              ),
+              withDiskWriteLock(`rm -rf ${shellEscape(diskPath)}`),
             );
             if (result.exitCode !== 0) {
               throw new Error(`Failed to remove ${path}: ${result.stderr}`);

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -12,6 +12,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { defineProvider } from '@computesdk/provider';
 import { randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
+import { gzipSync } from 'node:zlib';
 import type {
   CommandResult,
   SandboxInfo,
@@ -193,13 +194,16 @@ function mapFilesystemPath(path: string): string {
   return `${ARCHIL_MOUNT_ROOT}${normalized}`;
 }
 
-function withDiskWriteLock(command: string): string {
-  const mountRoot = shellEscape(ARCHIL_MOUNT_ROOT);
-  return [
-    `archil checkout --force --yes ${mountRoot}`,
-    `{ ${command}; status=$?; archil checkin ${mountRoot}; checkin_status=$?; ` +
-      `if [ $status -ne 0 ]; then exit $status; fi; exit $checkin_status; }`,
-  ].join(' && ');
+function checkoutCommand(path: string): string {
+  return `archil checkout --force --yes ${shellEscape(path)}`;
+}
+
+function checkinCommand(path: string): string {
+  return `archil checkin ${shellEscape(path)}`;
+}
+
+function withParentCheckout(path: string, command: string): string {
+  return `${checkoutCommand(path)} && { ${command}; status=$?; ${checkinCommand(path)}; checkin_status=$?; if [ $status -ne 0 ]; then exit $status; fi; exit $checkin_status; }`;
 }
 
 function execCommandBytes(command: string): number {
@@ -247,7 +251,8 @@ function maxWriteChunkSize(
 
   while (low < high) {
     const candidate = Math.ceil((low + high) / 2);
-    const command = withDiskWriteLock(
+    const command = withParentCheckout(
+      parent,
       buildWriteChunkCommand(
         parent,
         tempPath,
@@ -510,21 +515,31 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
           return withDiskLock(sandbox, async () => {
             const diskPath = mapFilesystemPath(path);
             const parent = posix.dirname(diskPath);
-            const encoded = Buffer.from(content, 'utf8').toString('base64');
             const tempPath = `${diskPath}.computesdk-write-${randomUUID()}`;
             let started = false;
 
+            function writeCommand(body: string): string {
+              return [
+                `mkdir -p ${shellEscape(parent)}`,
+                body,
+                finalizeStagedFileCommand(tempPath, diskPath),
+              ].join(' && ');
+            }
+
+            function gzipWriteCommand(gzipBase64: string): string {
+              return writeCommand(
+                `printf %s ${shellEscape(gzipBase64)} | base64 -d | gzip -d > ${shellEscape(tempPath)}`,
+              );
+            }
+
             try {
-              if (encoded.length === 0) {
+              if (content.length === 0) {
                 started = true;
                 const result = await runCommand(
                   sandbox,
-                  withDiskWriteLock(
-                    [
-                      `mkdir -p ${shellEscape(parent)}`,
-                      `: > ${shellEscape(tempPath)}`,
-                      finalizeStagedFileCommand(tempPath, diskPath),
-                    ].join(' && '),
+                  withParentCheckout(
+                    parent,
+                    writeCommand(`: > ${shellEscape(tempPath)}`),
                   ),
                 );
                 if (result.exitCode !== 0) {
@@ -533,24 +548,110 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 return;
               }
 
-              const chunkSize = maxWriteChunkSize(parent, tempPath, diskPath);
-              for (let offset = 0; offset < encoded.length; offset += chunkSize) {
-                const isFirst = offset === 0;
-                const isFinal = offset + chunkSize >= encoded.length;
+              const raw = Buffer.from(content, 'utf8');
+              const encoded = raw.toString('base64');
+
+              // Compressible content can be written in a single command because
+              // gzip shrinks the payload before it is base64-encoded for the
+              // exec command limit.
+              let gzipBase64: string | undefined;
+              try {
+                const compressed = gzipSync(raw);
+                const candidate = compressed.toString('base64');
+                if (candidate.length < encoded.length) {
+                  const command = withParentCheckout(
+                    parent,
+                    gzipWriteCommand(candidate),
+                  );
+                  if (execCommandBytes(command) <= ARCHIL_MAX_EXEC_COMMAND_BYTES) {
+                    gzipBase64 = candidate;
+                  }
+                }
+              } catch {
+                // Fall back to uncompressed base64 chunking.
+              }
+
+              if (gzipBase64) {
                 started = true;
                 const result = await runCommand(
                   sandbox,
-                  withDiskWriteLock(
+                  withParentCheckout(parent, gzipWriteCommand(gzipBase64)),
+                );
+                if (result.exitCode !== 0) {
+                  throw new Error(result.stderr);
+                }
+                return;
+              }
+
+              const chunkSize = maxWriteChunkSize(parent, tempPath, diskPath);
+
+              if (encoded.length <= chunkSize) {
+                started = true;
+                const result = await runCommand(
+                  sandbox,
+                  withParentCheckout(
+                    parent,
                     buildWriteChunkCommand(
                       parent,
                       tempPath,
                       diskPath,
-                      encoded.slice(offset, offset + chunkSize),
-                      isFirst,
-                      isFinal,
+                      encoded,
+                      true,
+                      true,
                     ),
                   ),
                 );
+                if (result.exitCode !== 0) {
+                  throw new Error(result.stderr);
+                }
+                return;
+              }
+
+              const chunks: string[] = [];
+              for (let offset = 0; offset < encoded.length; offset += chunkSize) {
+                const isFirst = offset === 0;
+                const isFinal = offset + chunkSize >= encoded.length;
+                const chunk = encoded.slice(offset, offset + chunkSize);
+
+                if (isFirst) {
+                  chunks.push(
+                    `${checkoutCommand(parent)} && ${buildWriteChunkCommand(
+                      parent,
+                      tempPath,
+                      diskPath,
+                      chunk,
+                      true,
+                      false,
+                    )}`,
+                  );
+                } else if (isFinal) {
+                  chunks.push(
+                    `${buildWriteChunkCommand(
+                      parent,
+                      tempPath,
+                      diskPath,
+                      chunk,
+                      false,
+                      true,
+                    )} && ${checkinCommand(parent)}`,
+                  );
+                } else {
+                  chunks.push(
+                    buildWriteChunkCommand(
+                      parent,
+                      tempPath,
+                      diskPath,
+                      chunk,
+                      false,
+                      false,
+                    ),
+                  );
+                }
+              }
+
+              started = true;
+              for (const command of chunks) {
+                const result = await runCommand(sandbox, command);
                 if (result.exitCode !== 0) {
                   throw new Error(result.stderr);
                 }
@@ -560,7 +661,10 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 try {
                   await runCommand(
                     sandbox,
-                    withDiskWriteLock(`rm -f ${shellEscape(tempPath)}`),
+                    withParentCheckout(
+                      parent,
+                      `rm -f ${shellEscape(tempPath)}`,
+                    ),
                   );
                 } catch {
                   // Preserve the original write error if cleanup fails.
@@ -578,9 +682,13 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         mkdir: async (sandbox, path, runCommand) => {
           return withDiskLock(sandbox, async () => {
             const diskPath = mapFilesystemPath(path);
+            const parent = posix.dirname(diskPath);
             const result = await runCommand(
               sandbox,
-              withDiskWriteLock(`mkdir -p ${shellEscape(diskPath)}`),
+              withParentCheckout(
+                parent,
+                `mkdir -p ${shellEscape(diskPath)}`,
+              ),
             );
             if (result.exitCode !== 0) {
               throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
@@ -629,9 +737,13 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
             if (diskPath === ARCHIL_MOUNT_ROOT) {
               throw new Error('Refusing to remove the Archil disk mount root.');
             }
+            const parent = posix.dirname(diskPath);
             const result = await runCommand(
               sandbox,
-              withDiskWriteLock(`rm -rf ${shellEscape(diskPath)}`),
+              withParentCheckout(
+                parent,
+                `rm -rf ${shellEscape(diskPath)}`,
+              ),
             );
             if (result.exitCode !== 0) {
               throw new Error(`Failed to remove ${path}: ${result.stderr}`);

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -568,50 +568,25 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                 return;
               }
 
-              const chunks: string[] = [];
+              started = true;
               for (let offset = 0; offset < encoded.length; offset += chunkSize) {
                 const isFirst = offset === 0;
                 const isFinal = offset + chunkSize >= encoded.length;
                 const chunk = encoded.slice(offset, offset + chunkSize);
-
+                let command = buildWriteChunkCommand(
+                  parent,
+                  tempPath,
+                  diskPath,
+                  chunk,
+                  isFirst,
+                  isFinal,
+                );
                 if (isFirst) {
-                  chunks.push(
-                    `${checkoutCommand(ARCHIL_MOUNT_ROOT)} && ${buildWriteChunkCommand(
-                      parent,
-                      tempPath,
-                      diskPath,
-                      chunk,
-                      true,
-                      false,
-                    )}`,
-                  );
-                } else if (isFinal) {
-                  chunks.push(
-                    `${buildWriteChunkCommand(
-                      parent,
-                      tempPath,
-                      diskPath,
-                      chunk,
-                      false,
-                      true,
-                    )} && ${checkinCommand(ARCHIL_MOUNT_ROOT)}`,
-                  );
-                } else {
-                  chunks.push(
-                    buildWriteChunkCommand(
-                      parent,
-                      tempPath,
-                      diskPath,
-                      chunk,
-                      false,
-                      false,
-                    ),
-                  );
+                  command = `${checkoutCommand(ARCHIL_MOUNT_ROOT)} && ${command}`;
                 }
-              }
-
-              started = true;
-              for (const command of chunks) {
+                if (isFinal) {
+                  command = `${command} && ${checkinCommand(ARCHIL_MOUNT_ROOT)}`;
+                }
                 const result = await runCommand(sandbox, command);
                 if (result.exitCode !== 0) {
                   throw new Error(result.stderr);


### PR DESCRIPTION
## Summary
Archil disks are exec-only: every `runCommand` and `filesystem` call becomes a `POST /api/disks/{id}/exec`. The filesystem benchmark's `populate` stage for archil took ~5.4 s for 10 × 100 KiB files because writes were split into many `exec` commands and each command paid the full `archil checkout`/`archil checkin` delegation cost.

## Changes

`packages/archil/src/index.ts`:
- Gzip the file payload before base64-encoding it. For repetitive/compressible content (e.g. the benchmark's `x` repeats) a 100 KiB file fits in a single `exec` command: `printf '<gzipB64>' | base64 -d | gzip -d > <temp> && mv <temp> <dest>`.
- Fall back to uncompressed base64 chunking when gzip does not shrink the payload enough to fit.
- Checkout and checkin the disk mount root (`/mnt/archil`) once per `writeFile` instead of on every chunk, so nested paths whose parents do not yet exist still work.
- Apply the same root checkout to `mkdir` and `remove`.
- Keep the `AsyncLocalStorage`-based per-disk lock and the temp-file staging so concurrent `Promise.all` writes serialize and failed writes do not corrupt existing files.

```ts
withDiskLock(sandbox, async () => {
  if (gzipBase64Fits) {
    await runCommand(sandbox, checkoutRoot + gzipWrite + checkinRoot);
  } else {
    await runCommand(sandbox, checkoutRoot + firstChunk);
    for (const chunk of middleChunks) await runCommand(sandbox, chunk);
    await runCommand(sandbox, finalChunk + mv(dest) + checkinRoot);
  }
});
```

`packages/archil/src/__tests__/index.test.ts`:
- Test that compressible 100 KiB writes use a single `gzip` command under the 102,400-byte limit.
- Test that incompressible data still falls back to multiple base64 chunks within the limit.
- Test that a failed chunk still cleans up the staged file.
- Test that concurrent writes to the same file remain serialized.
- Test writing and removing nested paths whose parent directories do not exist.

## Verification
- `pnpm --filter @computesdk/archil run typecheck` ✅
- `pnpm --filter @computesdk/archil run lint` ✅
- `pnpm --filter @computesdk/archil run test` ✅
- `pnpm build` ✅

## Related
- `computesdk/benchmarks-sandbox-filesystem#10` applies the same optimization as a pnpm patch until this SDK version is released.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->