### PR TITLE
chore(miosa): add changeset for ready-session routing with quorum cold-start

### DIFF
--- a/.changeset/miosa-ready-session-routing.md
+++ b/.changeset/miosa-ready-session-routing.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/miosa": patch
+---
+
+Route MIOSA sandbox requests over ready HTTP/2 sessions, with a quorum-based cold-start gate. The provider now tracks connected sessions and dispatches only onto warm connections; on a cold pool it waits for the first session to connect and up to 250 ms for a quorum of 8, improving burst median TTI. The wait is bounded by a 1 second deadline and re-armed when the pool is fully recycled, preventing hangs and stale gates.


### PR DESCRIPTION
## Summary

Adds a missing changeset for the recent `@computesdk/miosa` update that introduced ready-session routing with a quorum-based cold-start gate for the HTTP/2 pool. The package is bumped as `patch` per repository changeset policy.

Link to Devin session: https://app.devin.ai/sessions/072f97831a014fabb42c2721c0d30d81
Open in Devin Desktop: https://app.devin.ai/desktop/session/072f97831a014fabb42c2721c0d30d81?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->