### PR TITLE
test: add sandbox filesystem test to computesdk core

### DIFF
--- a/.changeset/chunky-archil-writes.md
+++ b/.changeset/chunky-archil-writes.md
@@ -2,4 +2,4 @@
 '@computesdk/archil': patch
 ---
 
-Chunk large filesystem writes to stay within Archil exec command limits.
+Support large filesystem reads, chunk large writes, and reject writes to directory paths.

--- a/.changeset/chunky-archil-writes.md
+++ b/.changeset/chunky-archil-writes.md
@@ -1,0 +1,5 @@
+---
+'@computesdk/archil': patch
+---
+
+Chunk large filesystem writes to stay within Archil exec command limits.

--- a/.changeset/sandbox-filesystem-test.md
+++ b/.changeset/sandbox-filesystem-test.md
@@ -1,5 +1,0 @@
----
-"computesdk": patch
----
-
-Add a sandbox filesystem test to the `computesdk` core package that exercises `readFile`, `writeFile`, `mkdir`, `readdir`, `exists`, and `remove` through `compute.sandbox.create()`. The test runs against an in-memory provider by default and can be run against any sandbox provider by setting `COMPUTESDK_INTEGRATION=1` and `TEST_PROVIDER`.

--- a/.changeset/sandbox-filesystem-test.md
+++ b/.changeset/sandbox-filesystem-test.md
@@ -1,0 +1,5 @@
+---
+"computesdk": patch
+---
+
+Add a sandbox filesystem test to the `computesdk` core package that exercises `readFile`, `writeFile`, `mkdir`, `readdir`, `exists`, and `remove` through `compute.sandbox.create()`. The test runs against an in-memory provider by default and can be run against any sandbox provider by setting `COMPUTESDK_INTEGRATION=1` and `TEST_PROVIDER`.

--- a/docs/providers/archil.md
+++ b/docs/providers/archil.md
@@ -95,11 +95,12 @@ interface ArchilConfig {
 | `runCommand` | ✅         | Calls Archil's HTTP `exec` endpoint and waits for completion.      |
 | `getInfo`    | ✅         |                                                                    |
 | `getUrl`     | ❌         | Each exec runs in a fresh ephemeral container — no port to expose. |
-| `filesystem` | ✅         | Implemented via shell commands (`cat`, `find`, `mkdir`, etc.).     |
+| `filesystem` | ✅         | Accepts normal paths and maps them into `/mnt/archil`; shared-mode checkout/checkin is automatic. |
 
 ### Limitations
 
 * Each `exec` call provisions a fresh container — no persistent state between calls beyond what is written to the disk.
 * Responses are truncated to \~5 MB by the Archil control plane.
 * `getUrl` is not supported — each exec runs in a fresh ephemeral container, so there is no long-lived process to expose a port on.
-* Filesystem operations are implemented as shell commands, so each call costs one HTTP round trip.
+* Filesystem operations accept normal absolute paths and map them into `/mnt/archil` internally.
+* Raw `runCommand` strings are not rewritten. Commands that access the disk directly must use `/mnt/archil` themselves.

--- a/packages/archil/README.md
+++ b/packages/archil/README.md
@@ -58,7 +58,7 @@ await provider.sandbox.destroy(sandbox.sandboxId);
 | `runCommand`  | ✅        | Executes shell commands through Archil's HTTP `exec` endpoint. |
 | `getInfo`     | ✅        |                                                             |
 | `getUrl`      | ❌        | Each exec runs in a fresh ephemeral container — no port to expose. |
-| `filesystem`  | ✅        | Implemented via shell commands (`cat`, `find`, `mkdir`, etc.). |
+| `filesystem`  | ✅        | Maps paths into `/mnt/archil` and manages shared-mode checkout/checkin automatically. |
 
 ## Limitations
 
@@ -67,5 +67,8 @@ await provider.sandbox.destroy(sandbox.sandboxId);
 - Responses are truncated to ~5 MB by the Archil control plane.
 - `getUrl` is not supported — each exec runs in a fresh ephemeral container,
   so there is no long-lived process to expose a port on.
-- Filesystem operations are implemented as shell commands, so each call
-  costs one HTTP round trip.
+- Filesystem operations accept normal absolute paths and map them into the
+  `/mnt/archil` disk mount internally. Each mutating operation checks out and
+  checks in the disk automatically.
+- Raw `runCommand` strings are not rewritten. Commands that access the disk
+  directly must use `/mnt/archil` themselves.

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -127,7 +127,12 @@ describe('archil filesystem mapping', () => {
   }
 
   it('maps public filesystem paths to the Archil mount', async () => {
-    const fetchMock = vi.fn(async () => execResponse('hello'));
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { command: string };
+      return body.command.includes('wc -c')
+        ? execResponse('5\n')
+        : execResponse(Buffer.from('hello').toString('base64'));
+    });
     global.fetch = fetchMock as typeof fetch;
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
@@ -138,7 +143,10 @@ describe('archil filesystem mapping', () => {
     );
 
     expect(commands(fetchMock)[0]).toContain(
-      "cat '/mnt/archil/tmp/hello.txt'",
+      "wc -c < '/mnt/archil/tmp/hello.txt'",
+    );
+    expect(commands(fetchMock)[1]).toContain(
+      "dd if='/mnt/archil/tmp/hello.txt' bs=1 skip=0 count=5",
     );
   });
 
@@ -167,6 +175,9 @@ describe('archil filesystem mapping', () => {
     );
     expect(mutationCommands[1]).toContain(
       "'/mnt/archil/tmp/data/hello.txt'",
+    );
+    expect(mutationCommands[1]).toContain(
+      "if [ -d '/mnt/archil/tmp/data/hello.txt' ]; then",
     );
     expect(mutationCommands[2]).toContain(
       "rm -rf '/mnt/archil/tmp/data/hello.txt'",
@@ -200,6 +211,52 @@ describe('archil filesystem mapping', () => {
     );
   });
 
+  it('reads files larger than the Archil response limit in chunks', async () => {
+    const content = '0123456789abcdef'.repeat(400_000);
+    const bytes = Buffer.from(content, 'utf8');
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { command: string };
+      if (body.command.includes('wc -c')) {
+        return execResponse(`${bytes.length}\n`);
+      }
+
+      const match = body.command.match(/skip=(\d+) count=(\d+)/);
+      if (!match) throw new Error(`Unexpected read command: ${body.command}`);
+      const offset = Number(match[1]);
+      const count = Number(match[2]);
+      return execResponse(
+        bytes.subarray(offset, offset + count).toString('base64'),
+      );
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(
+      sandbox.filesystem.readFile('/tmp/large.txt'),
+    ).resolves.toBe(content);
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(2);
+    expect(commands(fetchMock)[0]).toContain('wc -c');
+    expect(
+      commands(fetchMock).filter((command) => command.includes('dd if=')).length,
+    ).toBeGreaterThan(1);
+  });
+
+  it('reads empty files without issuing a chunk command', async () => {
+    const fetchMock = vi.fn(async () => execResponse('0\n'));
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(sandbox.filesystem.readFile('/tmp/empty.txt')).resolves.toBe(
+      '',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('writes empty files without emitting a base64 chunk', async () => {
     const fetchMock = vi.fn(async () => execResponse());
     global.fetch = fetchMock as typeof fetch;
@@ -216,6 +273,52 @@ describe('archil filesystem mapping', () => {
     );
     expect(command).toContain(" '/mnt/archil/tmp/empty.txt'");
     expect(command).not.toContain('base64 -d');
+  });
+
+  it('rejects non-empty writes to existing directories', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(execResponse('', 1, 'destination is a directory'))
+      .mockResolvedValueOnce(execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(
+      sandbox.filesystem.writeFile('/tmp/existing-dir', 'hello'),
+    ).rejects.toThrow(
+      'Failed to write /tmp/existing-dir: destination is a directory',
+    );
+    expect(commands(fetchMock)[0]).toContain(
+      "if [ -d '/mnt/archil/tmp/existing-dir' ]; then",
+    );
+    expect(commands(fetchMock)[0]).toContain(
+      "mv '/mnt/archil/tmp/existing-dir.computesdk-write-",
+    );
+  });
+
+  it('rejects empty writes to existing directories', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(execResponse('', 1, 'destination is a directory'))
+      .mockResolvedValueOnce(execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(
+      sandbox.filesystem.writeFile('/tmp/existing-dir', ''),
+    ).rejects.toThrow(
+      'Failed to write /tmp/existing-dir: destination is a directory',
+    );
+    expect(commands(fetchMock)[0]).toContain(
+      "if [ -d '/mnt/archil/tmp/existing-dir' ]; then",
+    );
+    expect(commands(fetchMock)[0]).toContain(
+      "mv '/mnt/archil/tmp/existing-dir.computesdk-write-",
+    );
   });
 
   it('stops after a failed chunk and cleans up the staged file', async () => {

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -97,6 +97,85 @@ describe('archil create semantics', () => {
   });
 });
 
+describe('archil filesystem mapping', () => {
+  function execResponse(stdout = '', exitCode = 0): Response {
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          stdout,
+          stderr: '',
+          exitCode,
+          timing: { totalMs: 0, queueMs: 0, executeMs: 0 },
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  function commands(fetchMock: { mock: { calls: any[][] } }): string[] {
+    return (fetchMock.mock.calls as any[][]).map((call) => {
+      const body = JSON.parse(String((call[1] as RequestInit).body)) as {
+        command: string;
+      };
+      return body.command;
+    });
+  }
+
+  it('maps public filesystem paths to the Archil mount', async () => {
+    const fetchMock = vi.fn(async () => execResponse('hello'));
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(sandbox.filesystem.readFile('/tmp/hello.txt')).resolves.toBe(
+      'hello',
+    );
+
+    expect(commands(fetchMock)[0]).toContain(
+      "cat '/mnt/archil/tmp/hello.txt'",
+    );
+  });
+
+  it('checks out and checks in mutating filesystem operations', async () => {
+    const fetchMock = vi.fn(async () => execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await sandbox.filesystem.mkdir('/tmp/data');
+    await sandbox.filesystem.writeFile('/tmp/data/hello.txt', 'hello');
+    await sandbox.filesystem.remove('/tmp/data/hello.txt');
+
+    const mutationCommands = commands(fetchMock);
+    expect(mutationCommands).toHaveLength(3);
+    for (const command of mutationCommands) {
+      expect(command).toContain("archil checkout --force --yes '/mnt/archil'");
+      expect(command).toContain("archil checkin '/mnt/archil'");
+    }
+    expect(mutationCommands[0]).toContain(
+      "mkdir -p '/mnt/archil/tmp/data'",
+    );
+    expect(mutationCommands[1]).toContain(
+      "printf %s 'aGVsbG8=' | base64 -d > '/mnt/archil/tmp/data/hello.txt'",
+    );
+    expect(mutationCommands[2]).toContain(
+      "rm -rf '/mnt/archil/tmp/data/hello.txt'",
+    );
+  });
+
+  it('refuses to remove the disk mount root', async () => {
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(sandbox.filesystem.remove('/')).rejects.toThrow(
+      /refusing to remove the Archil disk mount root/i,
+    );
+  });
+});
+
 runProviderTestSuite({
   name: 'archil',
   provider: (() => {
@@ -129,11 +208,7 @@ runProviderTestSuite({
 
     return provider;
   })(),
-  // Archil filesystem mount points vary by account/runtime and are not yet
-  // stable enough for generic provider-test-suite path assumptions.
-  // Keep command/runtime integration coverage on, and add dedicated filesystem
-  // integration once mount-path behavior is standardized.
-  supportsFilesystem: false,
+  supportsFilesystem: true,
   supportsGetUrl: false,
   skipIntegration:
     !process.env.ARCHIL_API_KEY || !process.env.ARCHIL_REGION || !process.env.ARCHIL_DISK_ID,

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -98,13 +98,17 @@ describe('archil create semantics', () => {
 });
 
 describe('archil filesystem mapping', () => {
-  function execResponse(stdout = '', exitCode = 0): Response {
+  function execResponse(
+    stdout = '',
+    exitCode = 0,
+    stderr = '',
+  ): Response {
     return new Response(
       JSON.stringify({
         success: true,
         data: {
           stdout,
-          stderr: '',
+          stderr,
           exitCode,
           timing: { totalMs: 0, queueMs: 0, executeMs: 0 },
         },
@@ -159,10 +163,84 @@ describe('archil filesystem mapping', () => {
       "mkdir -p '/mnt/archil/tmp/data'",
     );
     expect(mutationCommands[1]).toContain(
-      "printf %s 'aGVsbG8=' | base64 -d > '/mnt/archil/tmp/data/hello.txt'",
+      "printf %s 'aGVsbG8=' | base64 -d > '/mnt/archil/tmp/data/hello.txt.computesdk-write-",
+    );
+    expect(mutationCommands[1]).toContain(
+      "'/mnt/archil/tmp/data/hello.txt'",
     );
     expect(mutationCommands[2]).toContain(
       "rm -rf '/mnt/archil/tmp/data/hello.txt'",
+    );
+  });
+
+  it('chunks large writes within Archil exec limits', async () => {
+    const fetchMock = vi.fn(async () => execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await sandbox.filesystem.writeFile('/tmp/large.txt', 'x'.repeat(100_000));
+
+    const writeCommands = commands(fetchMock);
+    const chunkCommands = writeCommands.filter((command) =>
+      command.includes('base64 -d'),
+    );
+    expect(chunkCommands.length).toBeGreaterThan(1);
+    expect(
+      writeCommands.every(
+        (command) => Buffer.byteLength(command, 'utf8') <= 102_400,
+      ),
+    ).toBe(true);
+    expect(writeCommands.at(-1)).toContain(
+      "mv '/mnt/archil/tmp/large.txt.computesdk-write-",
+    );
+    expect(writeCommands.at(-1)).toContain(
+      " '/mnt/archil/tmp/large.txt'",
+    );
+  });
+
+  it('writes empty files without emitting a base64 chunk', async () => {
+    const fetchMock = vi.fn(async () => execResponse());
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await sandbox.filesystem.writeFile('/tmp/empty.txt', '');
+
+    const [command] = commands(fetchMock);
+    expect(command).toContain(": > '/mnt/archil/tmp/empty.txt.computesdk-write-");
+    expect(command).toContain(
+      "mv '/mnt/archil/tmp/empty.txt.computesdk-write-",
+    );
+    expect(command).toContain(" '/mnt/archil/tmp/empty.txt'");
+    expect(command).not.toContain('base64 -d');
+  });
+
+  it('stops after a failed chunk and cleans up the staged file', async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn(async () => {
+      callCount += 1;
+      return callCount === 2
+        ? execResponse('', 1, 'chunk failed')
+        : execResponse();
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
+    const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
+
+    await expect(
+      sandbox.filesystem.writeFile('/tmp/partial.txt', 'x'.repeat(200_000)),
+    ).rejects.toThrow('Failed to write /tmp/partial.txt: chunk failed');
+
+    const writeCommands = commands(fetchMock);
+    expect(
+      writeCommands.filter((command) => command.includes('base64 -d')),
+    ).toHaveLength(2);
+    expect(writeCommands.at(-1)).toContain(
+      "rm -f '/mnt/archil/tmp/partial.txt.computesdk-write-",
     );
   });
 

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import { defineProvider } from '@computesdk/provider';
+import { posix } from 'node:path';
 import type {
   CommandResult,
   SandboxInfo,
@@ -16,6 +17,8 @@ import type {
   FileEntry,
   RunCommandOptions,
 } from 'computesdk';
+
+const ARCHIL_MOUNT_ROOT = '/mnt/archil';
 
 // Per-region color overrides. Default is "green" for any region not listed here.
 const REGION_COLORS: Record<string, string> = {
@@ -167,6 +170,32 @@ function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+function mapFilesystemPath(path: string): string {
+  const normalized = posix.normalize(path.startsWith('/') ? path : `/${path}`);
+
+  if (normalized === '/') {
+    return ARCHIL_MOUNT_ROOT;
+  }
+
+  if (
+    normalized === ARCHIL_MOUNT_ROOT ||
+    normalized.startsWith(`${ARCHIL_MOUNT_ROOT}/`)
+  ) {
+    return normalized;
+  }
+
+  return `${ARCHIL_MOUNT_ROOT}${normalized}`;
+}
+
+function withDiskWriteLock(command: string): string {
+  const mountRoot = shellEscape(ARCHIL_MOUNT_ROOT);
+  return [
+    `archil checkout --force --yes ${mountRoot}`,
+    `{ ${command}; status=$?; archil checkin ${mountRoot}; checkin_status=$?; ` +
+      `if [ $status -ne 0 ]; then exit $status; fi; exit $checkin_status; }`,
+  ].join(' && ');
+}
+
 function wrapCommand(command: string, options?: RunCommandOptions): string {
   let wrapped = command;
 
@@ -298,7 +327,8 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
 
       filesystem: {
         readFile: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `cat ${shellEscape(path)}`);
+          const diskPath = mapFilesystemPath(path);
+          const result = await runCommand(sandbox, `cat ${shellEscape(diskPath)}`);
           if (result.exitCode !== 0) {
             throw new Error(`Failed to read ${path}: ${result.stderr}`);
           }
@@ -306,15 +336,16 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         },
 
         writeFile: async (sandbox, path, content, runCommand) => {
-          const parent = path.substring(0, path.lastIndexOf('/'));
-          if (parent) {
-            await runCommand(sandbox, `mkdir -p ${shellEscape(parent)}`);
-          }
+          const diskPath = mapFilesystemPath(path);
+          const parent = posix.dirname(diskPath);
           // base64-pipe to avoid heredoc/quoting hazards on arbitrary content.
           const encoded = Buffer.from(content, 'utf8').toString('base64');
           const result = await runCommand(
             sandbox,
-            `printf %s ${shellEscape(encoded)} | base64 -d > ${shellEscape(path)}`,
+            withDiskWriteLock(
+              `mkdir -p ${shellEscape(parent)} && ` +
+                `printf %s ${shellEscape(encoded)} | base64 -d > ${shellEscape(diskPath)}`,
+            ),
           );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to write ${path}: ${result.stderr}`);
@@ -322,17 +353,22 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         },
 
         mkdir: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `mkdir -p ${shellEscape(path)}`);
+          const diskPath = mapFilesystemPath(path);
+          const result = await runCommand(
+            sandbox,
+            withDiskWriteLock(`mkdir -p ${shellEscape(diskPath)}`),
+          );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to create directory ${path}: ${result.stderr}`);
           }
         },
 
         readdir: async (sandbox, path, runCommand) => {
+          const diskPath = mapFilesystemPath(path);
           // Tab-separated: type<TAB>size<TAB>mtime-iso<TAB>name. Robust to spaces in names.
           const result = await runCommand(
             sandbox,
-            `find ${shellEscape(path)} -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\n'`,
+            `find ${shellEscape(diskPath)} -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\n'`,
           );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to list directory ${path}: ${result.stderr}`);
@@ -353,12 +389,20 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         },
 
         exists: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `test -e ${shellEscape(path)}`);
+          const diskPath = mapFilesystemPath(path);
+          const result = await runCommand(sandbox, `test -e ${shellEscape(diskPath)}`);
           return result.exitCode === 0;
         },
 
         remove: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `rm -rf ${shellEscape(path)}`);
+          const diskPath = mapFilesystemPath(path);
+          if (diskPath === ARCHIL_MOUNT_ROOT) {
+            throw new Error('Refusing to remove the Archil disk mount root.');
+          }
+          const result = await runCommand(
+            sandbox,
+            withDiskWriteLock(`rm -rf ${shellEscape(diskPath)}`),
+          );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to remove ${path}: ${result.stderr}`);
           }

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -21,6 +21,9 @@ import type {
 
 const ARCHIL_MOUNT_ROOT = '/mnt/archil';
 const ARCHIL_MAX_EXEC_COMMAND_BYTES = 102_400;
+// Base64 expands the file data and adds line wrapping. Keep the raw chunk
+// comfortably below Archil's roughly 4 MiB response cap.
+const ARCHIL_MAX_READ_CHUNK_BYTES = 2 * 1024 * 1024;
 
 // Per-region color overrides. Default is "green" for any region not listed here.
 const REGION_COLORS: Record<string, string> = {
@@ -217,9 +220,20 @@ function buildWriteChunkCommand(
     ...(isFirst ? [`mkdir -p ${shellEscape(parent)}`] : []),
     writeCommand,
     ...(isFinal
-      ? [`mv ${shellEscape(tempPath)} ${shellEscape(diskPath)}`]
+      ? [finalizeStagedFileCommand(tempPath, diskPath)]
       : []),
   ].join(' && ');
+}
+
+function finalizeStagedFileCommand(tempPath: string, diskPath: string): string {
+  const quotedDestination = shellEscape(diskPath);
+  return [
+    `if [ -d ${quotedDestination} ]; then`,
+    `printf '%s\\n' ${shellEscape(`Refusing to overwrite directory ${diskPath}`)} >&2;`,
+    'exit 1;',
+    'fi;',
+    `mv ${shellEscape(tempPath)} ${quotedDestination}`,
+  ].join(' ');
 }
 
 function maxWriteChunkSize(
@@ -391,11 +405,68 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
       filesystem: {
         readFile: async (sandbox, path, runCommand) => {
           const diskPath = mapFilesystemPath(path);
-          const result = await runCommand(sandbox, `cat ${shellEscape(diskPath)}`);
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to read ${path}: ${result.stderr}`);
+          const sizeResult = await runCommand(
+            sandbox,
+            `wc -c < ${shellEscape(diskPath)}`,
+          );
+          if (sizeResult.exitCode !== 0) {
+            throw new Error(`Failed to read ${path}: ${sizeResult.stderr}`);
           }
-          return result.stdout;
+
+          const sizeText = sizeResult.stdout.trim();
+          if (!/^\d+$/.test(sizeText)) {
+            throw new Error(
+              `Failed to read ${path}: Archil returned an invalid file size.`,
+            );
+          }
+
+          const size = Number(sizeText);
+          if (!Number.isSafeInteger(size)) {
+            throw new Error(
+              `Failed to read ${path}: file size exceeds JavaScript's safe integer range.`,
+            );
+          }
+          if (size === 0) return '';
+
+          const chunks: Buffer[] = [];
+          for (
+            let offset = 0;
+            offset < size;
+            offset += ARCHIL_MAX_READ_CHUNK_BYTES
+          ) {
+            const expectedBytes = Math.min(
+              ARCHIL_MAX_READ_CHUNK_BYTES,
+              size - offset,
+            );
+            const result = await runCommand(
+              sandbox,
+              `dd if=${shellEscape(diskPath)} bs=1 skip=${offset} count=${expectedBytes} 2>/dev/null | base64`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to read ${path}: ${result.stderr}`);
+            }
+
+            const encoded = result.stdout.replace(/\s/g, '');
+            if (
+              encoded.length === 0 ||
+              encoded.length % 4 !== 0 ||
+              !/^[A-Za-z0-9+/]*={0,2}$/.test(encoded)
+            ) {
+              throw new Error(
+                `Failed to read ${path}: Archil returned an incomplete file chunk at byte ${offset}.`,
+              );
+            }
+
+            const chunk = Buffer.from(encoded, 'base64');
+            if (chunk.length !== expectedBytes) {
+              throw new Error(
+                `Failed to read ${path}: Archil returned an incomplete file chunk at byte ${offset}.`,
+              );
+            }
+            chunks.push(chunk);
+          }
+
+          return Buffer.concat(chunks).toString('utf8');
         },
 
         writeFile: async (sandbox, path, content, runCommand) => {
@@ -414,7 +485,7 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
                   [
                     `mkdir -p ${shellEscape(parent)}`,
                     `: > ${shellEscape(tempPath)}`,
-                    `mv ${shellEscape(tempPath)} ${shellEscape(diskPath)}`,
+                    finalizeStagedFileCommand(tempPath, diskPath),
                   ].join(' && '),
                 ),
               );

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import { defineProvider } from '@computesdk/provider';
+import { randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
 import type {
   CommandResult,
@@ -19,6 +20,7 @@ import type {
 } from 'computesdk';
 
 const ARCHIL_MOUNT_ROOT = '/mnt/archil';
+const ARCHIL_MAX_EXEC_COMMAND_BYTES = 102_400;
 
 // Per-region color overrides. Default is "green" for any region not listed here.
 const REGION_COLORS: Record<string, string> = {
@@ -196,6 +198,67 @@ function withDiskWriteLock(command: string): string {
   ].join(' && ');
 }
 
+function execCommandBytes(command: string): number {
+  return Buffer.byteLength(wrapCommand(command), 'utf8');
+}
+
+function buildWriteChunkCommand(
+  parent: string,
+  tempPath: string,
+  diskPath: string,
+  encodedChunk: string,
+  isFirst: boolean,
+  isFinal: boolean,
+): string {
+  const writeCommand =
+    `printf %s ${shellEscape(encodedChunk)} | base64 -d ` +
+    `${isFirst ? '>' : '>>'} ${shellEscape(tempPath)}`;
+  return [
+    ...(isFirst ? [`mkdir -p ${shellEscape(parent)}`] : []),
+    writeCommand,
+    ...(isFinal
+      ? [`mv ${shellEscape(tempPath)} ${shellEscape(diskPath)}`]
+      : []),
+  ].join(' && ');
+}
+
+function maxWriteChunkSize(
+  parent: string,
+  tempPath: string,
+  diskPath: string,
+): number {
+  let low = 0;
+  let high = ARCHIL_MAX_EXEC_COMMAND_BYTES;
+
+  while (low < high) {
+    const candidate = Math.ceil((low + high) / 2);
+    const command = withDiskWriteLock(
+      buildWriteChunkCommand(
+        parent,
+        tempPath,
+        diskPath,
+        'A'.repeat(candidate),
+        true,
+        true,
+      ),
+    );
+
+    if (execCommandBytes(command) <= ARCHIL_MAX_EXEC_COMMAND_BYTES) {
+      low = candidate;
+    } else {
+      high = candidate - 1;
+    }
+  }
+
+  const chunkSize = low - (low % 4);
+  if (chunkSize < 4) {
+    throw new Error(
+      `Archil filesystem path is too long to write within the ${ARCHIL_MAX_EXEC_COMMAND_BYTES}-byte exec command limit.`,
+    );
+  }
+  return chunkSize;
+}
+
 function wrapCommand(command: string, options?: RunCommandOptions): string {
   let wrapped = command;
 
@@ -338,17 +401,67 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
         writeFile: async (sandbox, path, content, runCommand) => {
           const diskPath = mapFilesystemPath(path);
           const parent = posix.dirname(diskPath);
-          // base64-pipe to avoid heredoc/quoting hazards on arbitrary content.
           const encoded = Buffer.from(content, 'utf8').toString('base64');
-          const result = await runCommand(
-            sandbox,
-            withDiskWriteLock(
-              `mkdir -p ${shellEscape(parent)} && ` +
-                `printf %s ${shellEscape(encoded)} | base64 -d > ${shellEscape(diskPath)}`,
-            ),
-          );
-          if (result.exitCode !== 0) {
-            throw new Error(`Failed to write ${path}: ${result.stderr}`);
+          const tempPath = `${diskPath}.computesdk-write-${randomUUID()}`;
+          let started = false;
+
+          try {
+            if (encoded.length === 0) {
+              started = true;
+              const result = await runCommand(
+                sandbox,
+                withDiskWriteLock(
+                  [
+                    `mkdir -p ${shellEscape(parent)}`,
+                    `: > ${shellEscape(tempPath)}`,
+                    `mv ${shellEscape(tempPath)} ${shellEscape(diskPath)}`,
+                  ].join(' && '),
+                ),
+              );
+              if (result.exitCode !== 0) {
+                throw new Error(result.stderr);
+              }
+              return;
+            }
+
+            const chunkSize = maxWriteChunkSize(parent, tempPath, diskPath);
+            for (let offset = 0; offset < encoded.length; offset += chunkSize) {
+              const isFirst = offset === 0;
+              const isFinal = offset + chunkSize >= encoded.length;
+              started = true;
+              const result = await runCommand(
+                sandbox,
+                withDiskWriteLock(
+                  buildWriteChunkCommand(
+                    parent,
+                    tempPath,
+                    diskPath,
+                    encoded.slice(offset, offset + chunkSize),
+                    isFirst,
+                    isFinal,
+                  ),
+                ),
+              );
+              if (result.exitCode !== 0) {
+                throw new Error(result.stderr);
+              }
+            }
+          } catch (error) {
+            if (started) {
+              try {
+                await runCommand(
+                  sandbox,
+                  withDiskWriteLock(`rm -f ${shellEscape(tempPath)}`),
+                );
+              } catch {
+                // Preserve the original write error if cleanup fails.
+              }
+            }
+            throw new Error(
+              `Failed to write ${path}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
           }
         },
 

--- a/packages/computesdk/src/__tests__/sandbox-filesystem.test.ts
+++ b/packages/computesdk/src/__tests__/sandbox-filesystem.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { compute, type DirectProvider } from '../compute';
+import type {
+  Sandbox,
+  SandboxFileSystem,
+  FileEntry,
+  CommandResult,
+  SandboxInfo,
+} from '../types/universal-sandbox';
+
+type SupportedProvider =
+  | 'e2b'
+  | 'vercel'
+  | 'daytona'
+  | 'modal'
+  | 'archil'
+  | 'just-bash';
+
+const runIntegration = process.env.COMPUTESDK_INTEGRATION === '1';
+const testProvider = process.env.TEST_PROVIDER as SupportedProvider | undefined;
+const describeIntegration =
+  runIntegration && testProvider ? describe : describe.skip;
+
+const filesystemBasePath = '/tmp/computesdk-fs-test';
+
+function getWorkspaceRoot(): string {
+  const cwd = process.cwd();
+  const candidates = [cwd, resolve(cwd, '..'), resolve(cwd, '..', '..')];
+
+  for (const candidate of candidates) {
+    if (existsSync(resolve(candidate, 'pnpm-workspace.yaml'))) {
+      return candidate;
+    }
+  }
+
+  return cwd;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function loadProviderFactory(
+  provider: SupportedProvider
+): Promise<(config: Record<string, string>) => DirectProvider> {
+  const workspaceRoot = getWorkspaceRoot();
+  const modulePaths: Record<SupportedProvider, string> = {
+    e2b: resolve(workspaceRoot, 'packages/e2b/dist/index.mjs'),
+    vercel: resolve(workspaceRoot, 'packages/vercel/dist/index.mjs'),
+    daytona: resolve(workspaceRoot, 'packages/daytona/dist/index.mjs'),
+    modal: resolve(workspaceRoot, 'packages/modal/dist/index.mjs'),
+    archil: resolve(workspaceRoot, 'packages/archil/dist/index.mjs'),
+    'just-bash': resolve(workspaceRoot, 'packages/just-bash/dist/index.mjs'),
+  };
+
+  const factoryMap: Record<SupportedProvider, string> = {
+    e2b: 'e2b',
+    vercel: 'vercel',
+    daytona: 'daytona',
+    modal: 'modal',
+    archil: 'archil',
+    'just-bash': 'justBash',
+  };
+
+  const moduleUrl = pathToFileURL(modulePaths[provider]).href;
+  const mod = await import(moduleUrl);
+  const factory = (mod as Record<string, unknown>)[factoryMap[provider]];
+  if (typeof factory !== 'function') {
+    throw new Error(
+      `Provider factory "${factoryMap[provider]}" not found for ${provider}`
+    );
+  }
+
+  return factory as (config: Record<string, string>) => DirectProvider;
+}
+
+function getProviderConfig(
+  provider: SupportedProvider
+): Record<string, string> {
+  switch (provider) {
+    case 'e2b':
+      return { apiKey: requireEnv('E2B_API_KEY') };
+    case 'vercel':
+      return {
+        token: requireEnv('VERCEL_TOKEN'),
+        teamId: requireEnv('VERCEL_TEAM_ID'),
+        projectId: requireEnv('VERCEL_PROJECT_ID'),
+      };
+    case 'daytona':
+      return { apiKey: requireEnv('DAYTONA_API_KEY') };
+    case 'modal':
+      return {
+        tokenId: requireEnv('MODAL_TOKEN_ID'),
+        tokenSecret: requireEnv('MODAL_TOKEN_SECRET'),
+      };
+    case 'archil':
+      return {
+        apiKey: requireEnv('ARCHIL_API_KEY'),
+        region: requireEnv('ARCHIL_REGION'),
+      };
+    case 'just-bash':
+      return {};
+    default:
+      throw new Error(`Unsupported TEST_PROVIDER: ${String(provider)}`);
+  }
+}
+
+function createInMemoryFilesystem(): SandboxFileSystem {
+  const files = new Map<string, { content: string; modified: Date }>();
+  const dirs = new Set<string>();
+
+  const normalize = (p: string): string => {
+    let normalized = p.replace(/\/+/g, '/');
+    if (normalized.length > 1 && normalized.endsWith('/')) {
+      normalized = normalized.slice(0, -1);
+    }
+    return normalized;
+  };
+
+  const ensureDir = (p: string): void => {
+    const normalized = normalize(p);
+    if (normalized === '/') return;
+    const parts = normalized.split('/').filter(Boolean);
+    let current = '';
+    for (const part of parts) {
+      current += `/${part}`;
+      dirs.add(current);
+    }
+  };
+
+  const parentDir = (p: string): string => {
+    const normalized = normalize(p);
+    const index = normalized.lastIndexOf('/');
+    return index <= 0 ? '/' : normalized.slice(0, index);
+  };
+
+  const listChildren = (p: string): FileEntry[] => {
+    const normalized = normalize(p);
+    const prefix = normalized === '/' ? '/' : `${normalized}/`;
+    const entries = new Map<
+      string,
+      { type: 'file' | 'directory'; size: number; modified: Date }
+    >();
+
+    for (const [filePath, file] of files) {
+      if (
+        filePath !== normalized &&
+        filePath.startsWith(prefix) &&
+        !filePath.slice(prefix.length).includes('/')
+      ) {
+        const name = filePath.slice(prefix.length);
+        entries.set(name, {
+          type: 'file',
+          size: file.content.length,
+          modified: file.modified,
+        });
+      }
+    }
+
+    for (const dirPath of dirs) {
+      if (
+        dirPath !== normalized &&
+        dirPath.startsWith(prefix) &&
+        !dirPath.slice(prefix.length).includes('/')
+      ) {
+        const name = dirPath.slice(prefix.length);
+        entries.set(name, { type: 'directory', size: 0, modified: new Date() });
+      }
+    }
+
+    return Array.from(entries.entries()).map(([name, meta]) => ({
+      name,
+      ...meta,
+    }));
+  };
+
+  return {
+    readFile: async (path: string): Promise<string> => {
+      const normalized = normalize(path);
+      const file = files.get(normalized);
+      if (!file) {
+        throw new Error(
+          `ENOENT: no such file or directory, open '${path}'`
+        );
+      }
+      return file.content;
+    },
+    writeFile: async (path: string, content: string): Promise<void> => {
+      const normalized = normalize(path);
+      ensureDir(parentDir(normalized));
+      files.set(normalized, { content, modified: new Date() });
+    },
+    mkdir: async (path: string): Promise<void> => {
+      ensureDir(path);
+    },
+    readdir: async (path: string): Promise<FileEntry[]> => {
+      return listChildren(path);
+    },
+    exists: async (path: string): Promise<boolean> => {
+      const normalized = normalize(path);
+      return files.has(normalized) || dirs.has(normalized);
+    },
+    remove: async (path: string): Promise<void> => {
+      const normalized = normalize(path);
+      for (const [filePath] of [...files]) {
+        if (filePath === normalized || filePath.startsWith(`${normalized}/`)) {
+          files.delete(filePath);
+        }
+      }
+      for (const dirPath of [...dirs]) {
+        if (dirPath === normalized || dirPath.startsWith(`${normalized}/`)) {
+          dirs.delete(dirPath);
+        }
+      }
+    },
+  };
+}
+
+function createInMemoryFilesystemProvider(): DirectProvider {
+  let counter = 0;
+
+  return {
+    name: 'in-memory-filesystem',
+    sandbox: {
+      create: async (): Promise<Sandbox> => {
+        const sandboxId = `mem-fs-${(counter += 1)}`;
+        const filesystem = createInMemoryFilesystem();
+
+        const sandbox: Sandbox = {
+          sandboxId,
+          provider: 'in-memory-filesystem',
+          runCommand: async (
+            command: string,
+            _options?: { env?: Record<string, string> }
+          ): Promise<CommandResult> => ({
+            stdout: `mock: ${command}`,
+            stderr: '',
+            exitCode: 0,
+            durationMs: 0,
+          }),
+          getInfo: async (): Promise<SandboxInfo> => ({
+            id: sandboxId,
+            provider: 'in-memory-filesystem',
+            status: 'running',
+            createdAt: new Date(),
+            timeout: 300000,
+          }),
+          getUrl: async ({
+            port,
+            protocol,
+          }: {
+            port: number;
+            protocol?: string;
+          }): Promise<string> =>
+            `${protocol || 'https'}://${port}-${sandboxId}.example.com`,
+          destroy: async (): Promise<void> => {},
+          filesystem,
+        };
+
+        return sandbox;
+      },
+      getById: async (): Promise<Sandbox | null> => null,
+      destroy: async (): Promise<void> => {},
+    },
+  };
+}
+
+async function runFilesystemAssertions(sandbox: Sandbox): Promise<void> {
+  const testFile = `${filesystemBasePath}/hello.txt`;
+  const testDir = `${filesystemBasePath}/data`;
+  const testNestedFile = `${testDir}/nested.txt`;
+
+  await sandbox.filesystem.mkdir(filesystemBasePath);
+  await sandbox.filesystem.writeFile(testFile, 'hello from computesdk');
+
+  const content = await sandbox.filesystem.readFile(testFile);
+  expect(content).toBe('hello from computesdk');
+
+  expect(await sandbox.filesystem.exists(testFile)).toBe(true);
+  expect(await sandbox.filesystem.exists('/tmp/computesdk-fs-missing')).toBe(
+    false
+  );
+
+  await sandbox.filesystem.mkdir(testDir);
+  await sandbox.filesystem.writeFile(testNestedFile, 'nested content');
+
+  const entries = await sandbox.filesystem.readdir(filesystemBasePath);
+  expect(Array.isArray(entries)).toBe(true);
+  const names = entries.map((entry: FileEntry) => entry.name).sort();
+  expect(names).toContain('hello.txt');
+  expect(names).toContain('data');
+
+  const dirEntries = await sandbox.filesystem.readdir(testDir);
+  const dirNames = dirEntries.map((entry: FileEntry) => entry.name);
+  expect(dirNames).toContain('nested.txt');
+
+  await sandbox.filesystem.remove(testNestedFile);
+  expect(await sandbox.filesystem.exists(testNestedFile)).toBe(false);
+
+  await sandbox.filesystem.remove(testDir);
+  expect(await sandbox.filesystem.exists(testDir)).toBe(false);
+
+  await sandbox.filesystem.remove(testFile);
+  expect(await sandbox.filesystem.exists(testFile)).toBe(false);
+
+  await sandbox.filesystem.remove(filesystemBasePath);
+  expect(await sandbox.filesystem.exists(filesystemBasePath)).toBe(false);
+}
+
+describe('sandbox filesystem', () => {
+  const sdk = compute({ provider: createInMemoryFilesystemProvider() });
+  let sandbox: Sandbox;
+
+  beforeEach(async () => {
+    sandbox = await sdk.sandbox.create();
+  });
+
+  afterEach(async () => {
+    try {
+      await sandbox.destroy();
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('exposes a filesystem on the sandbox', () => {
+    expect(sandbox.filesystem).toBeDefined();
+    expect(typeof sandbox.filesystem.readFile).toBe('function');
+    expect(typeof sandbox.filesystem.writeFile).toBe('function');
+    expect(typeof sandbox.filesystem.mkdir).toBe('function');
+    expect(typeof sandbox.filesystem.readdir).toBe('function');
+    expect(typeof sandbox.filesystem.exists).toBe('function');
+    expect(typeof sandbox.filesystem.remove).toBe('function');
+  });
+
+  it('performs filesystem operations', async () => {
+    await runFilesystemAssertions(sandbox);
+  });
+
+  it('throws when reading a missing file', async () => {
+    await expect(
+      sandbox.filesystem.readFile(`${filesystemBasePath}/missing.txt`)
+    ).rejects.toThrow();
+  });
+});
+
+describeIntegration('sandbox filesystem integration', () => {
+  let sandbox: Sandbox;
+
+  beforeEach(async () => {
+    if (!testProvider) {
+      throw new Error('TEST_PROVIDER must be set when COMPUTESDK_INTEGRATION=1');
+    }
+
+    const providerFactory = await loadProviderFactory(testProvider);
+    const provider = providerFactory(getProviderConfig(testProvider));
+    const sdk = compute({ provider });
+
+    const createOptions: Record<string, unknown> = { timeout: 120000 };
+    if (testProvider === 'archil') {
+      createOptions.diskId = requireEnv('ARCHIL_DISK_ID');
+    }
+
+    sandbox = await sdk.sandbox.create(createOptions as any);
+  }, 180000);
+
+  afterEach(async () => {
+    try {
+      await sandbox.destroy();
+    } catch {
+      // Ignore cleanup errors
+    }
+  }, 30000);
+
+  it('performs filesystem operations', async () => {
+    await runFilesystemAssertions(sandbox);
+  }, 180000);
+
+  it('throws when reading a missing file', async () => {
+    await expect(
+      sandbox.filesystem.readFile(`${filesystemBasePath}/missing.txt`)
+    ).rejects.toThrow();
+  }, 30000);
+});

--- a/packages/computesdk/src/__tests__/sandbox-filesystem.test.ts
+++ b/packages/computesdk/src/__tests__/sandbox-filesystem.test.ts
@@ -124,26 +124,17 @@ const providerDefinitions: Record<string, ProviderDefinition> = {
     config: () =>
       envConfig({
         sandboxUrl: env('CLOUDFLARE_SANDBOX_URL'),
-        sandboxApiKey: env('CLOUDFLARE_SANDBOX_API_KEY'),
+        sandboxSecret: env('CLOUDFLARE_SANDBOX_SECRET'),
       }),
     isConfigured: () =>
       Boolean(
         env('CLOUDFLARE_SANDBOX_URL') &&
-          env('CLOUDFLARE_SANDBOX_API_KEY')
+          env('CLOUDFLARE_SANDBOX_SECRET')
       ),
   },
   codesandbox: {
     config: () => envConfig({ apiKey: env('CSB_API_KEY') }),
     isConfigured: () => Boolean(env('CSB_API_KEY')),
-  },
-  collimate: {
-    config: () =>
-      envConfig({
-        serverUrl: env('COLLIMATE_API_URL') || 'https://api.collimate.ai',
-        apiKey: env('COLLIMATE_API_KEY'),
-        templateId: env('COLLIMATE_TEMPLATE_ID') || 'node',
-      }),
-    isConfigured: () => Boolean(env('COLLIMATE_API_KEY')),
   },
   'createos-sandbox': {
     config: () =>
@@ -214,16 +205,6 @@ const providerDefinitions: Record<string, ProviderDefinition> = {
     config: () => ({}),
     isConfigured: () => true,
   },
-  leap0: {
-    config: () =>
-      envConfig({
-        apiKey: env('LEAP0_API_KEY'),
-        baseUrl: env('LEAP0_API_URL'),
-        sandboxDomain: env('LEAP0_SANDBOX_DOMAIN'),
-        template: env('LEAP0_TEMPLATE'),
-      }),
-    isConfigured: () => Boolean(env('LEAP0_API_KEY')),
-  },
   lelantos: {
     config: () =>
       envConfig({
@@ -286,15 +267,6 @@ const providerDefinitions: Record<string, ProviderDefinition> = {
     isConfigured: () =>
       Boolean(env('MOSAIC_API_URL') && env('MOSAIC_API_TOKEN')),
     filesystemBasePath: '/workspace/computesdk-fs-test',
-  },
-  neevcloud: {
-    config: () =>
-      envConfig({
-        apiKey: env('NEEV_API_KEY'),
-        orgId: env('NEEV_ORG_ID'),
-        projectId: env('NEEV_PROJECT_ID'),
-      }),
-    isConfigured: () => Boolean(env('NEEV_API_KEY')),
   },
   northflank: {
     config: () =>
@@ -481,7 +453,6 @@ async function loadProviderFactory(
     'cloud-run': 'cloudRun',
     cloudflare: 'cloudflare',
     codesandbox: 'codesandbox',
-    collimate: 'collimate',
     'createos-sandbox': 'createosSandbox',
     daytona: 'daytona',
     declaw: 'declaw',
@@ -492,14 +463,12 @@ async function loadProviderFactory(
     hopx: 'hopx',
     isorun: 'isorun',
     'just-bash': 'justBash',
-    leap0: 'leap0',
     lelantos: 'lelantos',
     lightning: 'lightning',
     microsandbox: 'microsandbox',
     miosa: 'miosa',
     modal: 'modal',
     mosaic: 'mosaic',
-    neevcloud: 'neevcloud',
     northflank: 'northflank',
     opencomputer: 'opencomputer',
     quilt: 'quilt',

--- a/packages/computesdk/src/__tests__/sandbox-filesystem.test.ts
+++ b/packages/computesdk/src/__tests__/sandbox-filesystem.test.ts
@@ -11,20 +11,434 @@ import type {
   SandboxInfo,
 } from '../types/universal-sandbox';
 
-type SupportedProvider =
-  | 'e2b'
-  | 'vercel'
-  | 'daytona'
-  | 'modal'
-  | 'archil'
-  | 'just-bash';
+type ProviderConfig = Record<string, unknown>;
 
-const runIntegration = process.env.COMPUTESDK_INTEGRATION === '1';
-const testProvider = process.env.TEST_PROVIDER as SupportedProvider | undefined;
+interface ProviderDefinition {
+  config: () => ProviderConfig;
+  isConfigured: () => boolean;
+  createOptions?: () => Record<string, unknown>;
+  filesystemBasePath?: string;
+}
+
+function env(name: string): string | undefined {
+  return process.env[name] || undefined;
+}
+
+function firstEnv(...names: string[]): string | undefined {
+  return names.map((name) => env(name)).find(Boolean);
+}
+
+function envConfig(
+  values: Record<string, string | undefined>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(values).filter(
+      (entry): entry is [string, string] => Boolean(entry[1])
+    )
+  );
+}
+
+function hasAnyEnv(...names: string[]): boolean {
+  return names.some((name) => Boolean(env(name)));
+}
+
+function isDockerIntegrationEnabled(): boolean {
+  return env('RUN_INTEGRATION') === '1' || env('RUN_INTEGRATION') === 'true';
+}
+
+const runIntegration = env('COMPUTESDK_INTEGRATION') === '1';
+
+const providerDefinitions: Record<string, ProviderDefinition> = {
+  agentcore: {
+    config: () =>
+      envConfig({
+        region: firstEnv('AWS_REGION', 'AWS_DEFAULT_REGION'),
+        profile: env('AWS_PROFILE'),
+      }),
+    isConfigured: () =>
+      Boolean(
+        firstEnv('AWS_REGION', 'AWS_DEFAULT_REGION') &&
+          hasAnyEnv('AWS_ACCESS_KEY_ID', 'AWS_PROFILE', 'AWS_SESSION_TOKEN')
+      ),
+  },
+  agentuity: {
+    config: () =>
+      envConfig({
+        apiKey: env('AGENTUITY_SDK_KEY'),
+        region: env('AGENTUITY_REGION'),
+        baseURL: env('AGENTUITY_BASE_URL'),
+      }),
+    isConfigured: () => Boolean(env('AGENTUITY_SDK_KEY')),
+    filesystemBasePath: '/home/agentuity/computesdk-fs-test',
+  },
+  archil: {
+    config: () =>
+      envConfig({
+        apiKey: env('ARCHIL_API_KEY'),
+        region: env('ARCHIL_REGION'),
+        baseUrl: env('ARCHIL_BASE_URL'),
+      }),
+    isConfigured: () =>
+      Boolean(env('ARCHIL_API_KEY') && env('ARCHIL_REGION') && env('ARCHIL_DISK_ID')),
+    createOptions: () => ({ diskId: requireEnv('ARCHIL_DISK_ID') }),
+  },
+  arker: {
+    config: () =>
+      envConfig({
+        apiKey: env('ARKER_API_KEY'),
+        region: env('ARKER_REGION'),
+        provider: env('ARKER_PROVIDER'),
+      }),
+    isConfigured: () => Boolean(env('ARKER_API_KEY')),
+  },
+  beam: {
+    config: () =>
+      envConfig({
+        token: env('BEAM_TOKEN'),
+        workspaceId: env('BEAM_WORKSPACE_ID'),
+      }),
+    isConfigured: () => Boolean(env('BEAM_TOKEN') && env('BEAM_WORKSPACE_ID')),
+  },
+  blaxel: {
+    config: () =>
+      envConfig({
+        apiKey: env('BL_API_KEY'),
+        workspace: env('BL_WORKSPACE'),
+      }),
+    isConfigured: () => Boolean(env('BL_API_KEY') && env('BL_WORKSPACE')),
+  },
+  'cloud-run': {
+    config: () =>
+      envConfig({
+        sandboxUrl: env('CLOUD_RUN_SANDBOX_URL'),
+        sandboxSecret: env('CLOUD_RUN_SANDBOX_SECRET'),
+        gatewayAuthToken: env('CLOUD_RUN_AUTH_TOKEN'),
+        sandboxBinary: env('CLOUD_RUN_SANDBOX_BINARY'),
+        executionMode: 'stateful',
+      }),
+    isConfigured: () =>
+      Boolean(env('CLOUD_RUN_SANDBOX_URL') && env('CLOUD_RUN_SANDBOX_SECRET')),
+    filesystemBasePath: '/workspace/computesdk-fs-test',
+  },
+  cloudflare: {
+    config: () =>
+      envConfig({
+        sandboxUrl: env('CLOUDFLARE_SANDBOX_URL'),
+        sandboxApiKey: env('CLOUDFLARE_SANDBOX_API_KEY'),
+      }),
+    isConfigured: () =>
+      Boolean(
+        env('CLOUDFLARE_SANDBOX_URL') &&
+          env('CLOUDFLARE_SANDBOX_API_KEY')
+      ),
+  },
+  codesandbox: {
+    config: () => envConfig({ apiKey: env('CSB_API_KEY') }),
+    isConfigured: () => Boolean(env('CSB_API_KEY')),
+  },
+  collimate: {
+    config: () =>
+      envConfig({
+        serverUrl: env('COLLIMATE_API_URL') || 'https://api.collimate.ai',
+        apiKey: env('COLLIMATE_API_KEY'),
+        templateId: env('COLLIMATE_TEMPLATE_ID') || 'node',
+      }),
+    isConfigured: () => Boolean(env('COLLIMATE_API_KEY')),
+  },
+  'createos-sandbox': {
+    config: () =>
+      envConfig({
+        apiKey: env('CREATEOS_SANDBOX_API_KEY'),
+        baseUrl: env('CREATEOS_SANDBOX_BASE_URL'),
+      }),
+    isConfigured: () => Boolean(env('CREATEOS_SANDBOX_API_KEY')),
+  },
+  daytona: {
+    config: () => envConfig({ apiKey: env('DAYTONA_API_KEY') }),
+    isConfigured: () => Boolean(env('DAYTONA_API_KEY')),
+  },
+  declaw: {
+    config: () =>
+      envConfig({
+        apiKey: env('DECLAW_API_KEY'),
+        domain: env('DECLAW_DOMAIN'),
+      }),
+    isConfigured: () => Boolean(env('DECLAW_API_KEY')),
+  },
+  docker: {
+    config: () => ({
+      runtime: 'node',
+      image: {
+        name: env('DOCKER_NODE_IMAGE') || 'node:20-alpine',
+        pullPolicy: 'ifNotPresent',
+      },
+      container: { workdir: '/workspace', autoRemove: true },
+    }),
+    isConfigured: isDockerIntegrationEnabled,
+    filesystemBasePath: '/workspace/computesdk-fs-test',
+  },
+  e2b: {
+    config: () => envConfig({ apiKey: env('E2B_API_KEY') }),
+    isConfigured: () => Boolean(env('E2B_API_KEY')),
+  },
+  freestyle: {
+    config: () =>
+      envConfig({
+        apiKey: env('FREESTYLE_API_KEY'),
+        snapshotId: env('FREESTYLE_SNAPSHOT_ID'),
+        baseUrl: env('FREESTYLE_API_URL'),
+      }),
+    isConfigured: () => Boolean(env('FREESTYLE_API_KEY')),
+  },
+  givemeanode: {
+    config: () =>
+      envConfig({
+        apiKey: env('GMN_TOKEN'),
+        baseUrl: env('GMN_API_HOST'),
+      }),
+    isConfigured: () => Boolean(env('GMN_TOKEN')),
+  },
+  hopx: {
+    config: () =>
+      envConfig({
+        apiKey: env('HOPX_API_KEY'),
+        baseURL: env('HOPX_BASE_URL'),
+      }),
+    isConfigured: () => Boolean(env('HOPX_API_KEY')),
+  },
+  isorun: {
+    config: () => envConfig({ apiKey: env('ISORUN_API_KEY') }),
+    isConfigured: () => Boolean(env('ISORUN_API_KEY')),
+  },
+  'just-bash': {
+    config: () => ({}),
+    isConfigured: () => true,
+  },
+  leap0: {
+    config: () =>
+      envConfig({
+        apiKey: env('LEAP0_API_KEY'),
+        baseUrl: env('LEAP0_API_URL'),
+        sandboxDomain: env('LEAP0_SANDBOX_DOMAIN'),
+        template: env('LEAP0_TEMPLATE'),
+      }),
+    isConfigured: () => Boolean(env('LEAP0_API_KEY')),
+  },
+  lelantos: {
+    config: () =>
+      envConfig({
+        apiKey: env('LELANTOS_API_KEY') || env('E2B_API_KEY'),
+        domain: env('LELANTOS_DOMAIN') || 'lelantos.ai',
+      }),
+    isConfigured: () =>
+      Boolean(env('LELANTOS_API_KEY') || env('E2B_API_KEY')),
+  },
+  lightning: {
+    config: () =>
+      envConfig({
+        apiKey: firstEnv('LIGHTNING_SANDBOX_API_KEY', 'LIGHTNING_API_KEY'),
+        baseUrl: env('LIGHTNING_CLOUD_URL'),
+      }),
+    isConfigured: () =>
+      hasAnyEnv('LIGHTNING_SANDBOX_API_KEY', 'LIGHTNING_API_KEY'),
+  },
+  microsandbox: {
+    config: () => ({
+      ...(env('MSB_RUN_INTEGRATION') === '1'
+        ? { backend: 'local' }
+        : {
+            backend: 'cloud',
+            ...envConfig({
+              apiKey: env('MSB_API_KEY'),
+              apiUrl: env('MSB_API_URL'),
+              profile: env('MSB_PROFILE'),
+            }),
+          }),
+    }),
+    isConfigured: () =>
+      env('MSB_RUN_INTEGRATION') === '1' ||
+      hasAnyEnv('MSB_API_KEY', 'MSB_PROFILE'),
+  },
+  miosa: {
+    config: () =>
+      envConfig({
+        apiKey: env('MIOSA_API_KEY'),
+        baseUrl: env('MIOSA_API_URL'),
+      }),
+    isConfigured: () => Boolean(env('MIOSA_API_KEY')),
+  },
+  modal: {
+    config: () =>
+      envConfig({
+        tokenId: env('MODAL_TOKEN_ID'),
+        tokenSecret: env('MODAL_TOKEN_SECRET'),
+      }),
+    isConfigured: () =>
+      Boolean(env('MODAL_TOKEN_ID') && env('MODAL_TOKEN_SECRET')),
+  },
+  mosaic: {
+    config: () =>
+      envConfig({
+        baseUrl: env('MOSAIC_API_URL'),
+        apiKey: env('MOSAIC_API_TOKEN'),
+        template: env('MOSAIC_TEMPLATE'),
+      }),
+    isConfigured: () =>
+      Boolean(env('MOSAIC_API_URL') && env('MOSAIC_API_TOKEN')),
+    filesystemBasePath: '/workspace/computesdk-fs-test',
+  },
+  neevcloud: {
+    config: () =>
+      envConfig({
+        apiKey: env('NEEV_API_KEY'),
+        orgId: env('NEEV_ORG_ID'),
+        projectId: env('NEEV_PROJECT_ID'),
+      }),
+    isConfigured: () => Boolean(env('NEEV_API_KEY')),
+  },
+  northflank: {
+    config: () =>
+      envConfig({
+        token: env('NORTHFLANK_TOKEN'),
+        projectId: env('NORTHFLANK_PROJECT_ID'),
+        host: env('NORTHFLANK_API_URL'),
+      }),
+    isConfigured: () =>
+      Boolean(env('NORTHFLANK_TOKEN') && env('NORTHFLANK_PROJECT_ID')),
+  },
+  opencomputer: {
+    config: () =>
+      envConfig({
+        apiKey: env('OPENCOMPUTER_API_KEY'),
+        apiUrl: env('OPENCOMPUTER_API_URL'),
+        template: env('OPENCOMPUTER_TEMPLATE'),
+      }),
+    isConfigured: () => Boolean(env('OPENCOMPUTER_API_KEY')),
+  },
+  quilt: {
+    config: () =>
+      envConfig({
+        baseUrl: env('QUILT_BASE_URL'),
+        apiKey: env('QUILT_API_KEY'),
+        accessToken: env('QUILT_ACCESS_TOKEN'),
+        tenantId: env('QUILT_TENANT_ID'),
+      }),
+    isConfigured: () =>
+      Boolean(
+        env('QUILT_BASE_URL') &&
+          hasAnyEnv('QUILT_API_KEY', 'QUILT_ACCESS_TOKEN')
+      ),
+  },
+  railway: {
+    config: () =>
+      envConfig({
+        token: env('RAILWAY_API_TOKEN'),
+        environmentId: env('RAILWAY_ENVIRONMENT_ID'),
+      }),
+    isConfigured: () => Boolean(env('RAILWAY_API_TOKEN')),
+  },
+  'run-cloud': {
+    config: () =>
+      envConfig({
+        apiKey: firstEnv('RUN_CLOUD_API_KEY', 'RUN_CLOUD_API_TOKEN'),
+        apiUrl: env('RUN_CLOUD_API_URL'),
+      }),
+    isConfigured: () =>
+      hasAnyEnv('RUN_CLOUD_API_KEY', 'RUN_CLOUD_API_TOKEN'),
+  },
+  runloop: {
+    config: () => envConfig({ apiKey: env('RUNLOOP_API_KEY') }),
+    isConfigured: () => Boolean(env('RUNLOOP_API_KEY')),
+  },
+  sail: {
+    config: () =>
+      envConfig({
+        apiKey: env('SAIL_API_KEY'),
+        app: env('SAIL_APP'),
+      }),
+    isConfigured: () => Boolean(env('SAIL_API_KEY')),
+    filesystemBasePath: '/tmp',
+  },
+  sandbox0: {
+    config: () =>
+      envConfig({
+        token: env('SANDBOX0_TOKEN') || env('SANDBOX0_API_KEY'),
+        teamId: env('SANDBOX0_TEAM_ID'),
+        baseUrl: env('SANDBOX0_BASE_URL'),
+        templateId: env('SANDBOX0_TEMPLATE'),
+      }),
+    isConfigured: () =>
+      hasAnyEnv('SANDBOX0_TOKEN', 'SANDBOX0_API_KEY'),
+  },
+  'secure-exec': {
+    config: () => ({}),
+    isConfigured: () => true,
+    filesystemBasePath: '/workspace/computesdk-fs-test',
+  },
+  sprites: {
+    config: () =>
+      envConfig({
+        apiKey: env('SPRITES_TOKEN'),
+        baseUrl: env('SPRITES_API_URL'),
+      }),
+    isConfigured: () => Boolean(env('SPRITES_TOKEN')),
+  },
+  superserve: {
+    config: () =>
+      envConfig({
+        apiKey: env('SUPERSERVE_API_KEY'),
+        baseUrl: env('SUPERSERVE_BASE_URL'),
+      }),
+    isConfigured: () => Boolean(env('SUPERSERVE_API_KEY')),
+  },
+  tenki: {
+    config: () =>
+      envConfig({
+        apiKey: firstEnv('TENKI_API_KEY', 'TENKI_AUTH_TOKEN'),
+        baseUrl: env('TENKI_API_URL'),
+        workspaceId: env('TENKI_WORKSPACE_ID'),
+      }),
+    isConfigured: () =>
+      hasAnyEnv('TENKI_API_KEY', 'TENKI_AUTH_TOKEN'),
+    filesystemBasePath: '/home/tenki/computesdk-fs-test',
+  },
+  tensorlake: {
+    config: () =>
+      envConfig({
+        apiKey: env('TENSORLAKE_API_KEY'),
+        apiUrl: env('TENSORLAKE_API_URL'),
+        proxyUrl: env('TENSORLAKE_PROXY_URL'),
+      }),
+    isConfigured: () =>
+      env('SKIP_INTEGRATION') !== 'true' && Boolean(env('TENSORLAKE_API_KEY')),
+  },
+  upstash: {
+    config: () =>
+      envConfig({
+        apiKey: env('UPSTASH_BOX_API_KEY'),
+        runtime: env('UPSTASH_RUNTIME'),
+      }),
+    isConfigured: () => Boolean(env('UPSTASH_BOX_API_KEY')),
+  },
+};
+
+type SupportedProvider = keyof typeof providerDefinitions;
+
+const requestedProvider = process.env.TEST_PROVIDER;
+const testProvider: SupportedProvider | undefined =
+  requestedProvider && requestedProvider in providerDefinitions
+    ? (requestedProvider as SupportedProvider)
+    : undefined;
 const describeIntegration =
-  runIntegration && testProvider ? describe : describe.skip;
+  runIntegration &&
+  testProvider &&
+  providerDefinitions[testProvider].isConfigured()
+    ? describe
+    : describe.skip;
 
-const filesystemBasePath = '/tmp/computesdk-fs-test';
+const filesystemBasePath =
+  providerDefinitions[testProvider ?? 'just-bash'].filesystemBasePath ??
+  '/tmp/computesdk-fs-test';
 
 function getWorkspaceRoot(): string {
   const cwd = process.cwd();
@@ -49,24 +463,57 @@ function requireEnv(name: string): string {
 
 async function loadProviderFactory(
   provider: SupportedProvider
-): Promise<(config: Record<string, string>) => DirectProvider> {
+): Promise<(config: ProviderConfig) => DirectProvider> {
   const workspaceRoot = getWorkspaceRoot();
-  const modulePaths: Record<SupportedProvider, string> = {
-    e2b: resolve(workspaceRoot, 'packages/e2b/dist/index.mjs'),
-    vercel: resolve(workspaceRoot, 'packages/vercel/dist/index.mjs'),
-    daytona: resolve(workspaceRoot, 'packages/daytona/dist/index.mjs'),
-    modal: resolve(workspaceRoot, 'packages/modal/dist/index.mjs'),
-    archil: resolve(workspaceRoot, 'packages/archil/dist/index.mjs'),
-    'just-bash': resolve(workspaceRoot, 'packages/just-bash/dist/index.mjs'),
-  };
-
+  const modulePaths: Record<SupportedProvider, string> = Object.fromEntries(
+    Object.keys(providerDefinitions).map((name) => [
+      name,
+      resolve(workspaceRoot, `packages/${name}/dist/index.mjs`),
+    ])
+  ) as Record<SupportedProvider, string>;
   const factoryMap: Record<SupportedProvider, string> = {
-    e2b: 'e2b',
-    vercel: 'vercel',
-    daytona: 'daytona',
-    modal: 'modal',
+    agentcore: 'agentcore',
+    agentuity: 'agentuity',
     archil: 'archil',
+    arker: 'arker',
+    beam: 'beam',
+    blaxel: 'blaxel',
+    'cloud-run': 'cloudRun',
+    cloudflare: 'cloudflare',
+    codesandbox: 'codesandbox',
+    collimate: 'collimate',
+    'createos-sandbox': 'createosSandbox',
+    daytona: 'daytona',
+    declaw: 'declaw',
+    docker: 'docker',
+    e2b: 'e2b',
+    freestyle: 'freestyle',
+    givemeanode: 'givemeanode',
+    hopx: 'hopx',
+    isorun: 'isorun',
     'just-bash': 'justBash',
+    leap0: 'leap0',
+    lelantos: 'lelantos',
+    lightning: 'lightning',
+    microsandbox: 'microsandbox',
+    miosa: 'miosa',
+    modal: 'modal',
+    mosaic: 'mosaic',
+    neevcloud: 'neevcloud',
+    northflank: 'northflank',
+    opencomputer: 'opencomputer',
+    quilt: 'quilt',
+    railway: 'railway',
+    'run-cloud': 'runCloud',
+    runloop: 'runloop',
+    sail: 'sail',
+    sandbox0: 'sandbox0',
+    'secure-exec': 'secureExec',
+    sprites: 'sprites',
+    superserve: 'superserve',
+    tenki: 'tenki',
+    tensorlake: 'tensorlake',
+    upstash: 'upstash',
   };
 
   const moduleUrl = pathToFileURL(modulePaths[provider]).href;
@@ -78,38 +525,17 @@ async function loadProviderFactory(
     );
   }
 
-  return factory as (config: Record<string, string>) => DirectProvider;
+  return factory as (config: ProviderConfig) => DirectProvider;
 }
 
-function getProviderConfig(
+function getProviderConfig(provider: SupportedProvider): ProviderConfig {
+  return providerDefinitions[provider].config();
+}
+
+function getProviderCreateOptions(
   provider: SupportedProvider
-): Record<string, string> {
-  switch (provider) {
-    case 'e2b':
-      return { apiKey: requireEnv('E2B_API_KEY') };
-    case 'vercel':
-      return {
-        token: requireEnv('VERCEL_TOKEN'),
-        teamId: requireEnv('VERCEL_TEAM_ID'),
-        projectId: requireEnv('VERCEL_PROJECT_ID'),
-      };
-    case 'daytona':
-      return { apiKey: requireEnv('DAYTONA_API_KEY') };
-    case 'modal':
-      return {
-        tokenId: requireEnv('MODAL_TOKEN_ID'),
-        tokenSecret: requireEnv('MODAL_TOKEN_SECRET'),
-      };
-    case 'archil':
-      return {
-        apiKey: requireEnv('ARCHIL_API_KEY'),
-        region: requireEnv('ARCHIL_REGION'),
-      };
-    case 'just-bash':
-      return {};
-    default:
-      throw new Error(`Unsupported TEST_PROVIDER: ${String(provider)}`);
-  }
+): Record<string, unknown> {
+  return providerDefinitions[provider].createOptions?.() ?? {};
 }
 
 function createInMemoryFilesystem(): SandboxFileSystem {
@@ -284,7 +710,7 @@ async function runFilesystemAssertions(sandbox: Sandbox): Promise<void> {
   expect(content).toBe('hello from computesdk');
 
   expect(await sandbox.filesystem.exists(testFile)).toBe(true);
-  expect(await sandbox.filesystem.exists('/tmp/computesdk-fs-missing')).toBe(
+  expect(await sandbox.filesystem.exists(`${filesystemBasePath}-missing`)).toBe(
     false
   );
 
@@ -363,10 +789,10 @@ describeIntegration('sandbox filesystem integration', () => {
     const provider = providerFactory(getProviderConfig(testProvider));
     const sdk = compute({ provider });
 
-    const createOptions: Record<string, unknown> = { timeout: 120000 };
-    if (testProvider === 'archil') {
-      createOptions.diskId = requireEnv('ARCHIL_DISK_ID');
-    }
+    const createOptions: Record<string, unknown> = {
+      timeout: 120000,
+      ...getProviderCreateOptions(testProvider),
+    };
 
     sandbox = await sdk.sandbox.create(createOptions as any);
   }, 180000);


### PR DESCRIPTION
Adds a focused filesystem test under `packages/computesdk/src/__tests__/sandbox-filesystem.test.ts` that exercises the full `sandbox.filesystem` surface through the `compute` API.

What changed:
- `packages/computesdk/src/__tests__/sandbox-filesystem.test.ts`
  - Defines an in-memory `SandboxFileSystem` and a matching mock provider so the test runs without API keys by default.
  - Verifies `mkdir`, `writeFile`, `readFile`, `exists`, `readdir`, and `remove` end-to-end through `compute.sandbox.create()`.
  - Asserts that reading a missing file throws.
  - Includes an integration path gated by `COMPUTESDK_INTEGRATION=1` and `TEST_PROVIDER` that loads any supported provider (`e2b`, `vercel`, `daytona`, `modal`, `archil`, `just-bash`) from `packages/<provider>/dist/index.mjs` and runs the same assertions against a live sandbox.

```ts
const sdk = compute({ provider: createInMemoryFilesystemProvider() });
const sandbox = await sdk.sandbox.create();
await sandbox.filesystem.writeFile('/tmp/computesdk-fs-test/hello.txt', 'hello');
const content = await sandbox.filesystem.readFile('/tmp/computesdk-fs-test/hello.txt');
// content === 'hello'
```

Run:
- Unit: `pnpm --filter computesdk test`
- Integration (requires provider env vars and built provider packages):
  ```
  COMPUTESDK_INTEGRATION=1 TEST_PROVIDER=just-bash pnpm --filter computesdk test
  COMPUTESDK_INTEGRATION=1 TEST_PROVIDER=e2b E2B_API_KEY=... pnpm --filter computesdk test
  ```


Link to Devin session: https://app.devin.ai/sessions/9ea2592fa9204db7b37cb728dc270827
Open in Devin Desktop: https://app.devin.ai/desktop/session/9ea2592fa9204db7b37cb728dc270827?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->