### PR TITLE
chore(freestyle): update SDK to 0.2.11

### DIFF
--- a/.changeset/tidy-freestyle-sdk.md
+++ b/.changeset/tidy-freestyle-sdk.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/freestyle": patch
+---
+
+Update the Freestyle SDK dependency to ^0.2.11.

--- a/packages/freestyle/package.json
+++ b/packages/freestyle/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "freestyle": "^0.2.7",
+    "freestyle": "^0.2.11",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1020,8 +1020,8 @@ importers:
         specifier: workspace:*
         version: link:../computesdk
       freestyle:
-        specifier: ^0.2.7
-        version: 0.2.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^0.2.11
+        version: 0.2.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -6838,8 +6838,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  freestyle@0.2.7:
-    resolution: {integrity: sha512-fTISd4+LyrGB1so1HNhtbfUSaqbMue95lu9Pov7xap3WPNC+NLsXATwpsYuy7dJa7pcj/qIum/aXGgUSV+/CPg==}
+  freestyle@0.2.11:
+    resolution: {integrity: sha512-nZuWvjMH/Yjnf//DYl6Do0rNNr+wtNPT/c8AvZNzRaTZI4cifK05JU3g22onncu5Fwnr2ytV+LtwpC/vFlifMw==}
     hasBin: true
 
   fresh@2.0.0:
@@ -14608,11 +14608,13 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  freestyle@0.2.7(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  freestyle@0.2.11(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       dotenv: 17.4.2
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yargs: 17.7.2
+    optionalDependencies:
+      undici: 8.3.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
The Freestyle provider was locked to SDK 0.2.7. Update its dependency to `^0.2.11` and the lockfile to 0.2.11, the latest published release, and add a patch changeset for `@computesdk/freestyle`.

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter @computesdk/freestyle typecheck`
- `env -u FREESTYLE_API_KEY pnpm --filter @computesdk/freestyle test` — 14 passed, 1 skipped; mock mode, no live VM integration tests.
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->