### PR TITLE
chore(tenki): bump sandbox sdk to 1.0.4

### DIFF
--- a/.changeset/quiet-sandboxes-route.md
+++ b/.changeset/quiet-sandboxes-route.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/tenki": patch
+---
+
+Update the Tenki sandbox SDK to 1.0.4.

--- a/packages/tenki/package.json
+++ b/packages/tenki/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@computesdk/provider": "workspace:*",
-    "@tenkicloud/sandbox": "^1.0.3",
+    "@tenkicloud/sandbox": "^1.0.4",
     "computesdk": "workspace:*"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2238,8 +2238,8 @@ importers:
         specifier: workspace:*
         version: link:../provider
       '@tenkicloud/sandbox':
-        specifier: ^1.0.3
-        version: 1.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^1.0.4
+        version: 1.0.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
@@ -5441,8 +5441,8 @@ packages:
   '@superserve/sdk@0.7.6':
     resolution: {integrity: sha512-ovJG1hIoOolhMeKUl/j0y8awaexvHFTjYjkk7/HnrN5olpqeHDyLQT++6SJmnL3/94XFd2g2DPvc8VWABlOBqw==}
 
-  '@tenkicloud/sandbox@1.0.3':
-    resolution: {integrity: sha512-4ILe57lRDfwD73yBIG2WcJsqoplWZEa6vJWM4oLLu9EzDQNJo7tzAHKZzY5hdpIhgTVgkAdQn9Ib2fx7YqdAYQ==}
+  '@tenkicloud/sandbox@1.0.4':
+    resolution: {integrity: sha512-YynN84EEPfm9YeYIX6tMJ/qI2RCp0xmg1W8WIS8VO4df69IRlBaONgVgiak0ZB77hDQhj5nYHnkeEnvWOb+QPg==}
     engines: {node: '>=18'}
 
   '@tigrisdata/storage@3.6.0':
@@ -12779,7 +12779,7 @@ snapshots:
 
   '@superserve/sdk@0.7.6': {}
 
-  '@tenkicloud/sandbox@1.0.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@tenkicloud/sandbox@1.0.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)


### PR DESCRIPTION
## Summary

- Update `@tenkicloud/sandbox` from `^1.0.3` to `^1.0.4`.
- Pick up session-local data-plane endpoint hints so concurrent sessions do not reuse another session's node route.

## Testing

- `pnpm build`
- `pnpm --filter @computesdk/tenki typecheck`
- `pnpm --filter @computesdk/tenki lint`
- `npx -y -p node@20 -p pnpm@9.15.0 pnpm --filter @computesdk/tenki test` (34 tests passed)
