### PR TITLE
fix(arker): update to @arker-ai/sdk ^1.2.4 and adapt to the 1.x interface

### DIFF
--- a/.changeset/arker-sdk-1x-compat.md
+++ b/.changeset/arker-sdk-1x-compat.md
@@ -1,0 +1,13 @@
+---
+"@computesdk/arker": patch
+---
+
+Update to `@arker-ai/sdk` ^1.2.3 and adapt to its 1.x interface.
+
+The 1.x SDK changed three things this provider relied on:
+
+- **`provider` and `region` must now be supplied together.** The provider previously passed only `region`, defaulting to the combined string `aws-us-east-1`, which throws under 1.x. Provider and region are now resolved separately (config → `ARKER_PROVIDER` / `ARKER_REGION` → `aws` / `us-east-1`), and a combined `"<provider>-<region>"` region is split automatically so existing callers keep working unchanged.
+- **`fork(name, options)` was removed** in favour of a single options object keyed by the wire schema, so forks now pass `source_vm_name` / `source_vm_id`.
+- **`run()` selects its result type from `time_to_background`.** The provider was passing a `background: false` flag the SDK does not define, which missed the typed overloads and returned the `CompletedRunResult | BackgroundRunResult` union. Leaving `time_to_background` unset selects the synchronous overload, where the SDK polls the run to completion itself and resolves `CompletedRunResult`.
+
+Adds an optional `provider` config field (env: `ARKER_PROVIDER`).

--- a/.changeset/arker-sdk-1x-compat.md
+++ b/.changeset/arker-sdk-1x-compat.md
@@ -2,12 +2,12 @@
 "@computesdk/arker": patch
 ---
 
-Update to `@arker-ai/sdk` ^1.2.3 and adapt to its 1.x interface.
+Update to `@arker-ai/sdk` ^1.2.4 and adapt to its 1.x interface.
 
 The 1.x SDK changed three things this provider relied on:
 
 - **`provider` and `region` must now be supplied together.** The provider previously passed only `region`, defaulting to the combined string `aws-us-east-1`, which throws under 1.x. Provider and region are now resolved separately (config → `ARKER_PROVIDER` / `ARKER_REGION` → `aws` / `us-east-1`), and a combined `"<provider>-<region>"` region is split automatically so existing callers keep working unchanged.
-- **`fork(name, options)` was removed** in favour of a single options object keyed by the wire schema, so forks now pass `source_vm_name` / `source_vm_id`.
+- **`fork(name, options)` was removed** in favour of a single options object keyed by the wire schema, so forks now pass `source_vm_name` / `source_vm_id`. These fields are only accepted from 1.2.4, which is why the floor is ^1.2.4 and not ^1.2.3.
 - **`run()` selects its result type from `time_to_background`.** The provider was passing a `background: false` flag the SDK does not define, which missed the typed overloads and returned the `CompletedRunResult | BackgroundRunResult` union. Leaving `time_to_background` unset selects the synchronous overload, where the SDK polls the run to completion itself and resolves `CompletedRunResult`.
 
 Adds an optional `provider` config field (env: `ARKER_PROVIDER`).

--- a/packages/arker/package.json
+++ b/packages/arker/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@arker-ai/sdk": "^0.9.0",
+    "@arker-ai/sdk": "^1.2.3",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/arker/package.json
+++ b/packages/arker/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@arker-ai/sdk": "^1.2.3",
+    "@arker-ai/sdk": "^1.2.4",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/arker/src/index.ts
+++ b/packages/arker/src/index.ts
@@ -11,16 +11,22 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 import type { RunOptions } from '@arker-ai/sdk';
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
+/** Provider used when none is configured. */
+const DEFAULT_PROVIDER = 'aws';
 /** Region used when none is configured. */
-const DEFAULT_REGION = 'aws-us-east-1';
+const DEFAULT_REGION = 'us-east-1';
 /** Golden forked when none is requested — small Ubuntu VM with node + python. */
 const DEFAULT_SOURCE = 'ubuntu-small';
 
 export interface ArkerConfig {
   /** Arker API key (starts with `ark_`). Falls back to the ARKER_API_KEY environment variable. */
   apiKey?: string;
-  /** Region, e.g. `aws-us-east-1`. Falls back to ARKER_REGION, then the us-east-1 default. */
+  /** Region, e.g. `us-east-1`. Falls back to ARKER_REGION, then the us-east-1 default.
+   *  A combined `"<provider>-<region>"` value (e.g. `aws-us-east-1`) is still accepted. */
   region?: string;
+  /** Compute provider, e.g. `aws`. Falls back to ARKER_PROVIDER, then `aws`.
+   *  The SDK requires provider and region together. */
+  provider?: string;
   /** Golden source VM to fork on create(). Falls back to ARKER_SOURCE, then `ubuntu-small`. */
   source?: string;
   /** Compute platforms to fork onto, e.g. `['graviton4']`. Falls back to ARKER_PLATFORMS (comma-separated). */
@@ -32,15 +38,34 @@ const env = (key: string): string | undefined => {
   return value && value.trim() ? value.trim() : undefined;
 };
 
+/** Known compute providers, used to split a combined `<provider>-<region>` value. */
+const PROVIDER_PREFIXES = ['aws', 'gcp', 'azure', 'arker'] as const;
+
 /**
- * Build an Arker SDK client. Region precedence: config, then ARKER_REGION,
- * then the us-east-1 default — the SDK itself requires a region, so an
- * unconfigured caller gets a working default instead of a thrown error.
+ * Split a region that still carries a provider prefix (`aws-us-east-1`) into
+ * its parts. Returns `[undefined, region]` when there is no prefix.
+ */
+function splitPlacement(region: string): [string | undefined, string] {
+  for (const p of PROVIDER_PREFIXES) {
+    if (region.startsWith(`${p}-`)) return [p, region.slice(p.length + 1)];
+  }
+  return [undefined, region];
+}
+
+/**
+ * Build an Arker SDK client. The SDK requires `provider` and `region`
+ * together, so both always resolve to a value: config, then env
+ * (ARKER_PROVIDER / ARKER_REGION), then the aws/us-east-1 default. A
+ * combined `aws-us-east-1` region is split so older callers keep working.
  */
 function makeClient(config: ArkerConfig): Arker {
+  const rawRegion = config.region ?? env('ARKER_REGION') ?? DEFAULT_REGION;
+  const [prefixed, region] = splitPlacement(rawRegion);
+  const provider = config.provider ?? env('ARKER_PROVIDER') ?? prefixed ?? DEFAULT_PROVIDER;
   return new Arker({
     apiKey: config.apiKey ?? env('ARKER_API_KEY'),
-    region: config.region ?? env('ARKER_REGION') ?? DEFAULT_REGION,
+    provider,
+    region,
   });
 }
 
@@ -79,9 +104,14 @@ export const arker = defineProvider<VM, ArkerConfig>({
           config.platforms ??
           env('ARKER_PLATFORMS')?.split(',').map((p) => p.trim()).filter(Boolean);
 
+        // SDK 1.x takes a single options object keyed by the wire schema
+        // (`source_vm_id` / `source_vm_name`); the old `fork(name, opts)`
+        // overload is gone.
         const vm = options?.snapshotId
-          ? await client.fork({ sourceVmId: options.snapshotId, name })
-          : await client.fork(options?.templateId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE, {
+          ? await client.fork({ source_vm_id: options.snapshotId, name })
+          : await client.fork({
+              source_vm_name:
+                options?.templateId || config.source || env('ARKER_SOURCE') || DEFAULT_SOURCE,
               name,
               ...(platforms?.length ? { platforms } : {}),
             });
@@ -140,9 +170,10 @@ export const arker = defineProvider<VM, ArkerConfig>({
         // a bare `nohup cd … && …` would run only `cd` under nohup.
         if (options?.background) fullCommand = `nohup sh -c ${singleQuote(fullCommand)} > /dev/null 2>&1 &`;
 
-        // `background: false` picks the SDK's synchronous overload, which polls a
-        // backgrounded run to completion itself and always yields CompletedRunResult.
-        const runOptions: RunOptions & { background?: false } = { background: false };
+        // Leaving `time_to_background` unset selects the SDK's synchronous
+        // overload: the SDK polls the run to completion itself and resolves
+        // `CompletedRunResult`, so there is nothing to poll or narrow here.
+        const runOptions: Omit<RunOptions, 'time_to_background'> = {};
         // ComputeSDK's timeout is milliseconds; Arker's is seconds (rounded up so a
         // sub-second timeout stays non-zero — 0 means "no limit" to Arker).
         if (options?.timeout) runOptions.timeout = Math.max(1, Math.ceil(options.timeout / 1000));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
   packages/arker:
     dependencies:
       '@arker-ai/sdk':
-        specifier: ^0.9.0
-        version: 0.9.0(@computesdk/daytona@1.7.33(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
+        specifier: ^1.2.3
+        version: 1.2.4(@computesdk/daytona@1.7.33(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2567,8 +2567,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@arker-ai/sdk@0.9.0':
-    resolution: {integrity: sha512-fwtQmS4MQH7fvctM1jGtfGauVYsz8vS380oJmWKh+iEjWJUKyc9O18tujqHR/aljfusNCR1ILY3ZBKbJz5nsKg==}
+  '@arker-ai/sdk@1.2.4':
+    resolution: {integrity: sha512-mH6UKRfzQSIzDm+pdroe7+uArqJ8RQssUknx5i2q9IXRZpdua5pZpD6HLdr9sCRQCbF96c03vpiO1ijti1qgRQ==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -9461,8 +9461,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@arker-ai/sdk@0.9.0(@computesdk/daytona@1.7.33(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
+  '@arker-ai/sdk@1.2.4(@computesdk/daytona@1.7.33(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
+      dockerfile-ast: 0.7.1
       tar: 7.5.22
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,7 +286,7 @@ importers:
   packages/arker:
     dependencies:
       '@arker-ai/sdk':
-        specifier: ^1.2.3
+        specifier: ^1.2.4
         version: 1.2.4(@computesdk/daytona@1.7.33(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*


### PR DESCRIPTION
Updates `@computesdk/arker` to `@arker-ai/sdk` ^1.2.4 and adapts to the 1.x interface.

The `^0.9.0` range cannot resolve to 1.x, so the provider had been pinned to the 0.9 line. Moving to 1.x required fixing three call sites the major changed.

### What changed

**`provider` and `region` must now be supplied together.** The provider passed only `region`, defaulting to the combined string `aws-us-east-1`, which throws in 1.x before any network call. They are now resolved separately — config → `ARKER_PROVIDER` / `ARKER_REGION` → `aws` / `us-east-1` — and a combined `"<provider>-<region>"` region is split automatically, so existing callers (including bare `arker({})`) keep working unchanged.

**`fork(name, options)` was removed** in favour of a single options object keyed by the wire schema. Forks now pass `source_vm_name` / `source_vm_id`.

**`run()` selects its result type from `time_to_background`.** The provider passed a `background: false` flag the SDK does not define, which missed both typed overloads and fell through to the `CompletedRunResult | BackgroundRunResult` union. Leaving `time_to_background` unset selects the synchronous overload, where the SDK polls the run to completion itself and resolves `CompletedRunResult` — so the provider no longer needs to poll or narrow.

Adds an optional `provider` config field (env: `ARKER_PROVIDER`).

### Why the floor is ^1.2.4, not ^1.2.3

Caught in review by Devin. 1.2.3 rejects the snake_case source fields client-side, so every template and snapshot create would fail for anyone resolving exactly 1.2.3. Reproduced against 1.2.3 on live `us-east-1`:

```
fork({ source_vm_name: 'ubuntu-small' })
  -> bad_request: fork requires a source
     (a name, a VM, sourceVmName, sourceVmId, image, or dockerfile)

fork({ sourceVmName: 'ubuntu-small', sourceOrgId: 'ArkerHQ' })
  -> OK
```

Support for `source_vm_name` / `source_vm_id` landed in 1.2.4.

### Verification

Against live `aws` / `us-east-1`:

| check | result |
|---|---|
| provider test suite (integration enabled) | 14/14 |
| `node -v` | `v18.19.1` |
| sync run | exit 0, stdout correct |
| background run | returns immediately, process confirmed alive via `pgrep` |
| snapshot fork (`source_vm_id`) | child inherited parent's file |
| `platforms: ['graviton4']` | CPU part `0xd4f` (Neoverse-V2) |
| legacy combined region `aws-us-east-1` | works |
| zero-config `arker({})` | works |
| computesdk **dax** benchmark on `ubuntu-full-8` | ✅ 16219 MiB, clone 2.376s / install 13.439s / typecheck 49.844s, 30/30 turbo tasks |

Without the adapter changes, the SDK bump alone fails: the same suite times out 3/3 at sandbox creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
