### PR TITLE
chore(tenki): bump sandbox sdk to 1.0.3

### DIFF
--- a/.changeset/calm-clouds-run.md
+++ b/.changeset/calm-clouds-run.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/tenki": patch
+---
+
+Update the Tenki sandbox SDK to 1.0.3.

--- a/packages/tenki/package.json
+++ b/packages/tenki/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@tenkicloud/sandbox": "^0.5.4",
+    "@tenkicloud/sandbox": "^1.0.3",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2238,8 +2238,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@tenkicloud/sandbox':
-        specifier: ^0.5.4
-        version: 0.5.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^1.0.3
+        version: 1.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -5441,8 +5441,8 @@ packages:
   '@superserve/sdk@0.7.6':
     resolution: {integrity: sha512-ovJG1hIoOolhMeKUl/j0y8awaexvHFTjYjkk7/HnrN5olpqeHDyLQT++6SJmnL3/94XFd2g2DPvc8VWABlOBqw==}
 
-  '@tenkicloud/sandbox@0.5.4':
-    resolution: {integrity: sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==}
+  '@tenkicloud/sandbox@1.0.3':
+    resolution: {integrity: sha512-4ILe57lRDfwD73yBIG2WcJsqoplWZEa6vJWM4oLLu9EzDQNJo7tzAHKZzY5hdpIhgTVgkAdQn9Ib2fx7YqdAYQ==}
     engines: {node: '>=18'}
 
   '@tigrisdata/storage@3.6.0':
@@ -12779,7 +12779,7 @@ snapshots:
 
   '@superserve/sdk@0.7.6': {}
 
-  '@tenkicloud/sandbox@0.5.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@tenkicloud/sandbox@1.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)


### PR DESCRIPTION
## Summary

Upgrade the Tenki provider from `@tenkicloud/sandbox ^0.5.4` to `^1.0.3`. This keeps ComputeSDK on the current published Tenki client without changing the provider API.

## Testing

- `pnpm build`
- `pnpm --filter @computesdk/tenki run typecheck`
- `pnpm --filter @computesdk/tenki run lint`
- `pnpm --filter @computesdk/tenki run test` (34 tests)