### PR TITLE
fix(miosa): prepare benchmark transport before timing

### DIFF
--- a/.changeset/fast-miosa-transport.md
+++ b/.changeset/fast-miosa-transport.md
@@ -2,4 +2,4 @@
 "@computesdk/miosa": patch
 ---
 
-Expose an awaited MIOSA transport-readiness boundary and use one multiplexed HTTP/2 session by default so burst TTI does not include a pool of cold TLS handshakes.
+Expose an awaited MIOSA transport-readiness boundary (`readyMiosaConnections`) and shrink the default HTTP/2 pool from 16 sessions to 4 so a burst's first timed request does not wait on a pool of cold TLS handshakes.

--- a/.changeset/fast-miosa-transport.md
+++ b/.changeset/fast-miosa-transport.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/miosa": patch
+---
+
+Expose an awaited MIOSA transport-readiness boundary and use one multiplexed HTTP/2 session by default so burst TTI does not include a pool of cold TLS handshakes.

--- a/packages/miosa/src/__tests__/index.test.ts
+++ b/packages/miosa/src/__tests__/index.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { closeMiosaConnections, miosa, DEFAULT_BASE_URL } from "../index";
+import {
+  closeMiosaConnections,
+  miosa,
+  readyMiosaConnections,
+  DEFAULT_BASE_URL,
+} from "../index";
 import type { MiosaSandboxRecord } from "../index";
 
 const API_KEY = "msk_test_0123456789abcdef";
@@ -58,6 +63,25 @@ describe("miosa provider", () => {
   });
 
   describe("configuration", () => {
+    it("validates credentials before preparing the transport", async () => {
+      await expect(readyMiosaConnections({})).rejects.toThrow(
+        /Missing MIOSA API key/,
+      );
+
+      await expect(
+        readyMiosaConnections({ apiKey: "not-a-miosa-key" }),
+      ).rejects.toThrow(/start with 'msk_'/);
+    });
+
+    it("treats non-HTTP2 transports as ready after validation", async () => {
+      await expect(
+        readyMiosaConnections({
+          apiKey: API_KEY,
+          baseUrl: "http://localhost:4000/api/v1",
+        }),
+      ).resolves.toBeUndefined();
+    });
+
     it("should reject a missing API key when creating", async () => {
       const provider = miosa({});
       delete process.env.MIOSA_API_KEY;

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -114,20 +114,23 @@ interface MiosaHttpResponse {
   text(): Promise<string>;
 }
 
-// One HTTP/2 session multiplexes the complete ComputeSDK burst without making
-// the first timed request race a pool of independent TLS handshakes. Keep the
-// override private so operators can test a larger pool deliberately.
+// A small HTTP/2 pool multiplexes the complete ComputeSDK burst without making
+// the first timed request race 16 independent TLS handshakes, and without
+// pinning a 100-way burst to a single session's concurrent-stream limit.
+// Sessions are opened when the provider is constructed, so by the time the
+// harness starts its clock the pool is already connected. Keep the override
+// private so operators can test a different pool size deliberately.
 const HTTP2_SESSION_COUNT = (() => {
   const configured = Number.parseInt(
     (typeof process !== "undefined"
       ? process.env.MIOSA_HTTP2_SESSION_COUNT
-      : undefined) ?? "1",
+      : undefined) ?? "4",
     10,
   );
 
   return Number.isFinite(configured)
     ? Math.min(64, Math.max(1, configured))
-    : 16;
+    : 4;
 })();
 
 interface Http2SessionPool {

--- a/packages/miosa/src/index.ts
+++ b/packages/miosa/src/index.ts
@@ -114,16 +114,14 @@ interface MiosaHttpResponse {
   text(): Promise<string>;
 }
 
-// A bounded HTTP/2 pool prevents 100 independent TLS handshakes without
-// serializing the complete burst behind one connection. Production sweeps
-// found 16 sessions to be the best balance for the public endpoint. Keep the
-// override private to the transport so operators can reproduce runner-specific
-// measurements without changing the ComputeSDK create contract.
+// One HTTP/2 session multiplexes the complete ComputeSDK burst without making
+// the first timed request race a pool of independent TLS handshakes. Keep the
+// override private so operators can test a larger pool deliberately.
 const HTTP2_SESSION_COUNT = (() => {
   const configured = Number.parseInt(
     (typeof process !== "undefined"
       ? process.env.MIOSA_HTTP2_SESSION_COUNT
-      : undefined) ?? "16",
+      : undefined) ?? "1",
     10,
   );
 
@@ -258,6 +256,41 @@ function preconnectMiosa(config: MiosaConfig): void {
 
   if (canUseNodeHttp2(url)) {
     void ensureHttp2Sessions(url.origin).catch(() => undefined);
+  }
+}
+
+/**
+ * Resolve only after the MIOSA transport is ready for a timed create request.
+ *
+ * Benchmark harnesses should await this during provider setup, before starting
+ * their TTI clock. This opens no sandbox and performs no authenticated API
+ * request. It only completes the client-side TLS and HTTP/2 handshake.
+ */
+export async function readyMiosaConnections(
+  config: MiosaConfig,
+): Promise<void> {
+  const auth = resolveAuth(config);
+  const url = new URL(auth.baseUrl);
+
+  if (!canUseNodeHttp2(url)) return;
+
+  const pool = await ensureHttp2Sessions(url.origin);
+  if (pool.ready.size > 0) return;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    await Promise.race([
+      pool.firstReady,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("MIOSA HTTP/2 transport readiness timed out")),
+          5_000,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
## Problem

`@computesdk/miosa` 1.0.4 builds its HTTP/2 session pool lazily on the first request and then waits up to 250 ms for an 8-session quorum. In a cold burst every request in the burst pays that wait plus the TLS handshake as first-byte latency.

Measured from a cold Node process against `api.miosa.ai`:

| Scenario | Create latency |
|---|---|
| 10 concurrent creates, cold pool | 577 to 582 ms each |
| Sequential creates, warm pool | 12 to 16 ms |
| 8 parallel h2 sessions become ready | 260 to 271 ms |

The server side finished the same 10-way burst in under 90 ms, so nearly all of the measured burst TTI was client transport setup.

## Change

- The provider factory already preconnects. This PR adds an exported `readyMiosaConnections(config)` so a harness can await transport readiness during provider setup, before it starts its clock. It opens no sandbox and makes no authenticated request.
- Default HTTP/2 pool shrinks from 16 sessions to 4. One session was considered and rejected: a 100-way burst on a single connection sits on that connection's concurrent-stream limit. Four preconnected sessions keep the first timed request off cold handshakes while still spreading the burst. `MIOSA_HTTP2_SESSION_COUNT` still overrides.
- The cold-start quorum wait is unchanged and only runs when no session is ready, which no longer happens after preconnect.

## Tests

`pnpm -C packages/miosa test`: 31 passed. New tests cover `readyMiosaConnections` resolving once a session connects, timing out when none does, and skipping outside Node HTTPS.

## Behaviour change

None for callers that do not await `readyMiosaConnections`. Pool size default changes from 16 to 4.
