### PR TITLE
Add ASCII Box provider

### DIFF
--- a/.changeset/add-asciibox-provider.md
+++ b/.changeset/add-asciibox-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/asciibox": patch
+---
+
+Add ASCII Box provider

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 |----------|----------------------|-----------|
 | **Archil** | `ARCHIL_API_KEY` | Disk-attached command execution |
 | **Arker** | `ARKER_API_KEY` | Sandboxed VMs with persistent filesystems, forked from golden images |
+| **ASCII Box** | `ASCIIBOX_API_KEY` or `BOX_API_KEY` | Cloud sandboxes with command execution, filesystem access, and port forwarding |
 | **Beam** | `BEAM_TOKEN`, `BEAM_WORKSPACE_ID` | Serverless cloud sandboxes |
 | **Blaxel** | `BL_API_KEY`, `BL_WORKSPACE` | Agent sandboxes with custom images |
 | **Cloud Run** | `CLOUD_RUN_SANDBOX_URL`, `CLOUD_RUN_SANDBOX_SECRET` | Google Cloud Run sandboxes |
@@ -290,6 +291,7 @@ Install the provider packages you need and pass their instances into `compute.se
 
 ```bash
 npm install @computesdk/archil           # Archil provider
+npm install @computesdk/asciibox         # ASCII Box provider
 npm install @computesdk/beam             # Beam provider
 npm install @computesdk/blaxel           # Blaxel provider
 npm install @computesdk/cloud-run        # Google Cloud Run provider

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -12,6 +12,7 @@
   * [AWS Bedrock AgentCore](providers/agentcore.md)
   * [Agentuity](providers/agentuity.md)
   * [Archil](providers/archil.md)
+  * [ASCII Box](providers/asciibox.md)
   * [Beam](providers/beam.md)
   * [Blaxel](providers/blaxel.md)
   * [Cloud Run](providers/cloud-run.md)

--- a/docs/providers/asciibox.md
+++ b/docs/providers/asciibox.md
@@ -1,0 +1,91 @@
+---
+description: >-
+  Set up the ASCII Box provider for ComputeSDK, configure your API key, and
+  create cloud sandboxes to run commands and access the filesystem.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# ASCII Box
+
+ASCII Box provider for ComputeSDK - cloud sandboxes with a full Linux environment, shell command execution, filesystem access, and port forwarding.
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/asciibox
+```
+
+Add your ASCII Box credentials to a `.env` file:
+
+```bash
+ASCIIBOX_API_KEY=your_ascii_box_api_key
+```
+
+ASCII Box API keys are also accepted via the `BOX_API_KEY` environment variable or the `apiKey` constructor option.
+
+## Usage
+
+```typescript
+import { asciiBox } from '@computesdk/asciibox';
+
+const compute = asciiBox({
+  apiKey: process.env.ASCIIBOX_API_KEY,
+});
+
+// Create sandbox
+const sandbox = await compute.sandbox.create();
+
+// Run a command
+const result = await sandbox.runCommand('echo "Hello from ASCII Box!"');
+console.log(result.stdout); // "Hello from ASCII Box!"
+
+// Filesystem access
+await sandbox.filesystem.writeFile('/tmp/greeting.txt', 'hello');
+const contents = await sandbox.filesystem.readFile('/tmp/greeting.txt');
+
+// Clean up
+await sandbox.destroy();
+```
+
+### Configuration Options
+
+```typescript
+interface AsciiBoxConfig {
+  /** ASCII Box API key. Falls back to ASCIIBOX_API_KEY or BOX_API_KEY env var */
+  apiKey?: string;
+  /** ASCII Box API base URL. Defaults to https://ascii.dev/api/box/v1 */
+  basePath?: string;
+  /** Machine size: small, default, or large */
+  type?: 'small' | 'default' | 'large';
+  /** ASCII Box environment to attach */
+  environment?: string;
+}
+```
+
+## Features
+
+- Create, list, get, and destroy ASCII Box sandboxes
+- Run shell commands with `cwd`, environment variables, timeouts, and background support
+- Read and write files and directories in the sandbox
+- Expose sandbox ports via `getUrl`
+
+## Limitations
+
+- Snapshot and template (environment) lifecycle management must be done through the ASCII Box dashboard or CLI. ComputeSDK exposes these methods for API completeness but they throw descriptive errors when called.

--- a/docs/providers/asciibox.md
+++ b/docs/providers/asciibox.md
@@ -88,4 +88,4 @@ interface AsciiBoxConfig {
 
 ## Limitations
 
-- Snapshot and template (environment) lifecycle management must be done through the ASCII Box dashboard or CLI. ComputeSDK exposes these methods for API completeness but they throw descriptive errors when called.
+- Snapshot and template (environment) lifecycle management must be done through the ASCII Box dashboard or CLI. The ComputeSDK `snapshot` and `template` managers are not registered for this provider, so those operations are unavailable through `compute.snapshot` and `compute.template`.

--- a/packages/asciibox/README.md
+++ b/packages/asciibox/README.md
@@ -1,0 +1,128 @@
+# @computesdk/asciibox
+
+ASCII Box provider for ComputeSDK - Execute code in cloud ASCII Box sandboxes with shell command execution, filesystem access, and port forwarding.
+
+## Installation
+
+```bash
+npm install @computesdk/asciibox
+```
+
+## Setup
+
+1. Get your ASCII Box API key from [ASCII Box settings](https://ascii.dev/box/settings/api-keys)
+2. Set the environment variable:
+
+```bash
+export ASCIIBOX_API_KEY=your_ascii_box_api_key
+```
+
+The provider also accepts `BOX_API_KEY` and `BOX_BASE_URL` for compatibility with the official ASCII Box SDK.
+
+## Quick Start
+
+Configure `compute` with the ASCII Box provider and create a sandbox:
+
+```typescript
+import { compute } from 'computesdk';
+import { asciiBox } from '@computesdk/asciibox';
+
+compute.setConfig({
+  provider: asciiBox({ apiKey: process.env.ASCIIBOX_API_KEY }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('echo "Hello from ASCII Box!"');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+Alternatively, call the provider factory directly when you only need one provider:
+
+```typescript
+import { asciiBox } from '@computesdk/asciibox';
+
+const sdk = asciiBox({ apiKey: process.env.ASCIIBOX_API_KEY });
+const sandbox = await sdk.sandbox.create();
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+export ASCIIBOX_API_KEY=your_ascii_box_api_key
+export ASCIIBOX_BASE_URL=https://ascii.dev/api/box/v1  # optional
+```
+
+### Configuration Options
+
+```typescript
+interface AsciiBoxConfig {
+  /** ASCII Box API key. Falls back to ASCIIBOX_API_KEY or BOX_API_KEY env var */
+  apiKey?: string;
+  /** ASCII Box API base URL. Defaults to https://ascii.dev/api/box/v1 */
+  basePath?: string;
+  /** Machine size: small (2 vCPU / 4 GB), default (4 vCPU / 8 GB), or large (8 vCPU / 16 GB) */
+  type?: 'small' | 'default' | 'large';
+  /** ASCII Box environment to attach */
+  environment?: string;
+}
+```
+
+## Features
+
+- **Command Execution** - Run shell commands with `cwd`, environment variables, timeout, and background support
+- **Filesystem Operations** - Read, write, list, create, check, and remove files and directories
+- **Port Forwarding** - Expose sandbox ports via `getUrl`
+- **Sandbox Lifecycle** - Create, list, get by ID, and destroy sandboxes
+
+## API Reference
+
+### Command Execution
+
+```typescript
+const result = await sandbox.runCommand('ls -la');
+console.log(result.stdout);
+
+// With options
+const result2 = await sandbox.runCommand('echo $GREETING', {
+  env: { GREETING: 'hello' },
+  cwd: '/tmp',
+  timeout: 30000,
+});
+```
+
+### Filesystem Operations
+
+```typescript
+// Write file
+await sandbox.filesystem.writeFile('/tmp/hello.txt', 'Hello World');
+
+// Read file
+const content = await sandbox.filesystem.readFile('/tmp/hello.txt');
+
+// Create directory
+await sandbox.filesystem.mkdir('/tmp/data');
+
+// List directory
+const entries = await sandbox.filesystem.readdir('/tmp');
+
+// Check existence
+const exists = await sandbox.filesystem.exists('/tmp/hello.txt');
+
+// Remove file or directory
+await sandbox.filesystem.remove('/tmp/data');
+```
+
+### Port Forwarding
+
+```typescript
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+## Limitations
+
+- Snapshot and template (environment) lifecycle management are not supported through this provider. Use the ASCII Box dashboard or CLI to manage snapshots and environments.

--- a/packages/asciibox/package.json
+++ b/packages/asciibox/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@computesdk/asciibox",
+  "version": "1.0.0",
+  "description": "ASCII Box provider for ComputeSDK - cloud sandboxes for code execution, filesystem access, and snapshots",
+  "author": "ComputeSDK",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@asciidev/box-sdk": "^0.0.34",
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "keywords": [
+    "computesdk",
+    "asciibox",
+    "ascii",
+    "box",
+    "sandbox",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider",
+    "containers"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/asciibox"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/asciibox/src/__tests__/index.test.ts
+++ b/packages/asciibox/src/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { asciiBox } from '../index';
+
+runProviderTestSuite({
+  name: 'asciibox',
+  provider: asciiBox({}),
+  supportsFilesystem: true,
+  supportsGetUrl: true,
+  skipIntegration: !process.env.ASCIIBOX_API_KEY,
+  ports: [3000, 8080],
+});

--- a/packages/asciibox/src/__tests__/index.test.ts
+++ b/packages/asciibox/src/__tests__/index.test.ts
@@ -14,7 +14,12 @@ vi.mock('@asciidev/box-sdk', async (importOriginal) => {
   });
   const boxesMock = vi.fn().mockResolvedValue({ boxes: [], pageInfo: { hasMore: false } });
   const hostPortMock = vi.fn().mockResolvedValue({ url: 'https://box-123-8080.ascii.dev' });
-  const waitUntilReadyMock = vi.fn().mockResolvedValue(undefined);
+  const waitUntilReadyMock = vi.fn().mockResolvedValue({
+    id: 'box-123',
+    state: 'Ready',
+    name: 'test-box',
+    desktopAvailable: false,
+  });
   const stopAndRemoveMock = vi.fn().mockResolvedValue(undefined);
   const readTextMock = vi.fn().mockResolvedValue('hello');
   const writeTextMock = vi.fn().mockResolvedValue(undefined);

--- a/packages/asciibox/src/__tests__/index.test.ts
+++ b/packages/asciibox/src/__tests__/index.test.ts
@@ -1,5 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 import { asciiBox } from '../index';
+import { BoxApi, Configuration } from '@asciidev/box-sdk';
+
+vi.mock('@asciidev/box-sdk', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@asciidev/box-sdk')>();
+
+  const createMock = vi.fn().mockResolvedValue({
+    box: { id: 'box-123', state: 'Ready', name: 'test-box', desktopAvailable: false },
+  });
+  const getMock = vi.fn().mockResolvedValue({
+    box: { id: 'box-123', state: 'Ready', name: 'test-box', desktopAvailable: false },
+  });
+  const boxesMock = vi.fn().mockResolvedValue({ boxes: [], pageInfo: { hasMore: false } });
+  const hostPortMock = vi.fn().mockResolvedValue({ url: 'https://box-123-8080.ascii.dev' });
+  const waitUntilReadyMock = vi.fn().mockResolvedValue(undefined);
+  const stopAndRemoveMock = vi.fn().mockResolvedValue(undefined);
+  const readTextMock = vi.fn().mockResolvedValue('hello');
+  const writeTextMock = vi.fn().mockResolvedValue(undefined);
+  const execCommandMock = vi.fn().mockImplementation(async (_api, _id, command: string) => {
+    if (command.includes('ls -la')) {
+      return {
+        stdout:
+          'total 0\n' +
+          '-rw-r--r-- 1 user group 12 Sep  1 10:00 file -> real.txt\n' +
+          'drwxr-xr-x 1 user group  0 Sep  2  2024 mydir\n' +
+          'lrwxrwxrwx 1 user group  4 Sep  1 10:00 link -> target\n',
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  });
+
+  return {
+    ...original,
+    BoxApi: vi.fn().mockImplementation(() => ({
+      create: createMock,
+      get: getMock,
+      boxes: boxesMock,
+      hostPort: hostPortMock,
+    })),
+    Configuration: vi.fn(),
+    waitUntilReady: waitUntilReadyMock,
+    execCommand: execCommandMock,
+    readText: readTextMock,
+    writeText: writeTextMock,
+    stopAndRemove: stopAndRemoveMock,
+  };
+});
 
 runProviderTestSuite({
   name: 'asciibox',
@@ -8,4 +57,68 @@ runProviderTestSuite({
   supportsGetUrl: true,
   skipIntegration: !process.env.ASCIIBOX_API_KEY,
   ports: [3000, 8080],
+});
+
+describe('asciiBox SDK mapping', () => {
+  it('maps create options to the ASCII Box create request', async () => {
+    const provider = asciiBox({ apiKey: 'test-key', type: 'large' });
+    const sandbox = await provider.sandbox.create({
+      templateId: 'my-env',
+      snapshotId: 'my-snap',
+      envs: { FOO: 'bar' },
+      timeout: 120000,
+    });
+
+    const instance = sandbox.getInstance() as any;
+    expect(instance.api.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createBoxRequest: expect.objectContaining({
+          type: 'large',
+          ttlSeconds: 120,
+          environment: 'my-env',
+          env: { FOO: 'bar' },
+          from: 'my-snap',
+        }),
+      })
+    );
+  });
+
+  it('paginates list calls using pageInfo cursor', async () => {
+    const shared = new (BoxApi as any)(new (Configuration as any)()) as any;
+    shared.boxes
+      .mockResolvedValueOnce({
+        boxes: [
+          { id: 'box-1', state: 'Ready', name: 'one', desktopAvailable: false },
+        ],
+        pageInfo: { hasMore: true, nextCursor: 'cursor-1' },
+      })
+      .mockResolvedValueOnce({
+        boxes: [
+          { id: 'box-2', state: 'Ready', name: 'two', desktopAvailable: false },
+        ],
+        pageInfo: { hasMore: false },
+      });
+
+    const provider = asciiBox({ apiKey: 'test-key' });
+    const result = await provider.sandbox.list();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].sandboxId).toBe('box-1');
+    expect(result[1].sandboxId).toBe('box-2');
+    expect(shared.boxes).toHaveBeenCalledTimes(2);
+  });
+
+  it('parses ls output and handles symlinks', async () => {
+    const provider = asciiBox({ apiKey: 'test-key' });
+    const sandbox = await provider.sandbox.create({});
+
+    const entries = await sandbox.filesystem.readdir('/tmp');
+
+    const names = entries.map((e) => e.name).sort();
+    expect(names).toEqual(['file -> real.txt', 'link', 'mydir']);
+
+    const link = entries.find((e) => e.name === 'link');
+    expect(link).toBeDefined();
+    expect(link?.type).toBe('file');
+  });
 });

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -413,8 +413,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
 
           if (options.protocol) {
             const urlObj = new URL(url);
-            urlObj.protocol = `${options.protocol}:`;
-            return urlObj.toString();
+            return `${options.protocol}:${urlObj.href.slice(urlObj.protocol.length)}`;
           }
 
           return url;

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -118,6 +118,39 @@ function validateEnvKey(key: string): string {
   return key;
 }
 
+const MONTHS: Record<string, number> = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+};
+
+function parseLsDate(parts: string[], fallback: Date): Date {
+  if (parts.length < 8) return fallback;
+  const month = MONTHS[parts[5]];
+  const day = parseInt(parts[6], 10);
+  const timeOrYear = parts[7];
+  if (month === undefined || Number.isNaN(day)) return fallback;
+
+  if (timeOrYear.includes(':')) {
+    const [hours, minutes] = timeOrYear.split(':').map(Number);
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return fallback;
+    return new Date(new Date().getFullYear(), month, day, hours, minutes);
+  }
+
+  const year = parseInt(timeOrYear, 10);
+  if (Number.isNaN(year)) return fallback;
+  return new Date(year, month, day);
+}
+
 export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
   name: 'asciibox',
   methods: {
@@ -426,14 +459,15 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             if (parts.length < 9) continue;
             const rawName = parts.slice(8).join(' ');
             if (rawName === '.' || rawName === '..') continue;
-            const name = rawName.split(' -> ')[0];
+            const isSymlink = parts[0].startsWith('l');
+            const name = isSymlink ? rawName.split(' -> ')[0] : rawName;
             const size = parseInt(parts[4], 10) || 0;
             const isDirectory = parts[0].startsWith('d');
             entries.push({
               name,
               type: isDirectory ? ('directory' as const) : ('file' as const),
               size,
-              modified: new Date(),
+              modified: parseLsDate(parts, new Date()),
             });
           }
           return entries;

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@asciidev/box-sdk';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
-import type { Box, CommandResponse } from '@asciidev/box-sdk';
+import type { Box, CommandResponse, CreateBoxRequest } from '@asciidev/box-sdk';
 import type {
   CommandResult,
   SandboxInfo,
@@ -184,23 +184,32 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           directory: _directory,
           signal: _signal,
           environment: optEnvironment,
-          ...providerOptions
-        } = options || {};
+          setupScript,
+          noEnv,
+          org,
+          teamId,
+        } = (options || {}) as CreateSandboxOptions & Record<string, unknown>;
 
         const ttlSeconds = optTimeout ? Math.ceil(optTimeout / 1000) : 1800;
         const sandboxTimeout = optTimeout ? optTimeout : 1_800_000;
         let box: Box | undefined;
 
         try {
+          const createBoxRequest: CreateBoxRequest = {
+            type: config.type,
+            ttlSeconds,
+            environment: templateId ?? optEnvironment ?? config.environment,
+            env: envs,
+            from: snapshotId,
+          };
+
+          if (setupScript !== undefined) createBoxRequest.setupScript = setupScript as string;
+          if (noEnv !== undefined) createBoxRequest.noEnv = noEnv as boolean;
+          if (org !== undefined) createBoxRequest.org = org as string;
+          if (teamId !== undefined) createBoxRequest.teamId = teamId as string;
+
           const response = await api.create({
-            createBoxRequest: {
-              type: config.type,
-              ttlSeconds,
-              environment: templateId ?? optEnvironment ?? config.environment,
-              env: envs,
-              from: snapshotId,
-              ...providerOptions,
-            } as any,
+            createBoxRequest,
           });
 
           box = response.box;
@@ -341,6 +350,14 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             durationMs: Date.now() - startTime,
           };
         } catch (error) {
+          // Distinguish sandbox-level failures (auth / missing / not ready) from
+          // command execution, so callers don't confuse API errors with a missing
+          // command exit code.
+          if (isAuthError(error) || isNotFound(error)) {
+            throw new Error(
+              `Failed to run command in ASCII Box sandbox ${sandbox.box.id}: ${formatError(error)}`
+            );
+          }
           return {
             stdout: '',
             stderr: formatError(error),
@@ -460,7 +477,10 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             sandbox.box.id,
             `mkdir -p "${escapeShellArg(path)}"`
           );
-          if (isCommandResponse(result) && result.exitCode !== 0) {
+          if (!isCommandResponse(result)) {
+            throw new Error(`Failed to create directory ${path}: unexpected response from ASCII Box`);
+          }
+          if (result.exitCode !== 0) {
             throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
           }
         },
@@ -476,7 +496,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             `ls -la "${escapeShellArg(path)}"`
           );
           if (!isCommandResponse(result)) {
-            return [];
+            throw new Error(`Failed to list directory ${path}: unexpected response from ASCII Box`);
           }
           if (result.exitCode !== 0) {
             throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
@@ -513,7 +533,10 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             sandbox.box.id,
             `test -e "${escapeShellArg(path)}"`
           );
-          return isCommandResponse(result) && result.exitCode === 0;
+          if (!isCommandResponse(result)) {
+            throw new Error(`Failed to check existence of ${path}: unexpected response from ASCII Box`);
+          }
+          return result.exitCode === 0;
         },
 
         remove: async (
@@ -526,7 +549,10 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             sandbox.box.id,
             `rm -rf "${escapeShellArg(path)}"`
           );
-          if (isCommandResponse(result) && result.exitCode !== 0) {
+          if (!isCommandResponse(result)) {
+            throw new Error(`Failed to remove ${path}: unexpected response from ASCII Box`);
+          }
+          if (result.exitCode !== 0) {
             throw new Error(`Failed to remove ${path}: ${result.stderr}`);
           }
         },

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -43,7 +43,7 @@ interface AsciiBoxSandbox {
   box: Box;
 }
 
-const DEFAULT_TIMEOUT_MS = 300000;
+const DEFAULT_PROVISION_TIMEOUT_MS = 300000;
 
 function getApiKey(config: AsciiBoxConfig): string | undefined {
   return config.apiKey ?? process.env.ASCIIBOX_API_KEY ?? process.env.BOX_API_KEY;
@@ -130,12 +130,13 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           envs,
           name: _name,
           metadata: _metadata,
-          templateId: _templateId,
+          templateId,
           snapshotId,
           sandboxId: _sandboxId,
           namespace: _namespace,
           directory: _directory,
           signal: _signal,
+          environment: optEnvironment,
           ...providerOptions
         } = options || {};
 
@@ -147,7 +148,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             createBoxRequest: {
               type: config.type,
               ttlSeconds,
-              environment: config.environment,
+              environment: templateId ?? optEnvironment ?? config.environment,
               env: envs,
               from: snapshotId,
               ...providerOptions,
@@ -162,7 +163,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
 
           try {
             await waitUntilReady(api, box.id, {
-              timeoutMs: optTimeout ?? DEFAULT_TIMEOUT_MS,
+              timeoutMs: DEFAULT_PROVISION_TIMEOUT_MS,
             });
           } catch (waitError) {
             // Best-effort cleanup so a readiness failure does not leak the box
@@ -296,15 +297,21 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
       },
 
       getInfo: async (sandbox: AsciiBoxSandbox): Promise<SandboxInfo> => {
-        let box = sandbox.box;
+        let box: Box | undefined;
         try {
           const response = await sandbox.api.get({ boxId: sandbox.box.id });
-          if (response.box) {
-            box = response.box;
+          box = response.box;
+        } catch (error) {
+          if (isNotFound(error) || isAuthError(error)) {
+            throw new Error(
+              `Failed to get info for ASCII Box sandbox ${sandbox.box.id}: ${formatError(error)}`
+            );
           }
-        } catch {
-          // Fall back to the cached box if the API is unreachable
+          // Fall back to the cached box on transient failures
+          box = sandbox.box;
         }
+
+        box ??= sandbox.box;
 
         return {
           id: box.id,
@@ -422,10 +429,9 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             const name = rawName.split(' -> ')[0];
             const size = parseInt(parts[4], 10) || 0;
             const isDirectory = parts[0].startsWith('d');
-            const isSymlink = parts[0].startsWith('l');
             entries.push({
               name,
-              type: isDirectory ? ('directory' as const) : isSymlink ? ('file' as const) : ('file' as const),
+              type: isDirectory ? ('directory' as const) : ('file' as const),
               size,
               modified: new Date(),
             });
@@ -463,46 +469,6 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
       },
 
       getInstance: (sandbox: AsciiBoxSandbox): AsciiBoxSandbox => sandbox,
-    },
-
-    snapshot: {
-      create: async (
-        _config: AsciiBoxConfig,
-        _sandboxId: string,
-        _options?: { name?: string }
-      ) => {
-        throw new Error(
-          'ASCII Box snapshots are not supported through this provider yet. Use the ASCII Box dashboard or CLI to manage snapshots.'
-        );
-      },
-      list: async (_config: AsciiBoxConfig) => {
-        throw new Error(
-          'ASCII Box snapshots are not supported through this provider yet. Use the ASCII Box dashboard or CLI to manage snapshots.'
-        );
-      },
-      delete: async (_config: AsciiBoxConfig, _snapshotId: string) => {
-        throw new Error(
-          'ASCII Box snapshots are not supported through this provider yet. Use the ASCII Box dashboard or CLI to manage snapshots.'
-        );
-      },
-    },
-
-    template: {
-      create: async (_config: AsciiBoxConfig, _options: { name: string }) => {
-        throw new Error(
-          'ASCII Box templates (environments) must be managed via the ASCII Box dashboard or CLI.'
-        );
-      },
-      list: async (_config: AsciiBoxConfig) => {
-        throw new Error(
-          'ASCII Box templates (environments) must be managed via the ASCII Box dashboard or CLI.'
-        );
-      },
-      delete: async (_config: AsciiBoxConfig, _templateId: string) => {
-        throw new Error(
-          'ASCII Box templates (environments) must be managed via the ASCII Box dashboard or CLI.'
-        );
-      },
     },
   },
 });

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -1,0 +1,464 @@
+/**
+ * ASCII Box Provider - Factory-based Implementation
+ *
+ * ComputeSDK provider for ASCII Box cloud sandboxes.
+ */
+
+import {
+  BoxApi,
+  Configuration,
+  waitUntilReady,
+  execCommand,
+  readText,
+  writeText,
+  stopAndRemove,
+} from '@asciidev/box-sdk';
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+
+import type { Box, CommandResponse } from '@asciidev/box-sdk';
+import type {
+  CommandResult,
+  SandboxInfo,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+} from 'computesdk';
+
+/**
+ * ASCII Box-specific configuration options
+ */
+export interface AsciiBoxConfig {
+  /** ASCII Box API key - if not provided, will fallback to ASCIIBOX_API_KEY or BOX_API_KEY environment variable */
+  apiKey?: string;
+  /** ASCII Box API base URL - defaults to https://ascii.dev/api/box/v1 */
+  basePath?: string;
+  /** Machine size: small (2 vCPU / 4 GB), default (4 vCPU / 8 GB), or large (8 vCPU / 16 GB) */
+  type?: 'small' | 'default' | 'large';
+  /** ASCII Box environment to attach (defaults to account default) */
+  environment?: string;
+}
+
+interface AsciiBoxSandbox {
+  api: BoxApi;
+  box: Box;
+}
+
+function getApiKey(config: AsciiBoxConfig): string | undefined {
+  return config.apiKey ?? process.env.ASCIIBOX_API_KEY ?? process.env.BOX_API_KEY;
+}
+
+function getBasePath(config: AsciiBoxConfig): string {
+  return (
+    config.basePath ??
+    process.env.ASCIIBOX_BASE_URL ??
+    process.env.BOX_BASE_URL ??
+    'https://ascii.dev/api/box/v1'
+  );
+}
+
+function createBoxApi(config: AsciiBoxConfig): BoxApi {
+  const apiKey = getApiKey(config);
+  if (!apiKey) {
+    throw new Error(
+      'Missing ASCII Box API key.\n\n' +
+        'Get your key at https://ascii.dev/box/settings/api-keys\n' +
+        'Then pass it: asciiBox({ apiKey: "xxx" })\n' +
+        'Or set ASCIIBOX_API_KEY (or BOX_API_KEY) in your environment.'
+    );
+  }
+
+  return new BoxApi(
+    new Configuration({
+      basePath: getBasePath(config),
+      accessToken: apiKey,
+    })
+  );
+}
+
+function isCommandResponse(response: unknown): response is CommandResponse {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'stdout' in response &&
+    'stderr' in response &&
+    'exitCode' in response
+  );
+}
+
+export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
+  name: 'asciibox',
+  methods: {
+    sandbox: {
+      create: async (config: AsciiBoxConfig, options?: CreateSandboxOptions) => {
+        const api = createBoxApi(config);
+
+        const {
+          timeout: optTimeout,
+          envs,
+          name: _name,
+          metadata,
+          templateId: _templateId,
+          snapshotId: _snapshotId,
+          sandboxId: optSandboxId,
+          namespace: _namespace,
+          directory: _directory,
+          ...providerOptions
+        } = options || {};
+
+        const ttlSeconds = optTimeout ? Math.ceil(optTimeout / 1000) : 1800;
+
+        try {
+          const response = await api.create({
+            createBoxRequest: {
+              type: config.type,
+              ttlSeconds,
+              environment: config.environment,
+              env: envs,
+              ...providerOptions,
+            },
+          });
+
+          const box = response.box;
+
+          if (!box?.id) {
+            throw new Error('ASCII Box create() returned box without an ID');
+          }
+
+          await waitUntilReady(api, box.id, {
+            timeoutMs: optTimeout ?? 300000,
+          });
+
+          return {
+            sandbox: { api, box },
+            sandboxId: box.id,
+          };
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          if (
+            detail.includes('unauthorized') ||
+            detail.includes('Unauthorized') ||
+            detail.includes('API key')
+          ) {
+            throw new Error(
+              `ASCII Box authentication failed. Please check your ASCIIBOX_API_KEY environment variable.`
+            );
+          }
+          throw new Error(`Failed to create ASCII Box sandbox: ${detail}`);
+        }
+      },
+
+      getById: async (config: AsciiBoxConfig, sandboxId: string) => {
+        const api = createBoxApi(config);
+        try {
+          const response = await api.get({ boxId: sandboxId });
+          const box = response.box;
+          if (!box?.id) return null;
+          return { sandbox: { api, box }, sandboxId: box.id };
+        } catch {
+          return null;
+        }
+      },
+
+      list: async (config: AsciiBoxConfig) => {
+        const api = createBoxApi(config);
+        try {
+          const response = await api.boxes({});
+          return (response.boxes || []).map((box) => ({
+            sandbox: { api, box },
+            sandboxId: box.id,
+          }));
+        } catch {
+          return [];
+        }
+      },
+
+      destroy: async (config: AsciiBoxConfig, sandboxId: string) => {
+        const api = createBoxApi(config);
+        try {
+          await stopAndRemove(api, sandboxId, { delete: true });
+        } catch {
+          // Sandbox might already be destroyed or does not exist
+        }
+      },
+
+      runCommand: async (
+        sandbox: AsciiBoxSandbox,
+        command: string,
+        options?: RunCommandOptions
+      ): Promise<CommandResult> => {
+        const startTime = Date.now();
+
+        let fullCommand = command;
+
+        if (options?.env && Object.keys(options.env).length > 0) {
+          const envPrefix = Object.entries(options.env)
+            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+            .join(' ');
+          fullCommand = `${envPrefix} ${fullCommand}`;
+        }
+
+        if (options?.cwd) {
+          fullCommand = `cd "${escapeShellArg(options.cwd)}" && ${fullCommand}`;
+        }
+
+        if (options?.background) {
+          fullCommand = `nohup sh -c '${fullCommand.replace(/'/g, "'\\''")}' > /dev/null 2>&1 &`;
+        }
+
+        const timeoutSeconds = options?.timeout ? Math.ceil(options.timeout / 1000) : 60;
+
+        try {
+          const response = await execCommand(
+            sandbox.api,
+            sandbox.box.id,
+            fullCommand,
+            undefined,
+            timeoutSeconds
+          );
+
+          if (isCommandResponse(response)) {
+            return {
+              stdout: response.stdout || '',
+              stderr: response.stderr || '',
+              exitCode: response.exitCode ?? 0,
+              durationMs: Date.now() - startTime,
+            };
+          }
+
+          return {
+            stdout: '',
+            stderr: '',
+            exitCode: 0,
+            durationMs: Date.now() - startTime,
+          };
+        } catch (error) {
+          return {
+            stdout: '',
+            stderr: error instanceof Error ? error.message : String(error),
+            exitCode: 127,
+            durationMs: Date.now() - startTime,
+          };
+        }
+      },
+
+      getInfo: async (sandbox: AsciiBoxSandbox): Promise<SandboxInfo> => ({
+        id: sandbox.box.id,
+        provider: 'asciibox',
+        status: convertBoxState(sandbox.box.state),
+        createdAt: sandbox.box.createdAt ? new Date(sandbox.box.createdAt) : new Date(),
+        timeout: sandbox.box.archiveAfter
+          ? new Date(sandbox.box.archiveAfter).getTime() - Date.now()
+          : 300000,
+        metadata: {
+          name: sandbox.box.name,
+          type: sandbox.box.type,
+          vcpu: sandbox.box.vcpu,
+          memoryGB: sandbox.box.memoryGB,
+          environment: sandbox.box.environment,
+        },
+      }),
+
+      getUrl: async (
+        sandbox: AsciiBoxSandbox,
+        options: { port: number; protocol?: string }
+      ): Promise<string> => {
+        try {
+          const response = await sandbox.api.hostPort({
+            boxId: sandbox.box.id,
+            hostPortRequest: {
+              port: options.port,
+              _public: true,
+            },
+          });
+
+          const url = response.url;
+          if (!url) {
+            throw new Error(`Failed to get ASCII Box host for port ${options.port}`);
+          }
+
+          if (options.protocol) {
+            return url.replace(/^https?:/, `${options.protocol}:`);
+          }
+
+          return url;
+        } catch (error) {
+          throw new Error(
+            `Failed to get ASCII Box URL for port ${options.port}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      },
+
+      filesystem: {
+        readFile: async (
+          sandbox: AsciiBoxSandbox,
+          path: string,
+          _runCommand
+        ): Promise<string> => {
+          try {
+            return await readText(sandbox.api, sandbox.box.id, path);
+          } catch (error) {
+            throw new Error(
+              `Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        },
+
+        writeFile: async (
+          sandbox: AsciiBoxSandbox,
+          path: string,
+          content: string,
+          _runCommand
+        ): Promise<void> => {
+          try {
+            await writeText(sandbox.api, sandbox.box.id, path, content);
+          } catch (error) {
+            throw new Error(
+              `Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        },
+
+        mkdir: async (
+          sandbox: AsciiBoxSandbox,
+          path: string,
+          _runCommand
+        ): Promise<void> => {
+          const result = await execCommand(
+            sandbox.api,
+            sandbox.box.id,
+            `mkdir -p "${escapeShellArg(path)}"`
+          );
+          if (isCommandResponse(result) && result.exitCode !== 0) {
+            throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
+          }
+        },
+
+        readdir: async (
+          sandbox: AsciiBoxSandbox,
+          path: string,
+          _runCommand
+        ): Promise<FileEntry[]> => {
+          const result = await execCommand(
+            sandbox.api,
+            sandbox.box.id,
+            `ls -la "${escapeShellArg(path)}"`
+          );
+          if (!isCommandResponse(result)) {
+            return [];
+          }
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
+          }
+
+          const entries: FileEntry[] = [];
+          for (const line of result.stdout.trim().split('\n')) {
+            if (!line || line.startsWith('total')) continue;
+            const parts = line.split(/\s+/);
+            if (parts.length < 9) continue;
+            const name = parts.slice(8).join(' ');
+            if (name === '.' || name === '..') continue;
+            const size = parseInt(parts[4], 10) || 0;
+            const isDirectory = parts[0].startsWith('d');
+            entries.push({
+              name,
+              type: isDirectory ? ('directory' as const) : ('file' as const),
+              size,
+              modified: new Date(),
+            });
+          }
+          return entries;
+        },
+
+        exists: async (
+          sandbox: AsciiBoxSandbox,
+          path: string,
+          _runCommand
+        ): Promise<boolean> => {
+          const result = await execCommand(
+            sandbox.api,
+            sandbox.box.id,
+            `test -e "${escapeShellArg(path)}"`
+          );
+          return isCommandResponse(result) && result.exitCode === 0;
+        },
+
+        remove: async (
+          sandbox: AsciiBoxSandbox,
+          path: string,
+          _runCommand
+        ): Promise<void> => {
+          const result = await execCommand(
+            sandbox.api,
+            sandbox.box.id,
+            `rm -rf "${escapeShellArg(path)}"`
+          );
+          if (isCommandResponse(result) && result.exitCode !== 0) {
+            throw new Error(`Failed to remove ${path}: ${result.stderr}`);
+          }
+        },
+      },
+
+      getInstance: (sandbox: AsciiBoxSandbox): AsciiBoxSandbox => sandbox,
+    },
+
+    snapshot: {
+      create: async (
+        _config: AsciiBoxConfig,
+        _sandboxId: string,
+        _options?: { name?: string }
+      ) => {
+        throw new Error(
+          'ASCII Box snapshots are not supported through this provider yet. Use the ASCII Box dashboard or CLI to manage snapshots.'
+        );
+      },
+      list: async (_config: AsciiBoxConfig) => {
+        throw new Error(
+          'ASCII Box snapshots are not supported through this provider yet. Use the ASCII Box dashboard or CLI to manage snapshots.'
+        );
+      },
+      delete: async (_config: AsciiBoxConfig, _snapshotId: string) => {
+        throw new Error(
+          'ASCII Box snapshots are not supported through this provider yet. Use the ASCII Box dashboard or CLI to manage snapshots.'
+        );
+      },
+    },
+
+    template: {
+      create: async (_config: AsciiBoxConfig, _options: { name: string }) => {
+        throw new Error(
+          'ASCII Box templates (environments) must be managed via the ASCII Box dashboard or CLI.'
+        );
+      },
+      list: async (_config: AsciiBoxConfig) => {
+        throw new Error(
+          'ASCII Box templates (environments) must be managed via the ASCII Box dashboard or CLI.'
+        );
+      },
+      delete: async (_config: AsciiBoxConfig, _templateId: string) => {
+        throw new Error(
+          'ASCII Box templates (environments) must be managed via the ASCII Box dashboard or CLI.'
+        );
+      },
+    },
+  },
+});
+
+function convertBoxState(state?: string): 'running' | 'stopped' | 'error' {
+  switch (state?.toLowerCase()) {
+    case 'ready':
+    case 'idle':
+    case 'running':
+    case 'provisioning':
+    case 'provisioned':
+      return 'running';
+    case 'archived':
+    case 'archiving':
+      return 'stopped';
+    case 'error':
+      return 'error';
+    default:
+      return 'running';
+  }
+}

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -43,6 +43,8 @@ interface AsciiBoxSandbox {
   box: Box;
 }
 
+const DEFAULT_TIMEOUT_MS = 300000;
+
 function getApiKey(config: AsciiBoxConfig): string | undefined {
   return config.apiKey ?? process.env.ASCIIBOX_API_KEY ?? process.env.BOX_API_KEY;
 }
@@ -75,6 +77,28 @@ function createBoxApi(config: AsciiBoxConfig): BoxApi {
   );
 }
 
+function getErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: { status?: number } }).response;
+    return response?.status;
+  }
+  return undefined;
+}
+
+function isNotFound(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  return status === 404 || status === 410;
+}
+
+function isAuthError(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  return status === 401 || status === 403;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function isCommandResponse(response: unknown): response is CommandResponse {
   return (
     typeof response === 'object' &&
@@ -83,6 +107,15 @@ function isCommandResponse(response: unknown): response is CommandResponse {
     'stderr' in response &&
     'exitCode' in response
   );
+}
+
+function validateEnvKey(key: string): string {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) {
+    throw new Error(
+      `Invalid environment variable name: ${key}. Variable names must match /^[a-zA-Z_][a-zA-Z0-9_]*$/.`
+    );
+  }
+  return key;
 }
 
 export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
@@ -96,16 +129,18 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           timeout: optTimeout,
           envs,
           name: _name,
-          metadata,
+          metadata: _metadata,
           templateId: _templateId,
-          snapshotId: _snapshotId,
-          sandboxId: optSandboxId,
+          snapshotId,
+          sandboxId: _sandboxId,
           namespace: _namespace,
           directory: _directory,
+          signal: _signal,
           ...providerOptions
         } = options || {};
 
         const ttlSeconds = optTimeout ? Math.ceil(optTimeout / 1000) : 1800;
+        let box: Box | undefined;
 
         try {
           const response = await api.create({
@@ -114,36 +149,38 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
               ttlSeconds,
               environment: config.environment,
               env: envs,
+              from: snapshotId,
               ...providerOptions,
-            },
+            } as any,
           });
 
-          const box = response.box;
+          box = response.box;
 
           if (!box?.id) {
             throw new Error('ASCII Box create() returned box without an ID');
           }
 
-          await waitUntilReady(api, box.id, {
-            timeoutMs: optTimeout ?? 300000,
-          });
+          try {
+            await waitUntilReady(api, box.id, {
+              timeoutMs: optTimeout ?? DEFAULT_TIMEOUT_MS,
+            });
+          } catch (waitError) {
+            // Best-effort cleanup so a readiness failure does not leak the box
+            await stopAndRemove(api, box.id, { delete: true }).catch(() => {});
+            throw waitError;
+          }
 
           return {
             sandbox: { api, box },
             sandboxId: box.id,
           };
         } catch (error) {
-          const detail = error instanceof Error ? error.message : String(error);
-          if (
-            detail.includes('unauthorized') ||
-            detail.includes('Unauthorized') ||
-            detail.includes('API key')
-          ) {
+          if (isAuthError(error)) {
             throw new Error(
-              `ASCII Box authentication failed. Please check your ASCIIBOX_API_KEY environment variable.`
+              'ASCII Box authentication failed. Please check your ASCIIBOX_API_KEY environment variable.'
             );
           }
-          throw new Error(`Failed to create ASCII Box sandbox: ${detail}`);
+          throw new Error(`Failed to create ASCII Box sandbox: ${formatError(error)}`);
         }
       },
 
@@ -154,21 +191,35 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           const box = response.box;
           if (!box?.id) return null;
           return { sandbox: { api, box }, sandboxId: box.id };
-        } catch {
-          return null;
+        } catch (error) {
+          if (isNotFound(error)) return null;
+          throw new Error(
+            `Failed to get ASCII Box sandbox ${sandboxId}: ${formatError(error)}`
+          );
         }
       },
 
       list: async (config: AsciiBoxConfig) => {
         const api = createBoxApi(config);
         try {
-          const response = await api.boxes({});
-          return (response.boxes || []).map((box) => ({
+          const boxes: Box[] = [];
+          let cursor: string | null | undefined;
+
+          while (true) {
+            const response = await api.boxes({ cursor });
+            boxes.push(...(response.boxes || []));
+
+            const pageInfo = response.pageInfo;
+            if (!pageInfo?.hasMore || !pageInfo?.nextCursor) break;
+            cursor = pageInfo.nextCursor;
+          }
+
+          return boxes.map((box) => ({
             sandbox: { api, box },
             sandboxId: box.id,
           }));
-        } catch {
-          return [];
+        } catch (error) {
+          throw new Error(`Failed to list ASCII Box sandboxes: ${formatError(error)}`);
         }
       },
 
@@ -176,8 +227,11 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
         const api = createBoxApi(config);
         try {
           await stopAndRemove(api, sandboxId, { delete: true });
-        } catch {
-          // Sandbox might already be destroyed or does not exist
+        } catch (error) {
+          if (isNotFound(error)) return;
+          throw new Error(
+            `Failed to destroy ASCII Box sandbox ${sandboxId}: ${formatError(error)}`
+          );
         }
       },
 
@@ -192,7 +246,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
 
         if (options?.env && Object.keys(options.env).length > 0) {
           const envPrefix = Object.entries(options.env)
-            .map(([k, v]) => `${k}="${escapeShellArg(String(v))}"`)
+            .map(([k, v]) => `${validateEnvKey(k)}="${escapeShellArg(String(v))}"`)
             .join(' ');
           fullCommand = `${envPrefix} ${fullCommand}`;
         }
@@ -220,7 +274,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             return {
               stdout: response.stdout || '',
               stderr: response.stderr || '',
-              exitCode: response.exitCode ?? 0,
+              exitCode: response.exitCode ?? (response.timedOut ? 124 : -1),
               durationMs: Date.now() - startTime,
             };
           }
@@ -234,29 +288,41 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
         } catch (error) {
           return {
             stdout: '',
-            stderr: error instanceof Error ? error.message : String(error),
+            stderr: formatError(error),
             exitCode: 127,
             durationMs: Date.now() - startTime,
           };
         }
       },
 
-      getInfo: async (sandbox: AsciiBoxSandbox): Promise<SandboxInfo> => ({
-        id: sandbox.box.id,
-        provider: 'asciibox',
-        status: convertBoxState(sandbox.box.state),
-        createdAt: sandbox.box.createdAt ? new Date(sandbox.box.createdAt) : new Date(),
-        timeout: sandbox.box.archiveAfter
-          ? new Date(sandbox.box.archiveAfter).getTime() - Date.now()
-          : 300000,
-        metadata: {
-          name: sandbox.box.name,
-          type: sandbox.box.type,
-          vcpu: sandbox.box.vcpu,
-          memoryGB: sandbox.box.memoryGB,
-          environment: sandbox.box.environment,
-        },
-      }),
+      getInfo: async (sandbox: AsciiBoxSandbox): Promise<SandboxInfo> => {
+        let box = sandbox.box;
+        try {
+          const response = await sandbox.api.get({ boxId: sandbox.box.id });
+          if (response.box) {
+            box = response.box;
+          }
+        } catch {
+          // Fall back to the cached box if the API is unreachable
+        }
+
+        return {
+          id: box.id,
+          provider: 'asciibox',
+          status: convertBoxState(box.state),
+          createdAt: box.createdAt ? new Date(box.createdAt) : new Date(),
+          timeout: box.archiveAfter
+            ? new Date(box.archiveAfter).getTime() - Date.now()
+            : 300000,
+          metadata: {
+            name: box.name,
+            type: box.type,
+            vcpu: box.vcpu,
+            memoryGB: box.memoryGB,
+            environment: box.environment,
+          },
+        };
+      },
 
       getUrl: async (
         sandbox: AsciiBoxSandbox,
@@ -283,9 +349,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           return url;
         } catch (error) {
           throw new Error(
-            `Failed to get ASCII Box URL for port ${options.port}: ${
-              error instanceof Error ? error.message : String(error)
-            }`
+            `Failed to get ASCII Box URL for port ${options.port}: ${formatError(error)}`
           );
         }
       },
@@ -299,9 +363,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           try {
             return await readText(sandbox.api, sandbox.box.id, path);
           } catch (error) {
-            throw new Error(
-              `Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`
-            );
+            throw new Error(`Failed to read file ${path}: ${formatError(error)}`);
           }
         },
 
@@ -314,9 +376,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           try {
             await writeText(sandbox.api, sandbox.box.id, path, content);
           } catch (error) {
-            throw new Error(
-              `Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)}`
-            );
+            throw new Error(`Failed to write file ${path}: ${formatError(error)}`);
           }
         },
 
@@ -357,13 +417,15 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
             if (!line || line.startsWith('total')) continue;
             const parts = line.split(/\s+/);
             if (parts.length < 9) continue;
-            const name = parts.slice(8).join(' ');
-            if (name === '.' || name === '..') continue;
+            const rawName = parts.slice(8).join(' ');
+            if (rawName === '.' || rawName === '..') continue;
+            const name = rawName.split(' -> ')[0];
             const size = parseInt(parts[4], 10) || 0;
             const isDirectory = parts[0].startsWith('d');
+            const isSymlink = parts[0].startsWith('l');
             entries.push({
               name,
-              type: isDirectory ? ('directory' as const) : ('file' as const),
+              type: isDirectory ? ('directory' as const) : isSymlink ? ('file' as const) : ('file' as const),
               size,
               modified: new Date(),
             });

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -41,9 +41,12 @@ export interface AsciiBoxConfig {
 interface AsciiBoxSandbox {
   api: BoxApi;
   box: Box;
+  timeout: number;
 }
 
 const DEFAULT_PROVISION_TIMEOUT_MS = 300000;
+const DEFAULT_COMMAND_TIMEOUT_MS = 60000;
+const MAX_COMMAND_TIMEOUT_SECONDS = 600;
 
 function getApiKey(config: AsciiBoxConfig): string | undefined {
   return config.apiKey ?? process.env.ASCIIBOX_API_KEY ?? process.env.BOX_API_KEY;
@@ -174,6 +177,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
         } = options || {};
 
         const ttlSeconds = optTimeout ? Math.ceil(optTimeout / 1000) : 1800;
+        const sandboxTimeout = optTimeout ?? 1_800_000;
         let box: Box | undefined;
 
         try {
@@ -195,7 +199,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           }
 
           try {
-            await waitUntilReady(api, box.id, {
+            box = await waitUntilReady(api, box.id, {
               timeoutMs: DEFAULT_PROVISION_TIMEOUT_MS,
             });
           } catch (waitError) {
@@ -205,7 +209,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           }
 
           return {
-            sandbox: { api, box },
+            sandbox: { api, box, timeout: sandboxTimeout },
             sandboxId: box.id,
           };
         } catch (error) {
@@ -224,7 +228,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           const response = await api.get({ boxId: sandboxId });
           const box = response.box;
           if (!box?.id) return null;
-          return { sandbox: { api, box }, sandboxId: box.id };
+          return { sandbox: { api, box, timeout: getBoxTimeout(box) }, sandboxId: box.id };
         } catch (error) {
           if (isNotFound(error)) return null;
           throw new Error(
@@ -249,7 +253,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           }
 
           return boxes.map((box) => ({
-            sandbox: { api, box },
+            sandbox: { api, box, timeout: getBoxTimeout(box) },
             sandboxId: box.id,
           }));
         } catch (error) {
@@ -293,7 +297,11 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           fullCommand = `nohup sh -c '${fullCommand.replace(/'/g, "'\\''")}' > /dev/null 2>&1 &`;
         }
 
-        const timeoutSeconds = options?.timeout ? Math.ceil(options.timeout / 1000) : 60;
+        const requestedTimeoutMs = options?.timeout ?? DEFAULT_COMMAND_TIMEOUT_MS;
+        const timeoutSeconds = Math.min(
+          Math.ceil(requestedTimeoutMs / 1000),
+          MAX_COMMAND_TIMEOUT_SECONDS
+        );
 
         try {
           const response = await execCommand(
@@ -351,9 +359,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           provider: 'asciibox',
           status: convertBoxState(box.state),
           createdAt: box.createdAt ? new Date(box.createdAt) : new Date(),
-          timeout: box.archiveAfter
-            ? new Date(box.archiveAfter).getTime() - Date.now()
-            : 300000,
+          timeout: sandbox.timeout,
           metadata: {
             name: box.name,
             type: box.type,
@@ -506,6 +512,19 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
     },
   },
 });
+
+function getBoxTimeout(box: Box): number {
+  if (box.archiveAfter && box.createdAt) {
+    return Math.max(
+      0,
+      new Date(box.archiveAfter).getTime() - new Date(box.createdAt).getTime()
+    );
+  }
+  if (box.archiveAfter) {
+    return Math.max(0, new Date(box.archiveAfter).getTime() - Date.now());
+  }
+  return 1_800_000;
+}
 
 function convertBoxState(state?: string): 'running' | 'stopped' | 'error' {
   switch (state?.toLowerCase()) {

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -146,7 +146,17 @@ function parseLsDate(parts: string[], fallback: Date): Date {
   if (timeOrYear.includes(':')) {
     const [hours, minutes] = timeOrYear.split(':').map(Number);
     if (Number.isNaN(hours) || Number.isNaN(minutes)) return fallback;
-    return new Date(new Date().getFullYear(), month, day, hours, minutes);
+    const now = new Date();
+    let year = now.getFullYear();
+    let date = new Date(year, month, day, hours, minutes);
+    // `ls` shows time for files modified within the last ~6 months. If the parsed
+    // date is far in the future, it belongs to the previous year (e.g. a December
+    // file listed in January).
+    if (date.getTime() - now.getTime() > 30 * 24 * 60 * 60 * 1000) {
+      year -= 1;
+      date = new Date(year, month, day, hours, minutes);
+    }
+    return date;
   }
 
   const year = parseInt(timeOrYear, 10);

--- a/packages/asciibox/src/index.ts
+++ b/packages/asciibox/src/index.ts
@@ -47,6 +47,7 @@ interface AsciiBoxSandbox {
 const DEFAULT_PROVISION_TIMEOUT_MS = 300000;
 const DEFAULT_COMMAND_TIMEOUT_MS = 60000;
 const MAX_COMMAND_TIMEOUT_SECONDS = 600;
+const ALLOWED_URL_PROTOCOLS = ['http', 'https', 'ws', 'wss', 'tcp'];
 
 function getApiKey(config: AsciiBoxConfig): string | undefined {
   return config.apiKey ?? process.env.ASCIIBOX_API_KEY ?? process.env.BOX_API_KEY;
@@ -187,7 +188,7 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
         } = options || {};
 
         const ttlSeconds = optTimeout ? Math.ceil(optTimeout / 1000) : 1800;
-        const sandboxTimeout = optTimeout ?? 1_800_000;
+        const sandboxTimeout = optTimeout ? optTimeout : 1_800_000;
         let box: Box | undefined;
 
         try {
@@ -307,7 +308,9 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           fullCommand = `nohup sh -c '${fullCommand.replace(/'/g, "'\\''")}' > /dev/null 2>&1 &`;
         }
 
-        const requestedTimeoutMs = options?.timeout ?? DEFAULT_COMMAND_TIMEOUT_MS;
+        const requestedTimeoutMs = options?.timeout
+          ? options.timeout
+          : DEFAULT_COMMAND_TIMEOUT_MS;
         const timeoutSeconds = Math.min(
           Math.ceil(requestedTimeoutMs / 1000),
           MAX_COMMAND_TIMEOUT_SECONDS
@@ -384,12 +387,22 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
         sandbox: AsciiBoxSandbox,
         options: { port: number; protocol?: string }
       ): Promise<string> => {
+        if (
+          options.protocol &&
+          !ALLOWED_URL_PROTOCOLS.includes(options.protocol)
+        ) {
+          throw new Error(
+            `Unsupported getUrl protocol: ${options.protocol}. ` +
+              `Use one of: ${ALLOWED_URL_PROTOCOLS.join(', ')}`
+          );
+        }
+
         try {
+          // Request a token-protected URL by default, not an ungated public URL.
           const response = await sandbox.api.hostPort({
             boxId: sandbox.box.id,
             hostPortRequest: {
               port: options.port,
-              _public: true,
             },
           });
 
@@ -399,7 +412,9 @@ export const asciiBox = defineProvider<AsciiBoxSandbox, AsciiBoxConfig>({
           }
 
           if (options.protocol) {
-            return url.replace(/^https?:/, `${options.protocol}:`);
+            const urlObj = new URL(url);
+            urlObj.protocol = `${options.protocol}:`;
+            return urlObj.toString();
           }
 
           return url;

--- a/packages/asciibox/tsconfig.json
+++ b/packages/asciibox/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/asciibox/tsup.config.ts
+++ b/packages/asciibox/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/asciibox/vitest.config.ts
+++ b/packages/asciibox/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*'
+      ]
+    }
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/asciibox:
+    dependencies:
+      '@asciidev/box-sdk':
+        specifier: ^0.0.34
+        version: 0.0.34
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/beam:
     dependencies:
       '@beamcloud/beam-js':
@@ -2591,6 +2628,9 @@ packages:
 
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
+
+  '@asciidev/box-sdk@0.0.34':
+    resolution: {integrity: sha512-BWy2RHKQMLvGGIVicshpngU+Vo0AlP3L2YfNXiCwBs8pXpAsdP8IC9tzQhmm3pBVdFsykoeA5aVPSMEjt7Ybyg==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -9490,6 +9530,8 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
     optional: true
+
+  '@asciidev/box-sdk@0.0.34': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:


### PR DESCRIPTION
## Summary

Adds `@computesdk/asciibox`, a new ComputeSDK provider for [ASCII Box](https://docs.ascii.dev/box/sdks/typescript) cloud sandboxes.

The provider wraps the official `@asciidev/box-sdk` and implements the standard `defineProvider` interface: `create`, `getById`, `list`, `destroy`, `runCommand`, `getInfo`, `getUrl`, and filesystem operations (`readFile`, `writeFile`, `mkdir`, `readdir`, `exists`, `remove`). Snapshot and template lifecycle management are not exposed through ComputeSDK for ASCII Box; they should be managed through the ASCII Box dashboard or CLI.

Authentication accepts `asciiBox({ apiKey, basePath })` and falls back to `ASCIIBOX_API_KEY` / `ASCIIBOX_BASE_URL`, with compatibility fallbacks to `BOX_API_KEY` / `BOX_BASE_URL`.

### Usage

```typescript
import { asciiBox } from '@computesdk/asciibox';

const compute = asciiBox({ apiKey: process.env.ASCIIBOX_API_KEY });
const sandbox = await compute.sandbox.create();

const result = await sandbox.runCommand('echo "Hello from ASCII Box!"');
console.log(result.stdout);

await sandbox.destroy();
```

### Notes

- New files are confined to `packages/asciibox/`, `docs/providers/asciibox.md`, `docs/SUMMARY.md`, `.changeset/add-asciibox-provider.md`, and the root `README.md`.
- Includes a `patch` changeset for `@computesdk/asciibox`.
- `pnpm build`, `typecheck`, `lint`, and `test` pass for the new package.

Link to Devin session: https://app.devin.ai/sessions/8188b2dacd3a414c868f9ffdd1cff2de
Open in Devin Desktop: https://app.devin.ai/desktop/session/8188b2dacd3a414c868f9ffdd1cff2de?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->