### PR TITLE
ci(release): restore NPM_TOKEN fallback for packages without npm trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # Publishing uses npm Trusted Publisher OIDC. Every package in this
-          # monorepo must have a trusted publisher configured on npmjs.com
-          # (repo: computesdk/computesdk, workflow: release.yml) before it can
-          # be released. --provenance signs the attestation.
+          # Publishing uses npm Trusted Publisher OIDC where configured.
+          # Packages without a trusted publisher on npmjs.com fall back to the
+          # long-lived NPM_TOKEN. --provenance signs the attestation.
+          # TODO: once every package has a trusted publisher configured, remove
+          # NPM_TOKEN entirely.
           publish: pnpm changeset publish --provenance
           title: "Version Packages"
           commit: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The `Release` workflow dropped the `NPM_TOKEN` fallback in #721, assuming every `@computesdk/*` package already had an npm Trusted Publisher configured. The release run for `@computesdk/arker@0.1.4` failed with `ENEEDAUTH` because it does not yet have a trusted publisher, so OIDC authentication alone could not publish it.

This PR restores the `NPM_TOKEN` environment variable as a fallback in the `changesets/action` step. Packages with a trusted publisher will continue to publish via OIDC; packages without one will fall back to the long-lived token until they are configured on npmjs.com.

```yaml
# .github/workflows/release.yml
      - name: Create Release Pull Request or Publish to npm
        ...
        env:
          GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```

The step comment is also updated to reflect the fallback behavior and the TODO to remove `NPM_TOKEN` once every package has a trusted publisher.

Link to Devin session: https://app.devin.ai/sessions/a3daa801d7f64bb4a740741389b61a31
Open in Devin Desktop: https://app.devin.ai/desktop/session/a3daa801d7f64bb4a740741389b61a31?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->