### PR TITLE
givemeanode: default fastToken to 'prime'

### DIFF
--- a/.changeset/givemeanode-prime-default.md
+++ b/.changeset/givemeanode-prime-default.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/givemeanode": minor
+---
+
+`fastToken` now defaults to `prime`: one cheap, single-flighted warm-up request per process, so even the first creates of a burst present the signed credential instead of each paying the authentication read. Pass `fastToken: 'absorb'` to keep the previous behaviour (no extra request; the first request pays the ordinary cost).

--- a/docs/providers/givemeanode.md
+++ b/docs/providers/givemeanode.md
@@ -73,7 +73,7 @@ await sandbox.destroy()
 |---|---|---|---|
 | `apiKey` | `string` | `GMN_TOKEN` | The `gmnt_` org service token. |
 | `baseUrl` | `string` | `GMN_API_HOST`, else `https://api.givemeanode.com` | Which regional endpoint to use. |
-| `fastToken` | `'absorb' \| 'prime' \| 'off'` | `'absorb'` | How to use the signed credential. |
+| `fastToken` | `'prime' \| 'absorb' \| 'off'` | `'prime'` | How to use the signed credential. |
 | `ramGib` | `number` | `2` | Guest memory in GiB. |
 | `egress` | `'open' \| 'none'` | account default | Whether the guest can reach the network. |
 | `execRetries` | `number` | `1` | Retries for an undelivered command. |
@@ -121,17 +121,21 @@ else as a curated name.
 
 Authenticating a request costs a round trip that presenting a signed
 credential does not. givemeanode hands one back on the response to any
-request made with your token, and this provider absorbs and presents it
-automatically: nothing to configure, nothing new to store, no extra round
-trip, and a fallback to the ordinary token on any failure.
+request made with your token, and this provider presents it automatically:
+nothing to configure, nothing new to store, and a fallback to the ordinary
+token on any failure.
 
-Set `fastToken: 'prime'` when you start many sandboxes at once, so the
-burst does not send every one of them down the ordinary path:
+By default (`fastToken: 'prime'`) the provider pays one small warm-up
+request per process, single-flighted, so even the first creates of a burst
+present the credential rather than each paying the authentication read.
+Set `fastToken: 'absorb'` for a process that makes one request and exits:
+no warm-up, the first request pays the ordinary cost, and its response
+carries the credential for everything after it.
 
 ```typescript
 const compute = givemeanode({
   apiKey: process.env.GMN_TOKEN,
-  fastToken: 'prime',
+  fastToken: 'absorb',
 })
 ```
 

--- a/packages/givemeanode/README.md
+++ b/packages/givemeanode/README.md
@@ -44,7 +44,7 @@ await sandbox.destroy()
 |---|---|---|---|
 | `apiKey` | `string` | `GMN_TOKEN` | The `gmnt_` org service token. |
 | `baseUrl` | `string` | `GMN_API_HOST`, else `https://api.givemeanode.com` | Which regional endpoint to use. |
-| `fastToken` | `'absorb' \| 'prime' \| 'off'` | `'absorb'` | See below. |
+| `fastToken` | `'prime' \| 'absorb' \| 'off'` | `'prime'` | See below. |
 | `ramGib` | `number` | 2 | Guest memory. `memoryMiB` / `memMiB` on `create` are read too and rounded up to whole GiB; `memory` is decimal MB, per the shared options. |
 | `egress` | `'open' \| 'none'` | account default | Whether the guest can reach the network. Fixed when the guest image is prepared, not per command. |
 | `execRetries` | `number` | 1 | See "Two behaviours worth knowing about". |
@@ -149,20 +149,28 @@ than not having one.
 
 Three modes, because the right one depends on your shape:
 
-- **`absorb`** (default) never adds a round trip. Your first request pays
-  the ordinary cost, its response carries the credential, and everything
-  after it is cheaper.
-- **`prime`** pays one cheap request up front, single-flighted across every
-  caller sharing the token. Use it when you start **N sandboxes at once**:
-  without it, all N take the ordinary path.
+- **`prime`** (default) pays one cheap request up front, single-flighted
+  across every caller sharing the token, so even the first creates of a
+  burst present the credential. When you start **N sandboxes at once** this
+  is one authentication read instead of N queued behind each other; for a
+  single create it is one small request before it and the same read saved
+  inside it, so close to free.
+- **`absorb`** never adds a round trip. Your first request pays the
+  ordinary cost, its response carries the credential, and everything after
+  it is cheaper. Pick it for a process that makes one request and exits.
 - **`off`** never presents one.
 
 ```typescript
 const compute = givemeanode({
   apiKey: process.env.GMN_TOKEN,
-  fastToken: 'prime', // starting a burst
+  fastToken: 'absorb', // one request, then exit
 })
 ```
+
+The default was `absorb` through 1.0.x and is `prime` from 1.1.0: measured
+at 100 concurrent creates against the us-east door, `absorb` had every
+create paying the authentication read, about 600 ms of a 767 ms create
+leg, all of it that read queued.
 
 What it costs, stated plainly: a signed credential is valid for its own
 lifetime regardless of what happens to the token behind it, so `gman token

--- a/packages/givemeanode/src/__tests__/client.node.test.ts
+++ b/packages/givemeanode/src/__tests__/client.node.test.ts
@@ -130,6 +130,25 @@ describe('the signed credential the door hands back', () => {
     await client.request('GET', '/preview/sandboxes')
     assert.equal(calls[1].authorization, `Bearer ${KEY}`)
   })
+
+  it('primes by default, so even the first create of a burst presents the credential', async () => {
+    // The default moved from `absorb` to `prime` in 1.1.0. Under `absorb`
+    // every create in a cold burst paid the authentication read; the door
+    // measured that at ~600 ms of a 767 ms create at N=100. One warm-up
+    // request, single-flighted, and the creates that follow are signed.
+    const { calls, fetchImpl } = stub([
+      { body: { sandboxes: [] }, headers: vending(600_000) },
+      { body: { sandbox: 'sbx-1' } },
+    ])
+    const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+    assert.equal(client.fastToken, 'prime')
+    await client.prime()
+    assert.equal(calls.length, 1, 'the prime is one request')
+    assert.equal(calls[0].method, 'GET')
+    assert.equal(calls[0].authorization, `Bearer ${KEY}`, 'the warm-up pays the ordinary cost')
+    await client.request('POST', '/preview/sandboxes', {})
+    assert.equal(calls[1].authorization, `Bearer ${SIGNED}`, 'the first create is already signed')
+  })
 })
 
 describe('the cache key, which is what makes a per-task runner benefit', () => {
@@ -199,9 +218,16 @@ describe('priming, for the burst that starts N sandboxes at once', () => {
     assert.equal(client.hasFastToken(), true)
   })
 
-  it('adds no round trip at all in the default mode', async () => {
+  it('adds no round trip at all in absorb mode', async () => {
+    // The mode for a process that makes one request and exits: nothing is
+    // sent until the caller's own first request.
     const { calls, fetchImpl } = stub([{ body: {} }])
-    const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+    const client = new GmnClient({
+      apiKey: KEY,
+      baseUrl: 'https://door.test',
+      fastToken: 'absorb',
+      fetch: fetchImpl,
+    })
     await client.prime()
     assert.equal(calls.length, 0)
   })

--- a/packages/givemeanode/src/__tests__/operations.node.test.ts
+++ b/packages/givemeanode/src/__tests__/operations.node.test.ts
@@ -36,7 +36,10 @@ function door(handler: (method: string, path: string, body: any) => { status?: n
       headers: { 'content-type': 'application/json' },
     })
   }) as unknown as typeof fetch
-  const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fetch: fetchImpl })
+  // `absorb`, not the `prime` default: these cases pin the exact requests an
+  // operation sends, and the warm-up `prime` adds is the client's business,
+  // covered in client.node.test.ts.
+  const client = new GmnClient({ apiKey: KEY, baseUrl: 'https://door.test', fastToken: 'absorb', fetch: fetchImpl })
   return { sent, client }
 }
 

--- a/packages/givemeanode/src/client.ts
+++ b/packages/givemeanode/src/client.ts
@@ -65,16 +65,24 @@ export const DEFAULT_BASE_URL = 'https://api.givemeanode.com'
 /**
  * How this client treats the offer of a signed credential.
  *
- * - `absorb` (default): use a signed credential whenever one has been
- *   handed to us, and never add a round trip to get one. The first request
- *   of a process pays the ordinary cost, its response carries the
- *   credential, and every request after it - including the command that
- *   follows that very first create - is cheaper.
- * - `prime`: pay ONE cheap authenticated request per token, up front and
- *   single-flighted, so even the first burst's creates are cheap. Right
- *   when N sandboxes start at once, because otherwise all N take the
- *   ordinary path.
+ * - `prime` (default): pay ONE cheap authenticated request per token, up
+ *   front and single-flighted, so even the first burst's creates present
+ *   the signed credential. When N sandboxes start at once this is the
+ *   difference between one authentication read and N of them queued behind
+ *   each other; for a single create it costs one small request before it
+ *   and saves the same read inside it, so it is close to free.
+ * - `absorb`: never add a round trip to get one. The first request of a
+ *   process pays the ordinary cost, its response carries the credential,
+ *   and every request after it - including the command that follows that
+ *   very first create - is cheaper. The right choice when a process makes
+ *   one request and exits.
  * - `off`: never present a signed credential.
+ *
+ * The default was `absorb` through 1.0.x. It moved to `prime` because the
+ * shape this package is mostly used in is N creates at once from a cold
+ * process, and under `absorb` every one of those N paid the authentication
+ * read - measured at ~600 ms of a 767 ms create at N=100 against the
+ * us-east door, all of it that read queued.
  */
 export type FastTokenMode = 'absorb' | 'prime' | 'off'
 
@@ -83,7 +91,7 @@ export interface GmnClientOptions {
   apiKey?: string
   /** Base URL. Falls back to `GMN_API_HOST`, then the public endpoint. */
   baseUrl?: string
-  /** See {@link FastTokenMode}. Default `absorb`. */
+  /** See {@link FastTokenMode}. Default `prime`. */
   fastToken?: FastTokenMode
   /** Per-request timeout in ms. Default 120000. */
   timeout?: number
@@ -213,7 +221,7 @@ export class GmnClient {
     this.baseUrl = requireSecureBaseUrl(
       (options.baseUrl ?? process.env.GMN_API_HOST ?? DEFAULT_BASE_URL).replace(/\/+$/, ''),
     )
-    this.fastToken = options.fastToken ?? 'absorb'
+    this.fastToken = options.fastToken ?? 'prime'
     this.timeout = options.timeout ?? 120_000
     this.doFetch = options.fetch ?? globalThis.fetch
     // A NUL cannot appear in a URL or in a bearer token, so no pair of


### PR DESCRIPTION
Under 'absorb' every create in a cold burst paid the authentication read and queued for it: ~600 ms of a 767 ms create leg at 100 concurrent creates against the us-east door. 'prime' pays one small, single-flighted warm-up per process and every create after it presents the signed credential; for a single create it adds one small request and saves the same read inside it. 'absorb' stays available for a one-request process. README, provider doc, tests and a minor changeset included.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->