### PR TITLE
givemeanode: surface the API's error message instead of [object Object]

### DIFF
--- a/.changeset/olive-cups-shout.md
+++ b/.changeset/olive-cups-shout.md
@@ -1,0 +1,11 @@
+---
+'@computesdk/givemeanode': patch
+---
+
+Surface the API's error message instead of `[object Object]`.
+
+The door answers a refusal with `{"error": {"code", "message"}}`, but the
+client ran `String()` over that object, so every non-2xx response arrived
+with its explanation discarded. Since the check sits in the shared request
+path, this affected every operation: create, exec, fork, snapshot and
+prepare-image.

--- a/packages/givemeanode/src/__tests__/client.node.test.ts
+++ b/packages/givemeanode/src/__tests__/client.node.test.ts
@@ -252,6 +252,77 @@ describe('refusals', () => {
     )
   })
 
+  it('reads the message out of the structured body the door actually sends', async () => {
+    // The door answers `{"error": {"code", "message"}}`, not a bare
+    // string. Stringifying that object yields `[object Object]` and loses
+    // the one part written to be read - which is how a 422 naming
+    // `sandbox_vcpus` reached a benchmark runner as no reason at all.
+    const { fetchImpl } = stub([
+      {
+        status: 422,
+        body: {
+          error: {
+            code: 'refused',
+            message: 'size sandbox-lg needs 8 vCPU; this org\'s sandbox_vcpus ceiling is 4',
+          },
+        },
+      },
+    ])
+    const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+    await assert.rejects(
+      () => client.request('POST', '/preview/sandboxes', { size: 'sandbox-lg' }),
+      (err: unknown) => {
+        assert.ok(err instanceof GmnError)
+        assert.equal(err.status, 422)
+        assert.match(err.message, /sandbox_vcpus ceiling is 4/)
+        assert.match(err.message, /refused/)
+        assert.doesNotMatch(err.message, /\[object Object\]/)
+        return true
+      },
+    )
+  })
+
+  it('falls back to the code when the body carries no message', async () => {
+    const { fetchImpl } = stub([{ status: 403, body: { error: { code: 'forbidden' } } }])
+    const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+    await assert.rejects(
+      () => client.request('GET', '/preview/sandboxes'),
+      (err: unknown) => {
+        assert.ok(err instanceof GmnError)
+        assert.match(err.message, /forbidden/)
+        assert.doesNotMatch(err.message, /\[object Object\]/)
+        return true
+      },
+    )
+  })
+
+  it('shows an unrecognised error body as JSON rather than as [object Object]', async () => {
+    const { fetchImpl } = stub([{ status: 500, body: { error: { unexpected: 'shape' } } }])
+    const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+    await assert.rejects(
+      () => client.request('GET', '/preview/sandboxes'),
+      (err: unknown) => {
+        assert.ok(err instanceof GmnError)
+        assert.match(err.message, /unexpected/)
+        assert.doesNotMatch(err.message, /\[object Object\]/)
+        return true
+      },
+    )
+  })
+
+  it('keeps the whole body on the error for a caller that wants to branch on it', async () => {
+    const { fetchImpl } = stub([{ status: 422, body: { error: { code: 'refused', message: 'no' } } }])
+    const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+    await assert.rejects(
+      () => client.request('POST', '/preview/sandboxes', {}),
+      (err: unknown) => {
+        assert.ok(err instanceof GmnError)
+        assert.deepEqual(err.body, { error: { code: 'refused', message: 'no' } })
+        return true
+      },
+    )
+  })
+
   it('names the environment variable when no credential was given', () => {
     const saved = process.env.GMN_TOKEN
     delete process.env.GMN_TOKEN

--- a/packages/givemeanode/src/client.ts
+++ b/packages/givemeanode/src/client.ts
@@ -120,6 +120,38 @@ export function resetFastTokenCache(): void {
   priming.clear()
 }
 
+/**
+ * The readable half of a refusal.
+ *
+ * The door answers a refusal with `{"error": {"code", "message"}}`, and
+ * the `message` is written to be read - it names the limit that refused,
+ * or the alternative that should have been passed instead. Stringifying
+ * the object loses exactly that, so a 422 that explained itself arrives as
+ * `[object Object]` and the caller has to reconstruct from the outside
+ * what the door already said.
+ *
+ * The string form is still accepted because older deployments answer that
+ * way, and an unrecognised shape falls back to its JSON rather than to
+ * `[object Object]`: a body we cannot read is still worth showing.
+ */
+function refusalDetail(parsed: unknown, text: string): string {
+  const fallback = () => text.slice(0, 400)
+  if (!parsed || typeof parsed !== 'object' || !('error' in parsed)) return fallback()
+  const error = (parsed as { error: unknown }).error
+  if (typeof error === 'string') return error || fallback()
+  if (!error || typeof error !== 'object') return fallback()
+  const { code, message } = error as { code?: unknown; message?: unknown }
+  const hasMessage = typeof message === 'string' && message !== ''
+  const hasCode = typeof code === 'string' && code !== ''
+  if (hasMessage) return hasCode ? `${code}: ${message}` : (message as string)
+  if (hasCode) return code as string
+  try {
+    return JSON.stringify(error)?.slice(0, 400) ?? fallback()
+  } catch {
+    return fallback()
+  }
+}
+
 export class GmnError extends Error {
   readonly status: number
   readonly body: unknown
@@ -339,10 +371,7 @@ export class GmnClient {
       }
     }
     if (!response.ok) {
-      const detail =
-        parsed && typeof parsed === 'object' && 'error' in parsed
-          ? String((parsed as { error: unknown }).error)
-          : text.slice(0, 400)
+      const detail = refusalDetail(parsed, text)
       throw new GmnError(
         `givemeanode ${method} ${path} failed (${response.status}): ${detail}`,
         response.status,


### PR DESCRIPTION
Fixes #754.

## The bug

`GmnClient.attempt` assumed the API's `error` field is a string. It isn't — the door answers a refusal with a structured body:

```json
{ "error": { "code": "refused", "message": "teaching text explaining the constraint" } }
```

`String()` over that object yields `[object Object]`, so **every non-2xx response from this provider produced an unreadable error**. Because the check lives in the shared `attempt()` path, it hit every operation — create, exec, fork, snapshot, prepare-image.

The `message` is precisely the part written to be read: it names the limit that refused, or the alternative that should have been passed instead. That was the one part being discarded.

## How it turned up

A `computesdk/benchmarks` DAX run failed with a message naming no cause:

```
givemeanode POST /preview/sandboxes failed (422): [object Object]
```

Working out what the door had actually said meant reading the provider's request builder, the API docs, and the org's limits from the operator side. The real answer: the run asked for `size: "sandbox-lg"` (8 vCPU) and the org's `sandbox_vcpus` ceiling was 4. The 422 had said so in `error.message` all along.

## The fix

A `refusalDetail()` helper that prefers `error.message` (prefixed with `error.code` when both are present), still accepts the bare-string form for older deployments, and falls back to the body's JSON rather than `[object Object]` for an unrecognised shape. `GmnError.body` keeps the whole parsed body, unchanged, for callers that want to branch on `code`.

## Why it survived this long

Every existing test in the `refusals` block used `{ error: 'a string' }` — the one shape the door does not send. So the tests passed while the real path was broken.

The four added cases cover the structured body, the code-only body, an unrecognised shape, and the preserved `body`. Three of them fail against the old line, verified by reverting it:

```
not ok 2 - reads the message out of the structured body the door actually sends
not ok 3 - falls back to the code when the body carries no message
not ok 4 - shows an unrecognised error body as JSON rather than as [object Object]
# tests 25   # pass 22   # fail 3
```

With the fix: `# tests 25  # pass 25  # fail 0`.

Note: I ran the suite via `tsx --test` rather than the package's `test:node` script, because the Node build on this machine was compiled without type stripping (`node_use_amaro: false`). Same tests, same runner, different loader.

## Not addressed here

The API returns a `request-id` header on refusals that `GmnError` still drops. Worth surfacing for support round-trips, but it changes the error's shape, so I left it out of a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->