### PR TITLE
feat: add Buddy provider

### DIFF
--- a/.changeset/buddy-provider.md
+++ b/.changeset/buddy-provider.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/buddy": patch
+---
+
+Add the Buddy provider: Ubuntu sandboxes served from Buddy's pre-warmed pool, with streamed command output, native filesystem endpoints, public tunnels via `getUrl`, and snapshots doubling as templates. Built on `@buddy-works/sandbox-sdk`.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Install the provider packages you need and pass their instances into `compute.se
 npm install @computesdk/archil           # Archil provider
 npm install @computesdk/beam             # Beam provider
 npm install @computesdk/blaxel           # Blaxel provider
+npm install @computesdk/buddy            # Buddy provider
 npm install @computesdk/cloud-run        # Google Cloud Run provider
 npm install @computesdk/cloudflare       # Cloudflare provider
 npm install @computesdk/codesandbox      # CodeSandbox provider
@@ -332,6 +333,7 @@ See individual provider READMEs for details:
 - **[@computesdk/archil](./packages/archil)** - Disk-attached command-execution sandboxes
 - **[@computesdk/beam](./packages/beam)** - Serverless cloud sandboxes
 - **[@computesdk/blaxel](./packages/blaxel)** - Agent sandboxes with custom images
+- **[@computesdk/buddy](./packages/buddy)** - Ubuntu sandboxes from a pre-warmed pool, with tunnels and snapshots
 - **[@computesdk/cloud-run](./packages/cloud-run)** - Google Cloud Run sandboxes
 - **[@computesdk/cloudflare](./packages/cloudflare)** - Edge computing sandboxes
 - **[@computesdk/codesandbox](./packages/codesandbox)** - Collaborative development

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Providers are platforms that provide sandboxes. Each package under `@computesdk/
 | `@computesdk/archil`           | Archil       |
 | `@computesdk/beam`             | Beam         |
 | `@computesdk/blaxel`           | Blaxel       |
+| `@computesdk/buddy`            | Buddy        |
 | `@computesdk/cloud-run`        | Cloud Run    |
 | `@computesdk/cloudflare`       | Cloudflare   |
 | `@computesdk/codesandbox`      | CodeSandbox  |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
   * [Archil](providers/archil.md)
   * [Beam](providers/beam.md)
   * [Blaxel](providers/blaxel.md)
+  * [Buddy](providers/buddy.md)
   * [Cloud Run](providers/cloud-run.md)
   * [Cloudflare](providers/cloudflare.md)
   * [CodeSandbox](providers/codesandbox.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,6 +8,7 @@ Install the provider package for the platform you want to use:
 # Pick one (or more) providers
 npm install @computesdk/archil
 npm install @computesdk/blaxel
+npm install @computesdk/buddy
 npm install @computesdk/cloudflare
 npm install @computesdk/codesandbox
 npm install @computesdk/daytona
@@ -39,6 +40,13 @@ ARCHIL_DISK_ID=your_archil_disk_id
 ```bash
 BL_API_KEY=your_blaxel_api_key
 BL_WORKSPACE=your_blaxel_workspace
+```
+
+### Buddy
+```bash
+BUDDY_TOKEN=your_buddy_api_token
+BUDDY_WORKSPACE=your_buddy_workspace_domain
+BUDDY_PROJECT=your_buddy_project_name
 ```
 
 ### Cloudflare

--- a/docs/providers/buddy.md
+++ b/docs/providers/buddy.md
@@ -1,0 +1,187 @@
+---
+description: >-
+  Install and use the Buddy provider for ComputeSDK: Ubuntu sandboxes from a
+  pre-warmed pool, public tunnels, native filesystem endpoints and snapshots.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# Buddy
+
+Buddy provider for ComputeSDK.
+
+Each sandbox is an Ubuntu microVM in your Buddy project, served from a pre-warmed pool. The provider is built on [`@buddy-works/sandbox-sdk`](https://www.npmjs.com/package/@buddy-works/sandbox-sdk), Buddy's official TypeScript SDK.
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/buddy
+```
+
+Node 20.19 or newer is required, because the Buddy SDK ships ESM only.
+
+1. Create an API token in **Buddy → My ID → Access tokens** with the `SANDBOX_MANAGE` scope
+2. Create (or pick) a Buddy project for your sandboxes
+3. Set environment variables:
+
+```bash
+export BUDDY_TOKEN=your_api_token_here
+export BUDDY_WORKSPACE=your_workspace_domain
+export BUDDY_PROJECT=your_project_name
+```
+
+## Usage
+
+```typescript
+import { compute } from 'computesdk';
+import { buddy } from '@computesdk/buddy';
+
+compute.setConfig({ provider: buddy() });
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('echo "hello from buddy"');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+Credentials come from the environment, so `buddy()` needs no arguments. Pass them explicitly to override.
+
+### Configuration Options
+
+```typescript
+buddy({
+  token: process.env.BUDDY_TOKEN,   // API token with the SANDBOX_MANAGE scope
+  workspace: 'acme',                // workspace domain
+  project: 'sandboxes',             // project the sandboxes belong to
+  os: 'ubuntu:24.04',               // or 'ubuntu:22.04'
+  resources: '4x8',                 // vCPU x RAM preset, 1x2 through 12x24
+  region: 'US',                     // installation: 'US', 'EU' or 'AS'
+  timeout: 3_600_000,               // sandbox lifetime in ms
+  ports: [3000],                    // ports exposed on every sandbox
+  apiUrl: undefined,                // overrides region, for on-premise
+});
+```
+
+### Choosing an installation
+
+Buddy runs independent installations rather than regions within one API, each with its own host, accounts and tokens. `region` selects both the API host and where tunnels terminate.
+
+| `region`       | API host                       |
+| -------------- | ------------------------------ |
+| `US` (default) | `https://api.buddy.works`      |
+| `EU`           | `https://api.eu.buddy.works`   |
+| `AS`           | `https://api.asia.buddy.works` |
+
+A token issued by one installation is not valid on the others.
+
+### Create options
+
+```typescript
+await compute.sandbox.create({
+  ports: [3000, { port: 443, type: 'TLS' }],
+  resources: '4x8',                  // or cpu / memory, which map onto a preset
+  firstBootCommands: 'npm ci',       // runs once, when the sandbox first boots
+  appDir: '/buddy/app',
+  tags: ['ci'],
+  snapshotId: 'snapshot-id',         // boot from a snapshot instead of a base image
+});
+```
+
+## Commands
+
+```typescript
+const result = await sandbox.runCommand('npm test', {
+  cwd: '/buddy/app',
+  env: { CI: '1' },
+  onStdout: chunk => process.stdout.write(chunk),
+});
+```
+
+Output is streamed as the command runs, with stdout and stderr kept apart, and `exitCode` comes from Buddy's own command record. `background: true` returns as soon as the command is queued; `timeout` terminates it.
+
+## Exposing Ports
+
+```typescript
+const sandbox = await compute.sandbox.create({ ports: [3000] });
+await sandbox.runCommand('npx serve -l 3000', { background: true });
+
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+`getUrl` opens a tunnel on demand if the port has none, keeping tunnels that are already open. Only `HTTP` and `TLS` tunnels get a public URL; `TCP` and `SSH` tunnels are reached by host and port, reported in `getInfo`.
+
+## Filesystem
+
+```typescript
+await sandbox.filesystem.mkdir('/buddy/app');
+await sandbox.filesystem.writeFile('/buddy/app/index.js', 'console.log(1)');
+await sandbox.filesystem.readFile('/buddy/app/index.js');
+await sandbox.filesystem.readdir('/buddy/app');
+await sandbox.filesystem.exists('/buddy/app/index.js');
+await sandbox.filesystem.remove('/buddy/app');
+```
+
+Filesystem calls go through Buddy's content endpoints rather than the shell, so they are binary-safe and cost one round trip each. Relative paths resolve against `/buddy`, the home directory of the default `buddy` user.
+
+The first filesystem call on a sandbox waits for first-boot setup to finish. Buddy queues *commands* against a starting sandbox, but the content endpoints do not: during setup they either refuse the request or accept a write and discard it. The wait costs a few hundred milliseconds once per sandbox.
+
+## Snapshots
+
+```typescript
+const snapshot = await compute.snapshot.create(sandbox.sandboxId, { name: 'with-deps' });
+
+await compute.snapshot.list();
+await compute.snapshot.list({ sandboxId: sandbox.sandboxId });
+await compute.snapshot.delete(snapshot.id);
+
+const prepared = await compute.sandbox.create({ snapshotId: snapshot.id });
+```
+
+Buddy creates snapshots asynchronously and they cannot be restored until they turn `CREATED`, so `create` waits for that. Buddy has no separate template entity, so `compute.template.list` and `compute.template.delete` alias the snapshot methods, and `compute.template.create` throws with a pointer to `compute.snapshot.create`.
+
+## Dropping down to the Buddy SDK
+
+`getInstance()` returns the provider's handle, including the live SDK client and filesystem, so Buddy features outside the ComputeSDK surface stay reachable:
+
+```typescript
+const { client, fs, sandboxId } = sandbox.getInstance();
+await client.startSandboxApp({ path: { sandbox_id: sandboxId, app_id: 'web' } });
+```
+
+## Supported Operations
+
+| Method       | Supported | Notes                                                                                       |
+| ------------ | --------- | ------------------------------------------------------------------------------------------- |
+| `create`     | ✅         | One request; returns while the sandbox is still starting, since commands queue against it.   |
+| `getById`    | ✅         | Returns `null` when the sandbox no longer exists.                                            |
+| `list`       | ✅         | Lists the sandboxes in the configured project.                                               |
+| `destroy`    | ✅         | Retries on server errors; a no-op if the sandbox is already gone.                            |
+| `runCommand` | ✅         | Streams stdout and stderr separately, with real exit codes.                                  |
+| `getInfo`    | ✅         | Reports Buddy's status, setup status and every tunnel in `metadata`.                          |
+| `getUrl`     | ✅         | Opens a tunnel if the port has none yet, keeping the existing ones.                          |
+| `filesystem` | ✅         | Native content endpoints — binary-safe, one round trip each.                                 |
+| `snapshot`   | ✅         | `create` / `list` / `delete`; `create` waits until the snapshot is restorable.                |
+| `template`   | ⚠️        | No template entity in Buddy — `list`/`delete` alias snapshots, `create` throws with a hint.  |
+
+## Notes
+
+- `create` does not wait for the sandbox to reach `RUNNING`, because Buddy queues commands submitted against a starting sandbox. For the same reason the provider calls the SDK's `BuddyApiClient` directly instead of `Sandbox.create()`, which polls for readiness once a second.
+- Sandbox placement inside an installation is not selectable; `region` picks the installation and the tunnel location.

--- a/docs/providers/buddy.md
+++ b/docs/providers/buddy.md
@@ -73,7 +73,7 @@ buddy({
   project: 'sandboxes',             // project the sandboxes belong to
   os: 'ubuntu:24.04',               // or 'ubuntu:22.04'
   resources: '4x8',                 // vCPU x RAM preset, 1x2 through 12x24
-  region: 'US',                     // installation: 'US', 'EU' or 'AS'
+  region: 'US',                     // installation: 'US' or 'EU'      
   timeout: 3_600_000,               // sandbox lifetime in ms
   ports: [3000],                    // ports exposed on every sandbox
   apiUrl: undefined,                // overrides region, for on-premise
@@ -88,7 +88,6 @@ Buddy runs independent installations rather than regions within one API, each wi
 | -------------- | ------------------------------ |
 | `US` (default) | `https://api.buddy.works`      |
 | `EU`           | `https://api.eu.buddy.works`   |
-| `AS`           | `https://api.asia.buddy.works` |
 
 A token issued by one installation is not valid on the others.
 

--- a/docs/providers/buddy.md
+++ b/docs/providers/buddy.md
@@ -138,7 +138,7 @@ await sandbox.filesystem.exists('/buddy/app/index.js');
 await sandbox.filesystem.remove('/buddy/app');
 ```
 
-Filesystem calls go through Buddy's content endpoints rather than the shell, so content is never squeezed through command-line quoting and each call costs one round trip. As with every provider, `readFile` and `writeFile` handle UTF-8 text; use `getInstance().fs` for raw bytes. Relative paths resolve against `/buddy`, the home directory of the default `buddy` user.
+Filesystem calls go through Buddy's content endpoints rather than the shell, so content is never squeezed through command-line quoting and each call costs one round trip. As with every provider, `readFile` and `writeFile` handle UTF-8 text; for raw bytes use `getInstance().fs`, which talks to the SDK directly and skips the first-boot wait described below, so on a fresh sandbox make one `sandbox.filesystem` call first. Relative paths resolve against `/buddy`, the home directory of the default `buddy` user.
 
 The first filesystem call on a sandbox waits for first-boot setup to finish. Buddy queues *commands* against a starting sandbox, but the content endpoints do not: during setup they either refuse the request or accept a write and discard it. The wait costs a few hundred milliseconds once per sandbox.
 
@@ -164,6 +164,8 @@ Buddy creates snapshots asynchronously and they cannot be restored until they tu
 const { client, fs, sandboxId } = sandbox.getInstance();
 await client.startSandboxApp({ path: { sandbox_id: sandboxId, app_id: 'web' } });
 ```
+
+The handle's `fs` and `client` call the API directly, without the provider's first-boot wait: on a sandbox that has just been created, make one `sandbox.filesystem` call (even `exists`) before uploading through them.
 
 ## Supported Operations
 

--- a/docs/providers/buddy.md
+++ b/docs/providers/buddy.md
@@ -138,7 +138,7 @@ await sandbox.filesystem.exists('/buddy/app/index.js');
 await sandbox.filesystem.remove('/buddy/app');
 ```
 
-Filesystem calls go through Buddy's content endpoints rather than the shell, so they are binary-safe and cost one round trip each. Relative paths resolve against `/buddy`, the home directory of the default `buddy` user.
+Filesystem calls go through Buddy's content endpoints rather than the shell, so content is never squeezed through command-line quoting and each call costs one round trip. As with every provider, `readFile` and `writeFile` handle UTF-8 text; use `getInstance().fs` for raw bytes. Relative paths resolve against `/buddy`, the home directory of the default `buddy` user.
 
 The first filesystem call on a sandbox waits for first-boot setup to finish. Buddy queues *commands* against a starting sandbox, but the content endpoints do not: during setup they either refuse the request or accept a write and discard it. The wait costs a few hundred milliseconds once per sandbox.
 
@@ -176,7 +176,7 @@ await client.startSandboxApp({ path: { sandbox_id: sandboxId, app_id: 'web' } })
 | `runCommand` | ✅         | Streams stdout and stderr separately, with real exit codes.                                  |
 | `getInfo`    | ✅         | Reports Buddy's status, setup status and every tunnel in `metadata`.                          |
 | `getUrl`     | ✅         | Opens a tunnel if the port has none yet, keeping the existing ones.                          |
-| `filesystem` | ✅         | Native content endpoints — binary-safe, one round trip each.                                 |
+| `filesystem` | ✅         | Native content endpoints — no shell quoting, one round trip each.                            |
 | `snapshot`   | ✅         | `create` / `list` / `delete`; `create` waits until the snapshot is restorable.                |
 | `template`   | ⚠️        | No template entity in Buddy — `list`/`delete` alias snapshots, `create` throws with a hint.  |
 

--- a/packages/buddy/README.md
+++ b/packages/buddy/README.md
@@ -65,7 +65,7 @@ interface BuddyConfig {
   os?: string;
   /** Resource preset, `"{vCPU}x{RAM GB}"` from `1x2` to `12x24`. Buddy's own default applies when omitted. */
   resources?: BuddyResources;
-  /** Buddy installation — `'US'` (default), `'EU'` or `'AS'`. */
+  /** Buddy installation — `'US'` (default) or `'EU'`. */
   region?: BuddyRegion;
   /** Sandbox lifetime in milliseconds, after which Buddy stops it. Defaults to 1 hour. */
   timeout?: number;
@@ -90,7 +90,6 @@ const compute = buddy({ region: 'EU' });
 | ------------ | ------------------------------ |
 | `US` (default) | `https://api.buddy.works`     |
 | `EU`         | `https://api.eu.buddy.works`   |
-| `AS`         | `https://api.asia.buddy.works` |
 
 A token issued by one installation is not valid on the others. For an on-premise
 installation, set `apiUrl` instead.

--- a/packages/buddy/README.md
+++ b/packages/buddy/README.md
@@ -191,7 +191,7 @@ await client.getSandboxAppLogs({ path: { sandbox_id: sandboxId, app_id: 'web' } 
 | `runCommand` | ✅        | Streams stdout/stderr separately as the command runs, with real exit codes.                   |
 | `getInfo`    | ✅        | Reports Buddy's own status and setup status, plus every tunnel, in `metadata`.                 |
 | `getUrl`     | ✅        | Opens a tunnel if the port has none yet, keeping the existing ones.                           |
-| `filesystem` | ✅        | Uses Buddy's native content endpoints, not the shell — binary-safe and one round trip each.    |
+| `filesystem` | ✅        | Uses Buddy's native content endpoints, not the shell — no quoting or size limits of a command line, one round trip each. |
 | `snapshot`   | ✅        | `create` / `list` / `delete`; `create` waits until the snapshot is restorable.                 |
 | `template`   | ⚠️        | No template entity in Buddy — `list`/`delete` alias snapshots, `create` throws with a hint.    |
 

--- a/packages/buddy/README.md
+++ b/packages/buddy/README.md
@@ -1,0 +1,208 @@
+# @computesdk/buddy
+
+Buddy provider for ComputeSDK.
+
+Each sandbox is a Buddy sandbox — an Ubuntu microVM in your Buddy project, served from a pre-warmed pool. Commands stream their output as they run, ports are published through Buddy tunnels, and snapshots double as reusable base images.
+
+Built on [`@buddy-works/sandbox-sdk`](https://www.npmjs.com/package/@buddy-works/sandbox-sdk), Buddy's official TypeScript SDK.
+
+## Installation
+
+```bash
+npm install @computesdk/buddy
+```
+
+Node 20.19 or newer is required, because the Buddy SDK ships ESM only.
+
+## Setup
+
+1. Create an API token in **Buddy → My ID → Access tokens** with the `SANDBOX_MANAGE` scope
+2. Create (or pick) a Buddy project for your sandboxes
+3. Set environment variables:
+
+```bash
+export BUDDY_TOKEN=your_api_token_here
+export BUDDY_WORKSPACE=your_workspace_domain
+export BUDDY_PROJECT=your_project_name
+```
+
+## Quick Start
+
+```ts
+import { buddy } from '@computesdk/buddy';
+
+const compute = buddy();
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('echo "hello from buddy"');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+Credentials are read from the environment, so `buddy()` needs no arguments. Pass them explicitly to override:
+
+```ts
+const compute = buddy({
+  token: process.env.BUDDY_TOKEN!,
+  workspace: 'acme',
+  project: 'sandboxes',
+});
+```
+
+## Configuration
+
+```ts
+interface BuddyConfig {
+  /** API token with the `SANDBOX_MANAGE` scope. Falls back to `BUDDY_TOKEN`. */
+  token?: string;
+  /** Workspace domain. Falls back to `BUDDY_WORKSPACE`. */
+  workspace?: string;
+  /** Project the sandboxes belong to. Falls back to `BUDDY_PROJECT`. */
+  project?: string;
+  /** Base OS image — `'ubuntu:24.04'` (default) or `'ubuntu:22.04'`. */
+  os?: string;
+  /** Resource preset, `"{vCPU}x{RAM GB}"` from `1x2` to `12x24`. Buddy's own default applies when omitted. */
+  resources?: BuddyResources;
+  /** Buddy installation — `'US'` (default), `'EU'` or `'AS'`. */
+  region?: BuddyRegion;
+  /** Sandbox lifetime in milliseconds, after which Buddy stops it. Defaults to 1 hour. */
+  timeout?: number;
+  /** Ports to expose on every sandbox this provider creates. */
+  ports?: BuddyPortInput[];
+  /** API base URL. Overrides `region`, for on-premise installations. */
+  apiUrl?: string;
+}
+```
+
+### Choosing an installation
+
+Buddy runs independent installations rather than regions within one API, each with
+its own host, accounts and tokens. `region` selects both the API host and where
+tunnels terminate:
+
+```ts
+const compute = buddy({ region: 'EU' });
+```
+
+| `region`     | API host                       |
+| ------------ | ------------------------------ |
+| `US` (default) | `https://api.buddy.works`     |
+| `EU`         | `https://api.eu.buddy.works`   |
+| `AS`         | `https://api.asia.buddy.works` |
+
+A token issued by one installation is not valid on the others. For an on-premise
+installation, set `apiUrl` instead.
+
+## Create options
+
+Beyond the cross-provider options, `create` accepts:
+
+```ts
+await compute.sandbox.create({
+  // Expose ports up front, so getUrl needs no extra round trip
+  ports: [3000, { port: 443, type: 'TLS', region: 'EU' }],
+  // Resources — either a preset, or cpu/memory that map onto one
+  resources: '4x8',
+  // Commands run once when the sandbox first boots
+  firstBootCommands: 'npm ci',
+  // Working directory for the sandbox's apps
+  appDir: '/buddy/app',
+  tags: ['ci'],
+});
+```
+
+`snapshotId` (or `templateId`) starts the sandbox from a snapshot instead of a base image.
+
+## Exposing ports
+
+```ts
+const sandbox = await compute.sandbox.create({ ports: [3000] });
+await sandbox.runCommand('npx serve -l 3000', { background: true });
+
+const url = await sandbox.getUrl({ port: 3000 });
+```
+
+`getUrl` opens a tunnel on demand if the port was not declared at create time,
+keeping any tunnels already open. Only `HTTP` and `TLS` tunnels get a public URL;
+`TCP` and `SSH` tunnels are reached by host and port, reported in `getInfo`.
+
+## Filesystem
+
+```ts
+await sandbox.filesystem.mkdir('/buddy/app');
+await sandbox.filesystem.writeFile('/buddy/app/index.js', 'console.log(1)');
+await sandbox.filesystem.readFile('/buddy/app/index.js');
+await sandbox.filesystem.readdir('/buddy/app');
+await sandbox.filesystem.exists('/buddy/app/index.js');
+await sandbox.filesystem.remove('/buddy/app');
+```
+
+Relative paths resolve against `/buddy`, the home directory of the default `buddy` user.
+
+The first filesystem call on a sandbox waits for its first-boot setup to finish. Buddy
+queues *commands* against a starting sandbox, but the content endpoints do not: during
+setup they either refuse the request or accept a write and discard it once setup
+completes. The wait costs a few hundred milliseconds on a freshly created sandbox and
+nothing afterwards.
+
+## Snapshots
+
+A snapshot is a disk image taken from a live sandbox, and doubles as the reusable base
+image other providers call a template.
+
+```ts
+const snapshot = await compute.snapshot.create(sandbox.sandboxId, { name: 'with-deps' });
+
+await compute.snapshot.list();                                 // the whole project
+await compute.snapshot.list({ sandboxId: sandbox.sandboxId });  // one sandbox
+await compute.snapshot.delete(snapshot.id);
+
+// Booting from it is a normal create
+const prepared = await compute.sandbox.create({ snapshotId: snapshot.id });
+```
+
+Buddy creates snapshots asynchronously and they cannot be restored until they turn
+`CREATED`, so `create` waits for that before returning. `metadata` is accepted for
+cross-provider compatibility but not stored: Buddy keeps only a name.
+
+Buddy has no separate template entity, so `template.list` and `template.delete` alias
+the snapshot methods and `template.create` throws, pointing at `snapshot.create`.
+
+## Dropping down to the Buddy SDK
+
+`getInstance()` returns the handle the provider works with, including the live SDK
+client and filesystem, so Buddy features outside the ComputeSDK surface stay reachable
+without building a second client:
+
+```ts
+const { client, fs, sandboxId } = sandbox.getInstance();
+await client.getSandboxAppLogs({ path: { sandbox_id: sandboxId, app_id: 'web' } });
+```
+
+## Supported Operations
+
+| Method       | Supported | Notes                                                                                        |
+| ------------ | --------- | -------------------------------------------------------------------------------------------- |
+| `create`     | ✅        | One request; returns while the sandbox is still starting, since commands queue against it.     |
+| `getById`    | ✅        | Returns `null` when the sandbox no longer exists.                                             |
+| `list`       | ✅        | Lists the sandboxes in the configured project.                                                |
+| `destroy`    | ✅        | Retries on server errors; a no-op if the sandbox is already gone.                             |
+| `runCommand` | ✅        | Streams stdout/stderr separately as the command runs, with real exit codes.                   |
+| `getInfo`    | ✅        | Reports Buddy's own status and setup status, plus every tunnel, in `metadata`.                 |
+| `getUrl`     | ✅        | Opens a tunnel if the port has none yet, keeping the existing ones.                           |
+| `filesystem` | ✅        | Uses Buddy's native content endpoints, not the shell — binary-safe and one round trip each.    |
+| `snapshot`   | ✅        | `create` / `list` / `delete`; `create` waits until the snapshot is restorable.                 |
+| `template`   | ⚠️        | No template entity in Buddy — `list`/`delete` alias snapshots, `create` throws with a hint.    |
+
+## Notes
+
+- `create` does not wait for the sandbox to reach `RUNNING`. Buddy queues commands submitted against a starting sandbox, so waiting would only add latency to the first command. For the same reason the provider calls the SDK's `BuddyApiClient` directly instead of `Sandbox.create()`, which polls for readiness once a second.
+- `runCommand(cmd, { background: true })` returns as soon as Buddy has queued the command, without reading its output.
+- `runCommand(cmd, { timeout })` terminates the command when the timeout passes.
+- Sandbox placement inside an installation is not selectable; `region` picks the installation and the tunnel location.
+
+## License
+
+MIT

--- a/packages/buddy/README.md
+++ b/packages/buddy/README.md
@@ -180,6 +180,8 @@ const { client, fs, sandboxId } = sandbox.getInstance();
 await client.getSandboxAppLogs({ path: { sandbox_id: sandboxId, app_id: 'web' } });
 ```
 
+The handle's `fs` and `client` call the API directly, without the provider's first-boot wait: on a sandbox that has just been created, make one `sandbox.filesystem` call (even `exists`) before uploading through them.
+
 ## Supported Operations
 
 | Method       | Supported | Notes                                                                                        |

--- a/packages/buddy/package.json
+++ b/packages/buddy/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@computesdk/buddy",
+  "version": "1.0.0",
+  "description": "Buddy provider for ComputeSDK - Ubuntu sandboxes served from a pre-warmed hot pool, with public HTTP tunnels and snapshots",
+  "author": "Lucas Czulak",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@buddy-works/sandbox-sdk": "^0.1.7",
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "keywords": [
+    "computesdk",
+    "buddy",
+    "sandbox",
+    "code-execution",
+    "cloud",
+    "compute",
+    "provider",
+    "ubuntu"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/buddy"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/buddy/package.json
+++ b/packages/buddy/package.json
@@ -33,7 +33,7 @@
     "computesdk": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "keywords": [
     "computesdk",

--- a/packages/buddy/package.json
+++ b/packages/buddy/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@buddy-works/sandbox-sdk": "^0.1.7",
+    "@buddy-works/sandbox-sdk": "^0.1.8",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 
-import { buddy, ensureTimeout } from '../index';
+import { buddy, ensureTimeout, toSeconds } from '../index';
 import { TIMEOUT_EXIT_CODE, buildShellCommand, runCommand, waitForExitCode } from '../commands';
 import {
   getClient,
@@ -215,6 +215,16 @@ describe('command execution', () => {
     expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
   });
 
+  it('kills the command when its log stream breaks mid-run', async () => {
+    const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { throw new Error('stream reset'); });
+
+    await expect(runCommand(sandbox, 'sleep 60', { timeout: 5_000 })).rejects.toThrow(/stream reset/);
+    expect(client.terminateCommand).toHaveBeenCalledTimes(1);
+    expect(client.getCommandDetails).not.toHaveBeenCalled();
+  });
+
   it('waits for the exit code instead of assuming success while in progress', async () => {
     const { sandbox, client } = fakeCommandClient([], [
       { status: 'INPROGRESS' },
@@ -258,6 +268,12 @@ describe('sandbox timeout', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('never shortens a lifetime when converting to whole seconds', () => {
+    expect(toSeconds(1_499)).toBe(2);
+    expect(toSeconds(300_000)).toBe(300);
+    expect(toSeconds(1)).toBe(1);
+  });
+
   it('patches the timeout a snapshot restore did not accept', async () => {
     const { BuddyApiClient } = await import('@buddy-works/sandbox-sdk');
     vi.spyOn(BuddyApiClient.prototype, 'getSandboxById')
@@ -269,6 +285,23 @@ describe('sandbox timeout', () => {
     await ensureTimeout(sandbox, 300_000);
     expect(update).toHaveBeenCalledWith(expect.objectContaining({ body: { timeout: 300 } }));
     expect(sandbox.timeout).toBe(300_000);
+  });
+});
+
+describe('sandbox creation', () => {
+  it('deletes the sandbox when post-create setup fails, keeping the original error', async () => {
+    const { BuddyApiClient } = await import('@buddy-works/sandbox-sdk');
+    vi.spyOn(BuddyApiClient.prototype, 'addSandbox')
+      .mockResolvedValue({ id: 'sb-new', identifier: 'sb-new', timeout: 3600 } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.spyOn(BuddyApiClient.prototype, 'getSandboxById')
+      .mockResolvedValue({ id: 'sb-new', status: 'RUNNING', setup_status: 'SUCCESS' } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    vi.spyOn(BuddyApiClient.prototype, 'updateSandbox').mockRejectedValue(new Error('quota exceeded'));
+    const remove = vi.spyOn(BuddyApiClient.prototype, 'deleteSandboxById').mockRejectedValue(new Error('gone'));
+
+    const provider = buddy({ token: 't', workspace: 'w', project: 'p' });
+    await expect(provider.sandbox.create({ snapshotId: 'snap', timeout: 300_000 }))
+      .rejects.toThrow(/quota exceeded/);
+    expect(remove).toHaveBeenCalledWith({ path: { id: 'sb-new' } });
   });
 });
 

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 
 import { buddy } from '../index';
-import { buildShellCommand } from '../commands';
+import { buildShellCommand, runCommand } from '../commands';
 import {
   apiUrlForRegion,
   isInstanceNotRunning,
@@ -120,6 +120,13 @@ describe('command building', () => {
 
   it('neutralises quotes in env values', () => {
     expect(buildShellCommand('echo hi', { env: { A: 'a"b' } })).not.toBe('export A="a"b" && echo hi');
+  });
+
+  it('rejects the outdated argument-array call shape', async () => {
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runCommand({} as any, 'echo', ['hello-args'] as any),
+    ).rejects.toThrow(/not an argument array/);
   });
 });
 

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -143,6 +143,15 @@ describe('command building', () => {
     expect(buildShellCommand('echo hi', { env: { A: 'a"b' } })).not.toBe('export A="a"b" && echo hi');
   });
 
+  it('rejects env names that are not shell identifiers', () => {
+    for (const name of ['A; rm -rf /', 'FOO=bar', '$(id)', '1ABC', 'a-b', '']) {
+      expect(() => buildShellCommand('echo hi', { env: { [name]: 'x' } }))
+        .toThrow(/Invalid environment variable name/);
+    }
+    expect(buildShellCommand('echo hi', { env: { _OK_1: 'x', lower: 'y' } }))
+      .toBe('export _OK_1="x" lower="y" && echo hi');
+  });
+
   it('rejects the outdated argument-array call shape', async () => {
     await expect(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -264,6 +273,21 @@ describe('command execution', () => {
     release();
     await new Promise(resolve => setTimeout(resolve, 20));
     expect(onStdout).not.toHaveBeenCalled();
+  });
+
+  it('keeps the output collected before the deadline in the timeout result', async () => {
+    const { sandbox } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () {
+      yield { type: 'STDOUT', data: 'step 1' } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      yield { type: 'STDERR', data: 'warn' } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      await new Promise(() => {}); // the command never finishes
+    });
+
+    const result = await runCommand(sandbox, 'sleep 60', { timeout: 30 });
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+    expect(result.stdout).toBe('step 1\n');
+    expect(result.stderr).toBe('warn\n');
   });
 
   it('retries a failed kill before giving up', async () => {

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 
-import { buddy } from '../index';
+import { buddy, ensureTimeout } from '../index';
 import { TIMEOUT_EXIT_CODE, buildShellCommand, runCommand, waitForExitCode } from '../commands';
 import {
+  getClient,
   isInstanceNotRunning,
   isNotFound,
   isUnroutableId,
@@ -64,6 +65,27 @@ describe('config resolution', () => {
     expect(config.apiUrl).toBe('https://buddy.internal');
     // The region still decides where tunnels terminate.
     expect(config.region).toBe('EU');
+  });
+
+  it('re-reads the environment when called without a config', () => {
+    const saved = {
+      BUDDY_TOKEN: process.env.BUDDY_TOKEN,
+      BUDDY_WORKSPACE: process.env.BUDDY_WORKSPACE,
+      BUDDY_PROJECT: process.env.BUDDY_PROJECT,
+    };
+    try {
+      Object.assign(process.env, { BUDDY_TOKEN: 'first', BUDDY_WORKSPACE: 'w', BUDDY_PROJECT: 'p' });
+      const first = resolveConfig();
+      expect(first.token).toBe('first');
+      expect(resolveConfig()).toBe(first);
+      process.env.BUDDY_TOKEN = 'rotated';
+      expect(resolveConfig().token).toBe('rotated');
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   it('reuses the resolved config for the same config object', () => {
@@ -168,17 +190,28 @@ describe('command execution', () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it('reports a timed-out command as failed even when Buddy still says in progress', async () => {
+  it('returns the timeout exit code without waiting for the stream to close', async () => {
     const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
     const { Command } = await import('@buddy-works/sandbox-sdk');
-    let release!: () => void;
-    const gate = new Promise<void>(resolve => { release = resolve; });
-    client.terminateCommand.mockImplementation(async () => { release(); });
-    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { await gate; });
+    // The stream never ends: the kill is what would normally close it.
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { await new Promise(() => {}); });
 
+    const started = Date.now();
     const result = await runCommand(sandbox, 'sleep 60', { timeout: 20 });
 
+    expect(Date.now() - started).toBeLessThan(1_000);
     expect(client.terminateCommand).toHaveBeenCalledTimes(1);
+    expect(client.getCommandDetails).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+  });
+
+  it('still times out when the kill itself fails', async () => {
+    const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    client.terminateCommand.mockImplementation(async () => { throw new Error('gateway timeout'); });
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { await new Promise(() => {}); });
+
+    const result = await runCommand(sandbox, 'sleep 60', { timeout: 20 });
     expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
   });
 
@@ -195,6 +228,47 @@ describe('command execution', () => {
   it('gives up on a command that never reports a result', async () => {
     const { sandbox } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
     await expect(waitForExitCode(sandbox, 'cmd-1', 0)).rejects.toThrow(/no exit code/);
+  });
+});
+
+describe('snapshots as templates', () => {
+  it('honours the limit on template.list', async () => {
+    const { BuddyApiClient } = await import('@buddy-works/sandbox-sdk');
+    vi.spyOn(BuddyApiClient.prototype, 'getProjectSnapshots').mockResolvedValue({
+      snapshots: [{ id: 's1', name: 'a' }, { id: 's2', name: 'b' }, { id: 's3', name: 'c' }],
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const provider = buddy({ token: 't', workspace: 'w', project: 'p' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const templates = await (provider.template as any).list({ limit: 2 });
+    expect(templates.map((t: { id: string }) => t.id)).toEqual(['s1', 's2']);
+  });
+});
+
+describe('sandbox timeout', () => {
+  const config = resolveConfig({ token: 't', workspace: 'w', project: 'p' });
+  const handle = (timeoutMs: number) => ({
+    sandboxId: 'sb-1', timeout: timeoutMs, config, client: getClient(config),
+  }) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  it('leaves a sandbox alone when Buddy already applied the requested timeout', async () => {
+    const { BuddyApiClient } = await import('@buddy-works/sandbox-sdk');
+    const update = vi.spyOn(BuddyApiClient.prototype, 'updateSandbox');
+    await ensureTimeout(handle(300_000), 300_000);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('patches the timeout a snapshot restore did not accept', async () => {
+    const { BuddyApiClient } = await import('@buddy-works/sandbox-sdk');
+    vi.spyOn(BuddyApiClient.prototype, 'getSandboxById')
+      .mockResolvedValue({ id: 'sb-1', status: 'RUNNING', setup_status: 'SUCCESS' } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const update = vi.spyOn(BuddyApiClient.prototype, 'updateSandbox')
+      .mockImplementation(async ({ body }: any) => ({ timeout: body.timeout }) as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const sandbox = handle(3_600_000);
+    await ensureTimeout(sandbox, 300_000);
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ body: { timeout: 300 } }));
+    expect(sandbox.timeout).toBe(300_000);
   });
 });
 

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { runProviderTestSuite } from '@computesdk/test-utils';
+
+import { buddy } from '../index';
+import { buildShellCommand } from '../commands';
+import {
+  apiUrlForRegion,
+  isInstanceNotRunning,
+  isNotFound,
+  isUnroutableId,
+  mapStatus,
+  normalizePort,
+  normalizeSandboxPath,
+  resolveConfig,
+  resolveResources,
+  toContentPath,
+  toIdentifier,
+} from '../utils';
+
+runProviderTestSuite({
+  name: 'buddy',
+  provider: buddy({}),
+  supportsFilesystem: true,
+  skipIntegration: !process.env.BUDDY_TOKEN
+    || !process.env.BUDDY_WORKSPACE
+    || !process.env.BUDDY_PROJECT,
+});
+
+describe('config resolution', () => {
+  it('names the missing credential in the error', () => {
+    // The env-var fallbacks have to be out of the way for this to be about the
+    // config object alone.
+    const saved = {
+      BUDDY_TOKEN: process.env.BUDDY_TOKEN,
+      BUDDY_WORKSPACE: process.env.BUDDY_WORKSPACE,
+      BUDDY_PROJECT: process.env.BUDDY_PROJECT,
+    };
+    delete process.env.BUDDY_TOKEN;
+    delete process.env.BUDDY_WORKSPACE;
+    delete process.env.BUDDY_PROJECT;
+
+    try {
+      expect(() => resolveConfig({ workspace: 'w', project: 'p' })).toThrow(/token/i);
+      expect(() => resolveConfig({ token: 't', project: 'p' })).toThrow(/workspace/i);
+      expect(() => resolveConfig({ token: 't', workspace: 'w' })).toThrow(/project/i);
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('defaults to the US installation and applies the region host', () => {
+    const base = { token: 't', workspace: 'w', project: 'p' };
+    expect(resolveConfig({ ...base }).apiUrl).toBe('https://api.buddy.works');
+    expect(resolveConfig({ ...base, region: 'EU' }).apiUrl).toBe('https://api.eu.buddy.works');
+    expect(apiUrlForRegion('AS')).toBe('https://api.asia.buddy.works');
+  });
+
+  it('lets apiUrl override the region and strips trailing slashes', () => {
+    const config = resolveConfig({
+      token: 't', workspace: 'w', project: 'p', region: 'EU', apiUrl: 'https://buddy.internal/',
+    });
+    expect(config.apiUrl).toBe('https://buddy.internal');
+    // The region still decides where tunnels terminate.
+    expect(config.region).toBe('EU');
+  });
+
+  it('reuses the resolved config for the same config object', () => {
+    const raw = { token: 't', workspace: 'w', project: 'p' };
+    expect(resolveConfig(raw)).toBe(resolveConfig(raw));
+  });
+});
+
+describe('resource presets', () => {
+  const cases: Array<[Record<string, unknown>, string | undefined]> = [
+    [{}, undefined],
+    [{ cpu: 2 }, '2x4'],
+    [{ memory: 8192 }, '4x8'],
+    // The larger of the two requests wins, since Buddy ties RAM to vCPU.
+    [{ cpu: 1, memory: 8192 }, '4x8'],
+    [{ cpu: 40 }, '12x24'],
+    [{ resources: '3x6' }, '3x6'],
+  ];
+
+  it.each(cases)('maps %j to %s', (options, expected) => {
+    expect(resolveResources(options)).toBe(expected);
+  });
+
+  it('falls back to the provider default', () => {
+    expect(resolveResources({}, '2x4')).toBe('2x4');
+  });
+});
+
+describe('paths', () => {
+  it('resolves relative paths against the sandbox home', () => {
+    expect(normalizeSandboxPath('app/index.js')).toBe('/buddy/app/index.js');
+    expect(normalizeSandboxPath('/etc//hosts')).toBe('/etc/hosts');
+  });
+
+  it('rejects the root', () => {
+    expect(() => normalizeSandboxPath('/')).toThrow();
+  });
+
+  it('drops the leading slash for content endpoints', () => {
+    expect(toContentPath('/buddy/a.txt')).toBe('buddy/a.txt');
+  });
+});
+
+describe('command building', () => {
+  it('passes a plain command through', () => {
+    expect(buildShellCommand('ls -la')).toBe('ls -la');
+  });
+
+  it('prepends cwd and env', () => {
+    expect(buildShellCommand('node app.js', { cwd: '/buddy/app', env: { PORT: '3000' } }))
+      .toBe('cd "/buddy/app" && export PORT="3000" && node app.js');
+  });
+
+  it('neutralises quotes in env values', () => {
+    expect(buildShellCommand('echo hi', { env: { A: 'a"b' } })).not.toBe('export A="a"b" && echo hi');
+  });
+});
+
+describe('status mapping', () => {
+  it('treats a starting sandbox as running, because commands queue', () => {
+    expect(mapStatus('STARTING')).toBe('running');
+    expect(mapStatus('RESTORING')).toBe('running');
+    expect(mapStatus('RUNNING')).toBe('running');
+    expect(mapStatus('STOPPED')).toBe('stopped');
+    expect(mapStatus('FAILED')).toBe('error');
+    expect(mapStatus(undefined)).toBe('stopped');
+  });
+});
+
+describe('error predicates', () => {
+  it('recognises a missing entity from either error shape', () => {
+    expect(isNotFound(Object.assign(new Error('HTTP 404: nope'), { status: 404 }))).toBe(true);
+    expect(isNotFound(Object.assign(new Error('nope'), { statusCode: 404 }))).toBe(true);
+    // The content endpoints report a missing path as 400.
+    expect(isNotFound(Object.assign(new Error('Path not find in browser'), { status: 400 }))).toBe(true);
+    expect(isNotFound(Object.assign(new Error('boom'), { status: 500 }))).toBe(false);
+  });
+
+  it('recognises an id Buddy cannot even route', () => {
+    const error = Object.assign(new Error('HTTP 400: Invalid url: /workspaces/w/sandboxes/nope'), { status: 400 });
+    expect(isUnroutableId(error)).toBe(true);
+    expect(isUnroutableId(Object.assign(new Error('Invalid url'), { status: 404 }))).toBe(false);
+  });
+
+  it('recognises the boot race', () => {
+    const error = Object.assign(new Error('HTTP 400: Instance is not running'), { status: 400 });
+    expect(isInstanceNotRunning(error)).toBe(true);
+    expect(isInstanceNotRunning(Object.assign(new Error('other'), { status: 400 }))).toBe(false);
+  });
+});
+
+describe('ports', () => {
+  it('defaults a bare port to an HTTP tunnel in the configured region', () => {
+    const config = resolveConfig({ token: 't', workspace: 'w', project: 'p', region: 'EU' });
+    expect(normalizePort(3000, config)).toEqual({
+      port: 3000, name: 'p3000', type: 'HTTP', region: 'EU',
+    });
+  });
+});
+
+describe('identifiers', () => {
+  it('follows the identifier rules Buddy enforces', () => {
+    expect(toIdentifier('ComputeSDK Test #1')).toBe('computesdk-test-1');
+    expect(toIdentifier('!!!')).toBe('computesdk');
+  });
+});

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 
 import { buddy } from '../index';
-import { buildShellCommand, runCommand } from '../commands';
+import { TIMEOUT_EXIT_CODE, buildShellCommand, runCommand, waitForExitCode } from '../commands';
 import {
   apiUrlForRegion,
   isInstanceNotRunning,
@@ -14,6 +14,7 @@ import {
   resolveConfig,
   resolveResources,
   toContentPath,
+  toEndpointUpdate,
   toIdentifier,
 } from '../utils';
 
@@ -130,6 +131,70 @@ describe('command building', () => {
   });
 });
 
+/** Fakes the SDK client surface `runCommand` touches. */
+function fakeCommandClient(
+  logs: Array<{ type: 'STDOUT' | 'STDERR'; data: string }>,
+  details: Array<{ exit_code?: number; status?: string }>,
+) {
+  const pending = [...details];
+  const client = {
+    executeCommand: vi.fn(async () => ({ id: 'cmd-1' })),
+    getCommandLogs: vi.fn(),
+    getCommandDetails: vi.fn(async () => pending.length > 1 ? pending.shift()! : pending[0]),
+    terminateCommand: vi.fn(async () => {}),
+  };
+  const sandbox = { sandboxId: 'sb-1', client } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  return { client, sandbox, logs };
+}
+
+describe('command execution', () => {
+  it('terminates every log record with a newline', async () => {
+    const { sandbox, logs } = fakeCommandClient(
+      [{ type: 'STDOUT', data: 'one' }, { type: 'STDOUT', data: 'two' }, { type: 'STDERR', data: 'warn' }],
+      [{ exit_code: 0, status: 'SUCCESSFUL' }],
+    );
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { yield* logs; });
+
+    const chunks: string[] = [];
+    const result = await runCommand(sandbox, 'printf "one\\ntwo"', { onStdout: chunk => chunks.push(chunk) });
+
+    expect(result.stdout).toBe('one\ntwo\n');
+    expect(result.stderr).toBe('warn\n');
+    expect(chunks.join('')).toBe(result.stdout);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('reports a timed-out command as failed even when Buddy still says in progress', async () => {
+    const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    client.terminateCommand.mockImplementation(async () => { release(); });
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { await gate; });
+
+    const result = await runCommand(sandbox, 'sleep 60', { timeout: 20 });
+
+    expect(client.terminateCommand).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+  });
+
+  it('waits for the exit code instead of assuming success while in progress', async () => {
+    const { sandbox, client } = fakeCommandClient([], [
+      { status: 'INPROGRESS' },
+      { status: 'INPROGRESS' },
+      { exit_code: 3, status: 'FAILED' },
+    ]);
+    await expect(waitForExitCode(sandbox, 'cmd-1', 5_000)).resolves.toBe(3);
+    expect(client.getCommandDetails).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up on a command that never reports a result', async () => {
+    const { sandbox } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    await expect(waitForExitCode(sandbox, 'cmd-1', 0)).rejects.toThrow(/no exit code/);
+  });
+});
+
 describe('status mapping', () => {
   it('treats a starting sandbox as running, because commands queue', () => {
     expect(mapStatus('STARTING')).toBe('running');
@@ -170,11 +235,29 @@ describe('ports', () => {
       port: 3000, name: 'p3000', type: 'HTTP', region: 'EU',
     });
   });
+
+  it('keeps writable tunnel settings and drops read-only ones when sending endpoints back', () => {
+    expect(toEndpointUpdate({
+      name: 'web', endpoint: '3000', type: 'HTTP', region: 'EU',
+      whitelist: ['10.0.0.0/8'], timeout: 30, http: { auth_type: 'BASIC' }, tls: { tls_ca: 'x' },
+      endpoint_url: 'https://web.example', active: true, target_latency: 12,
+    })).toEqual({
+      name: 'web', endpoint: '3000', type: 'HTTP', region: 'EU',
+      whitelist: ['10.0.0.0/8'], timeout: 30, http: { auth_type: 'BASIC' }, tls: { tls_ca: 'x' },
+    });
+  });
 });
 
 describe('identifiers', () => {
   it('follows the identifier rules Buddy enforces', () => {
     expect(toIdentifier('ComputeSDK Test #1')).toBe('computesdk-test-1');
     expect(toIdentifier('!!!')).toBe('computesdk');
+  });
+
+  it('never leaves a hyphen at the end after truncating', () => {
+    const name = `${'a'.repeat(59)}-tail`;
+    const identifier = toIdentifier(name);
+    expect(identifier).toBe('a'.repeat(59));
+    expect(identifier.length).toBeLessThanOrEqual(60);
   });
 });

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 
 import { buddy, ensureTimeout, toSeconds } from '../index';
-import { TIMEOUT_EXIT_CODE, buildShellCommand, runCommand, waitForExitCode } from '../commands';
+import { TIMEOUT_EXIT_CODE, buildShellCommand, killCommand, runCommand, waitForExitCode } from '../commands';
 import {
   getClient,
   isInstanceNotRunning,
@@ -215,6 +215,35 @@ describe('command execution', () => {
     expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
   });
 
+  it('counts a slow submission against the timeout', async () => {
+    const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    // Buddy holds the submission (e.g. while the sandbox boots) past the deadline.
+    client.executeCommand.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 60));
+      return { id: 'cmd-1' };
+    });
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () { await new Promise(() => {}); });
+
+    const started = Date.now();
+    const result = await runCommand(sandbox, 'sleep 60', { timeout: 30 });
+
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it('retries a failed kill before giving up', async () => {
+    const kill = vi.fn()
+      .mockRejectedValueOnce(new Error('gateway timeout'))
+      .mockResolvedValue(undefined);
+    await expect(killCommand({ kill })).resolves.toBe(true);
+    expect(kill).toHaveBeenCalledTimes(2);
+
+    const hopeless = vi.fn().mockRejectedValue(new Error('gateway timeout'));
+    await expect(killCommand({ kill: hopeless })).resolves.toBe(false);
+    expect(hopeless).toHaveBeenCalledTimes(3);
+  });
+
   it('kills the command when its log stream breaks mid-run', async () => {
     const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
     const { Command } = await import('@buddy-works/sandbox-sdk');
@@ -296,11 +325,15 @@ describe('sandbox creation', () => {
     vi.spyOn(BuddyApiClient.prototype, 'getSandboxById')
       .mockResolvedValue({ id: 'sb-new', status: 'RUNNING', setup_status: 'SUCCESS' } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     vi.spyOn(BuddyApiClient.prototype, 'updateSandbox').mockRejectedValue(new Error('quota exceeded'));
-    const remove = vi.spyOn(BuddyApiClient.prototype, 'deleteSandboxById').mockRejectedValue(new Error('gone'));
+    // The cleanup retries transient failures the same way destroy does.
+    const remove = vi.spyOn(BuddyApiClient.prototype, 'deleteSandboxById')
+      .mockRejectedValueOnce(Object.assign(new Error('HTTP 503'), { status: 503 }))
+      .mockResolvedValue(undefined as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const provider = buddy({ token: 't', workspace: 'w', project: 'p' });
     await expect(provider.sandbox.create({ snapshotId: 'snap', timeout: 300_000 }))
       .rejects.toThrow(/quota exceeded/);
+    expect(remove).toHaveBeenCalledTimes(2);
     expect(remove).toHaveBeenCalledWith({ path: { id: 'sb-new' } });
   });
 });

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -4,7 +4,6 @@ import { runProviderTestSuite } from '@computesdk/test-utils';
 import { buddy } from '../index';
 import { TIMEOUT_EXIT_CODE, buildShellCommand, runCommand, waitForExitCode } from '../commands';
 import {
-  apiUrlForRegion,
   isInstanceNotRunning,
   isNotFound,
   isUnroutableId,
@@ -56,7 +55,6 @@ describe('config resolution', () => {
     const base = { token: 't', workspace: 'w', project: 'p' };
     expect(resolveConfig({ ...base }).apiUrl).toBe('https://api.buddy.works');
     expect(resolveConfig({ ...base, region: 'EU' }).apiUrl).toBe('https://api.eu.buddy.works');
-    expect(apiUrlForRegion('AS')).toBe('https://api.asia.buddy.works');
   });
 
   it('lets apiUrl override the region and strips trailing slashes', () => {
@@ -148,6 +146,11 @@ function fakeCommandClient(
 }
 
 describe('command execution', () => {
+  it('streams over its own API instead of the daemon fallback', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((buddy({}).sandbox as any).methods.streamCommand).toBe(runCommand);
+  });
+
   it('terminates every log record with a newline', async () => {
     const { sandbox, logs } = fakeCommandClient(
       [{ type: 'STDOUT', data: 'one' }, { type: 'STDOUT', data: 'two' }, { type: 'STDERR', data: 'warn' }],

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -120,8 +120,16 @@ describe('paths', () => {
     expect(normalizeSandboxPath('/etc//hosts')).toBe('/etc/hosts');
   });
 
-  it('rejects the root', () => {
+  it('resolves dot segments', () => {
+    expect(normalizeSandboxPath('./app/../lib/./x.js')).toBe('/buddy/lib/x.js');
+    expect(normalizeSandboxPath('/buddy/../etc/hosts')).toBe('/etc/hosts');
+    expect(normalizeSandboxPath('/../../etc')).toBe('/etc');
+  });
+
+  it('rejects the root, also when reached through dot segments', () => {
     expect(() => normalizeSandboxPath('/')).toThrow();
+    expect(() => normalizeSandboxPath('/tmp/..')).toThrow();
+    expect(() => normalizeSandboxPath('/./')).toThrow();
   });
 
   it('drops the leading slash for content endpoints', () => {

--- a/packages/buddy/src/__tests__/index.test.ts
+++ b/packages/buddy/src/__tests__/index.test.ts
@@ -232,6 +232,40 @@ describe('command execution', () => {
     expect(Date.now() - started).toBeLessThan(500);
   });
 
+  it('returns the timeout result while Buddy still holds the submission', async () => {
+    const { sandbox, client } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    let accept!: (value: { id: string }) => void;
+    client.executeCommand.mockImplementation(() => new Promise<{ id: string }>(resolve => { accept = resolve; }));
+
+    const started = Date.now();
+    const result = await runCommand(sandbox, 'sleep 60', { timeout: 20 });
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+    expect(Date.now() - started).toBeLessThan(500);
+
+    // Once Buddy finally reports the command, it is killed.
+    accept({ id: 'cmd-late' });
+    await vi.waitFor(() => expect(client.terminateCommand).toHaveBeenCalledTimes(1));
+  });
+
+  it('stops forwarding output after the timeout result was returned', async () => {
+    const { sandbox } = fakeCommandClient([], [{ status: 'INPROGRESS' }]);
+    const { Command } = await import('@buddy-works/sandbox-sdk');
+    let release!: () => void;
+    vi.spyOn(Command.prototype, 'logs').mockImplementation(async function* () {
+      await new Promise<void>(resolve => { release = resolve; });
+      yield { type: 'STDOUT', data: 'late' } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      yield { type: 'STDOUT', data: 'later' } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    });
+
+    const onStdout = vi.fn();
+    const result = await runCommand(sandbox, 'sleep 60', { timeout: 20, onStdout });
+    expect(result.exitCode).toBe(TIMEOUT_EXIT_CODE);
+
+    release();
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(onStdout).not.toHaveBeenCalled();
+  });
+
   it('retries a failed kill before giving up', async () => {
     const kill = vi.fn()
       .mockRejectedValueOnce(new Error('gateway timeout'))

--- a/packages/buddy/src/boot.ts
+++ b/packages/buddy/src/boot.ts
@@ -1,0 +1,78 @@
+/**
+ * The boot gate.
+ *
+ * `create` deliberately returns while the sandbox is still starting, because
+ * Buddy queues commands submitted against a starting sandbox. Two other groups
+ * of endpoints do not queue:
+ *
+ * - the content endpoints answer 400 "Instance is not running", or answer 2xx to
+ *   a write whose bytes never land (observed roughly once in twelve sandboxes);
+ * - `updateSandbox` answers 400 "Cannot update sandbox, operation in progress".
+ *
+ * So those calls wait here for `RUNNING` + `setup_status: SUCCESS` once per
+ * sandbox, and retry the two races until the deadline.
+ */
+
+import {
+  getSandboxData,
+  isInstanceNotRunning,
+  isOperationInProgress,
+  sleep,
+  type BuddySandboxHandle,
+} from './utils.js';
+
+/** Long enough to cover a drained warm pool; a real boot failure surfaces sooner. */
+const BOOT_WAIT_TIMEOUT_MS = 90_000;
+const BOOT_WAIT_POLL_MS = 250;
+
+/** Sandboxes already known to have booted — the gate runs at most once each. */
+const settled = new WeakSet<BuddySandboxHandle>();
+
+export async function untilSettled(sandbox: BuddySandboxHandle): Promise<void> {
+  if (settled.has(sandbox)) return;
+
+  const deadline = Date.now() + BOOT_WAIT_TIMEOUT_MS;
+  for (;;) {
+    const data = await getSandboxData(sandbox.config, sandbox.sandboxId);
+    if (data.status === 'RUNNING' && data.setup_status === 'SUCCESS') {
+      settled.add(sandbox);
+      return;
+    }
+    if (data.status === 'FAILED' || data.setup_status === 'FAILED') {
+      throw new Error(
+        `Buddy sandbox ${sandbox.sandboxId} failed to start ` +
+        `(status: ${data.status}, setup: ${data.setup_status}).`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Buddy sandbox ${sandbox.sandboxId} was still starting after ` +
+        `${BOOT_WAIT_TIMEOUT_MS / 1000}s (status: ${data.status}, setup: ${data.setup_status}).`,
+      );
+    }
+    await sleep(BOOT_WAIT_POLL_MS);
+  }
+}
+
+/**
+ * Runs an operation once the sandbox has booted, retrying the races that remain
+ * afterwards — Buddy reports a snapshot or app operation still in flight the
+ * same way.
+ */
+export async function whenBooted<T>(
+  sandbox: BuddySandboxHandle,
+  operation: () => Promise<T>,
+): Promise<T> {
+  await untilSettled(sandbox);
+
+  const deadline = Date.now() + BOOT_WAIT_TIMEOUT_MS;
+  for (;;) {
+    try {
+      return await operation();
+    } catch (error) {
+      const retryable = isInstanceNotRunning(error) || isOperationInProgress(error);
+      if (!retryable || Date.now() >= deadline) throw error;
+      await sleep(BOOT_WAIT_POLL_MS);
+    }
+  }
+}

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -86,45 +86,80 @@ export async function runCommand(
 
   // Killing the command ends the followed stream, which is what unblocks the
   // loop below — there is no way to abort the HTTP read itself.
+  let timedOut = false;
   const killTimer = options.timeout
-    ? setTimeout(() => { void running.kill().catch(() => {}); }, options.timeout)
+    ? setTimeout(() => {
+      timedOut = true;
+      void running.kill().catch(() => {});
+    }, options.timeout)
     : undefined;
 
   try {
     // `follow: true` holds the connection open until the command exits, so this
-    // loop is the wait — nothing is polled.
+    // loop is the wait — nothing is polled. Each record is one line without its
+    // terminator, so the newline goes back on here.
     for await (const log of running.logs({ follow: true })) {
       if (log.data == null) continue;
+      const chunk = `${log.data}\n`;
       if (log.type === 'STDERR') {
-        stderr.push(log.data);
-        options.onStderr?.(log.data);
+        stderr.push(chunk);
+        options.onStderr?.(chunk);
       } else {
-        stdout.push(log.data);
-        options.onStdout?.(log.data);
+        stdout.push(chunk);
+        options.onStdout?.(chunk);
       }
     }
   } finally {
     if (killTimer) clearTimeout(killTimer);
   }
 
-  const details = await sandbox.client.getCommandDetails({
-    path: { sandbox_id: sandbox.sandboxId, id: commandId },
-  });
+  const exitCode = timedOut
+    ? TIMEOUT_EXIT_CODE
+    : await waitForExitCode(sandbox, commandId);
 
   return {
     stdout: stdout.join(''),
     stderr: stderr.join(''),
-    exitCode: resolveExitCode(details),
+    exitCode,
     durationMs: Date.now() - startedAt,
   };
 }
 
+/** What a shell reports for a command killed by `timeout(1)`. */
+export const TIMEOUT_EXIT_CODE = 124;
+
+const EXIT_CODE_WAIT_MS = 5_000;
+const EXIT_CODE_POLL_MS = 200;
+
+export interface BuddyCommandDetails {
+  exit_code?: number;
+  status?: string;
+}
+
 /**
- * `exit_code` is missing while a command is still in progress, which happens
- * when the log stream ends before Buddy has recorded the result. Reporting a
- * failure there would be wrong, so the status decides.
+ * The log stream can close a moment before Buddy records the result, so the
+ * details may still say `INPROGRESS` without an `exit_code`. Treating that as
+ * success would hide failures; poll briefly until a terminal state shows up.
  */
-function resolveExitCode(details: { exit_code?: number; status?: string }): number {
-  if (typeof details.exit_code === 'number') return details.exit_code;
-  return details.status === 'FAILED' ? 1 : 0;
+export async function waitForExitCode(
+  sandbox: Pick<BuddySandboxHandle, 'client' | 'sandboxId'>,
+  commandId: string,
+  deadlineMs = EXIT_CODE_WAIT_MS,
+): Promise<number> {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    const details: BuddyCommandDetails = await sandbox.client.getCommandDetails({
+      path: { sandbox_id: sandbox.sandboxId, id: commandId },
+    });
+    if (typeof details.exit_code === 'number') return details.exit_code;
+    if (details.status === 'FAILED') return 1;
+    if (details.status === 'SUCCESSFUL') return 0;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Buddy command ${commandId} on sandbox ${sandbox.sandboxId} reported no exit code `
+        + `within ${deadlineMs / 1000}s of its log stream closing (status: ${details.status ?? 'unknown'}).`,
+      );
+    }
+    await new Promise(resolve => setTimeout(resolve, EXIT_CODE_POLL_MS));
+  }
 }

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -45,6 +45,17 @@ export async function runCommand(
   command: string,
   options: BuddyRunCommandOptions = {},
 ): Promise<CommandResult> {
+  // `ADD-PROVIDER.md` still documents an older `runCommand(command, args)`
+  // shape. Called that way, the array arrives here as `options`, where only
+  // `cwd` and `env` are read — the arguments would be dropped silently and the
+  // bare command would still exit 0. Fail loudly instead.
+  if (Array.isArray(options)) {
+    throw new TypeError(
+      `runCommand takes a command line and an options object, not an argument array. `
+      + `Pass the arguments inside the command, e.g. '${command} ${options.join(' ')}'.`,
+    );
+  }
+
   const startedAt = Date.now();
   const runtime = options.runtime ?? 'BASH';
   const payload = runtime === 'BASH' ? buildShellCommand(command, options) : command;

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -77,10 +77,34 @@ export async function runCommand(
   const runtime = options.runtime ?? 'BASH';
   const payload = runtime === 'BASH' ? buildShellCommand(command, options) : command;
 
-  const commandResponse = await sandbox.client.executeCommand({
+  const deadline = options.timeout ? startedAt + options.timeout : undefined;
+  const timedOutResult = () => ({
+    stdout: '', stderr: '', exitCode: TIMEOUT_EXIT_CODE, durationMs: Date.now() - startedAt,
+  });
+
+  // Buddy may hold the submission while the sandbox boots (up to the client's
+  // request timeout), so the deadline applies here too: when it passes first,
+  // the timeout result is returned and the command is killed once (if ever)
+  // Buddy reports it accepted.
+  const submission = sandbox.client.executeCommand({
     path: { sandbox_id: sandbox.sandboxId },
     body: { command: payload, runtime },
   });
+  const commandResponse = deadline ? await raceDeadline(submission, deadline) : await submission;
+  if (commandResponse === DEADLINE_PASSED) {
+    void submission.then(
+      response => {
+        if (!response.id) return;
+        void killCommand(new Command({
+          commandResponse: response,
+          client: sandbox.client,
+          sandboxId: sandbox.sandboxId,
+        }));
+      },
+      () => {},
+    );
+    return timedOutResult();
+  }
 
   const commandId = commandResponse.id;
   if (!commandId) {
@@ -103,9 +127,13 @@ export async function runCommand(
 
   // `follow: true` holds the connection open until the command exits, so this
   // loop is the wait — nothing is polled. Each record is one line without its
-  // terminator, so the newline goes back on here.
+  // terminator, so the newline goes back on here. Once the caller has been
+  // given the timeout result the loop stops at the next record instead of
+  // buffering output and firing callbacks for a result nobody will read.
+  let timedOut = false;
   const drain = (async () => {
     for await (const log of running.logs({ follow: true })) {
+      if (timedOut) break;
       if (log.data == null) continue;
       const chunk = `${log.data}\n`;
       if (log.type === 'STDERR') {
@@ -120,44 +148,43 @@ export async function runCommand(
 
   // The SDK stream cannot be aborted, so on timeout the result is returned
   // right away and the reader is left to finish on its own once the kill (best
-  // effort — it may fail or take the client's request timeout) closes it. The
-  // deadline counts from the call, so time spent submitting the command (which
-  // Buddy may hold while the sandbox boots) is not added on top.
-  let timedOut = false;
-  let killTimer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = options.timeout
-    ? new Promise<void>(resolve => {
-      const remaining = Math.max(0, options.timeout! - (Date.now() - startedAt));
-      killTimer = setTimeout(() => {
-        timedOut = true;
-        void killCommand(running);
-        resolve();
-      }, remaining);
-    })
-    : undefined;
-
+  // effort, retried) closes it or the next record arrives.
   try {
-    await (timeout ? Promise.race([drain, timeout]) : drain);
+    const outcome = deadline ? await raceDeadline(drain, deadline) : await drain;
+    if (outcome === DEADLINE_PASSED) {
+      timedOut = true;
+      void killCommand(running);
+      drain.catch(() => {});
+      return timedOutResult();
+    }
   } catch (error) {
     // The stream broke mid-command. Buddy keeps running it, so stop it — best
     // effort and not awaited, so a hanging kill cannot delay the error.
     void killCommand(running);
     throw error;
-  } finally {
-    if (killTimer) clearTimeout(killTimer);
-    if (timedOut) drain.catch(() => {});
   }
-
-  const exitCode = timedOut
-    ? TIMEOUT_EXIT_CODE
-    : await waitForExitCode(sandbox, commandId);
 
   return {
     stdout: stdout.join(''),
     stderr: stderr.join(''),
-    exitCode,
+    exitCode: await waitForExitCode(sandbox, commandId),
     durationMs: Date.now() - startedAt,
   };
+}
+
+const DEADLINE_PASSED = Symbol('deadline passed');
+
+/** Resolves to `DEADLINE_PASSED` if `deadline` (epoch ms) arrives first. */
+async function raceDeadline<T>(work: Promise<T>, deadline: number): Promise<T | typeof DEADLINE_PASSED> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<typeof DEADLINE_PASSED>(resolve => {
+    timer = setTimeout(() => resolve(DEADLINE_PASSED), Math.max(0, deadline - Date.now()));
+  });
+  try {
+    return await Promise.race([work, expiry]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** What a shell reports for a command killed by `timeout(1)`. */

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -13,7 +13,7 @@ import { Command } from '@buddy-works/sandbox-sdk';
 import { escapeShellArg } from '@computesdk/provider';
 import type { CommandResult, RunCommandOptions } from '@computesdk/provider';
 
-import type { BuddyCommandRuntime, BuddySandboxHandle } from './utils.js';
+import { sleep, type BuddyCommandRuntime, type BuddySandboxHandle } from './utils.js';
 
 export interface BuddyRunCommandOptions extends RunCommandOptions {
   /**
@@ -38,6 +38,23 @@ export function buildShellCommand(command: string, options: RunCommandOptions = 
     line = `cd "${escapeShellArg(options.cwd)}" && ${line}`;
   }
   return line;
+}
+
+/** A termination that fails leaves the command running remotely, so retry. */
+const KILL_ATTEMPTS = 3;
+const KILL_RETRY_DELAY_MS = 500;
+
+/** Best-effort kill: never throws, gives up after `KILL_ATTEMPTS`. */
+export async function killCommand(running: Pick<Command, 'kill'>): Promise<boolean> {
+  for (let attempt = 1; attempt <= KILL_ATTEMPTS; attempt++) {
+    try {
+      await running.kill();
+      return true;
+    } catch {
+      if (attempt < KILL_ATTEMPTS) await sleep(KILL_RETRY_DELAY_MS);
+    }
+  }
+  return false;
 }
 
 export async function runCommand(
@@ -103,16 +120,19 @@ export async function runCommand(
 
   // The SDK stream cannot be aborted, so on timeout the result is returned
   // right away and the reader is left to finish on its own once the kill (best
-  // effort — it may fail or take the client's request timeout) closes it.
+  // effort — it may fail or take the client's request timeout) closes it. The
+  // deadline counts from the call, so time spent submitting the command (which
+  // Buddy may hold while the sandbox boots) is not added on top.
   let timedOut = false;
   let killTimer: ReturnType<typeof setTimeout> | undefined;
   const timeout = options.timeout
     ? new Promise<void>(resolve => {
+      const remaining = Math.max(0, options.timeout! - (Date.now() - startedAt));
       killTimer = setTimeout(() => {
         timedOut = true;
-        void running.kill().catch(() => {});
+        void killCommand(running);
         resolve();
-      }, options.timeout);
+      }, remaining);
     })
     : undefined;
 
@@ -121,7 +141,7 @@ export async function runCommand(
   } catch (error) {
     // The stream broke mid-command. Buddy keeps running it, so stop it — best
     // effort and not awaited, so a hanging kill cannot delay the error.
-    void running.kill().catch(() => {});
+    void killCommand(running);
     throw error;
   } finally {
     if (killTimer) clearTimeout(killTimer);

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -1,0 +1,119 @@
+/**
+ * Command execution.
+ *
+ * Buddy accepts a command and returns its id immediately; output arrives over a
+ * JSONL log stream. The provider consumes that stream once through the SDK's
+ * `Command` entity, splits it into stdout/stderr and forwards chunks to the
+ * streaming callbacks, then reads the exit code from the command details.
+ * `Command.wait()` is deliberately unused — it polls once a second, which would
+ * add up to a second to every call.
+ */
+
+import { Command } from '@buddy-works/sandbox-sdk';
+import { escapeShellArg } from '@computesdk/provider';
+import type { CommandResult, RunCommandOptions } from '@computesdk/provider';
+
+import type { BuddyCommandRuntime, BuddySandboxHandle } from './utils.js';
+
+export interface BuddyRunCommandOptions extends RunCommandOptions {
+  /**
+   * Interpreter Buddy runs the command with. Defaults to `BASH`; the other
+   * runtimes take a script instead of a shell line, so `cwd` and `env` do not
+   * apply to them.
+   */
+  runtime?: BuddyCommandRuntime;
+}
+
+/** Prepends `cd` and `export` when the caller asked for a cwd or env. */
+export function buildShellCommand(command: string, options: RunCommandOptions = {}): string {
+  let line = command;
+
+  if (options.env && Object.keys(options.env).length > 0) {
+    const exports = Object.entries(options.env)
+      .map(([key, value]) => `${key}="${escapeShellArg(String(value))}"`)
+      .join(' ');
+    line = `export ${exports} && ${line}`;
+  }
+  if (options.cwd) {
+    line = `cd "${escapeShellArg(options.cwd)}" && ${line}`;
+  }
+  return line;
+}
+
+export async function runCommand(
+  sandbox: BuddySandboxHandle,
+  command: string,
+  options: BuddyRunCommandOptions = {},
+): Promise<CommandResult> {
+  const startedAt = Date.now();
+  const runtime = options.runtime ?? 'BASH';
+  const payload = runtime === 'BASH' ? buildShellCommand(command, options) : command;
+
+  const commandResponse = await sandbox.client.executeCommand({
+    path: { sandbox_id: sandbox.sandboxId },
+    body: { command: payload, runtime },
+  });
+
+  const commandId = commandResponse.id;
+  if (!commandId) {
+    throw new Error('Buddy accepted the command but returned no command id.');
+  }
+
+  const running = new Command({
+    commandResponse,
+    client: sandbox.client,
+    sandboxId: sandbox.sandboxId,
+  });
+
+  // Fire-and-forget: return as soon as Buddy has the command queued.
+  if (options.background) {
+    return { stdout: '', stderr: '', exitCode: 0, durationMs: Date.now() - startedAt };
+  }
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  // Killing the command ends the followed stream, which is what unblocks the
+  // loop below — there is no way to abort the HTTP read itself.
+  const killTimer = options.timeout
+    ? setTimeout(() => { void running.kill().catch(() => {}); }, options.timeout)
+    : undefined;
+
+  try {
+    // `follow: true` holds the connection open until the command exits, so this
+    // loop is the wait — nothing is polled.
+    for await (const log of running.logs({ follow: true })) {
+      if (log.data == null) continue;
+      if (log.type === 'STDERR') {
+        stderr.push(log.data);
+        options.onStderr?.(log.data);
+      } else {
+        stdout.push(log.data);
+        options.onStdout?.(log.data);
+      }
+    }
+  } finally {
+    if (killTimer) clearTimeout(killTimer);
+  }
+
+  const details = await sandbox.client.getCommandDetails({
+    path: { sandbox_id: sandbox.sandboxId, id: commandId },
+  });
+
+  return {
+    stdout: stdout.join(''),
+    stderr: stderr.join(''),
+    exitCode: resolveExitCode(details),
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+/**
+ * `exit_code` is missing while a command is still in progress, which happens
+ * when the log stream ends before Buddy has recorded the result. Reporting a
+ * failure there would be wrong, so the status decides.
+ */
+function resolveExitCode(details: { exit_code?: number; status?: string }): number {
+  if (typeof details.exit_code === 'number') return details.exit_code;
+  return details.status === 'FAILED' ? 1 : 0;
+}

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -118,6 +118,11 @@ export async function runCommand(
 
   try {
     await (timeout ? Promise.race([drain, timeout]) : drain);
+  } catch (error) {
+    // The stream broke mid-command. Buddy keeps running it, so stop it — best
+    // effort and not awaited, so a hanging kill cannot delay the error.
+    void running.kill().catch(() => {});
+    throw error;
   } finally {
     if (killTimer) clearTimeout(killTimer);
     if (timedOut) drain.catch(() => {});

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -84,20 +84,10 @@ export async function runCommand(
   const stdout: string[] = [];
   const stderr: string[] = [];
 
-  // Killing the command ends the followed stream, which is what unblocks the
-  // loop below — there is no way to abort the HTTP read itself.
-  let timedOut = false;
-  const killTimer = options.timeout
-    ? setTimeout(() => {
-      timedOut = true;
-      void running.kill().catch(() => {});
-    }, options.timeout)
-    : undefined;
-
-  try {
-    // `follow: true` holds the connection open until the command exits, so this
-    // loop is the wait — nothing is polled. Each record is one line without its
-    // terminator, so the newline goes back on here.
+  // `follow: true` holds the connection open until the command exits, so this
+  // loop is the wait — nothing is polled. Each record is one line without its
+  // terminator, so the newline goes back on here.
+  const drain = (async () => {
     for await (const log of running.logs({ follow: true })) {
       if (log.data == null) continue;
       const chunk = `${log.data}\n`;
@@ -109,8 +99,28 @@ export async function runCommand(
         options.onStdout?.(chunk);
       }
     }
+  })();
+
+  // The SDK stream cannot be aborted, so on timeout the result is returned
+  // right away and the reader is left to finish on its own once the kill (best
+  // effort — it may fail or take the client's request timeout) closes it.
+  let timedOut = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = options.timeout
+    ? new Promise<void>(resolve => {
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        void running.kill().catch(() => {});
+        resolve();
+      }, options.timeout);
+    })
+    : undefined;
+
+  try {
+    await (timeout ? Promise.race([drain, timeout]) : drain);
   } finally {
     if (killTimer) clearTimeout(killTimer);
+    if (timedOut) drain.catch(() => {});
   }
 
   const exitCode = timedOut

--- a/packages/buddy/src/commands.ts
+++ b/packages/buddy/src/commands.ts
@@ -24,13 +24,28 @@ export interface BuddyRunCommandOptions extends RunCommandOptions {
   runtime?: BuddyCommandRuntime;
 }
 
-/** Prepends `cd` and `export` when the caller asked for a cwd or env. */
+/** What a POSIX shell accepts as a variable name. */
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Prepends `cd` and `export` when the caller asked for a cwd or env. Values are
+ * escaped; names cannot be, so a name that is not a valid identifier is
+ * rejected instead of being spliced into the shell line.
+ */
 export function buildShellCommand(command: string, options: RunCommandOptions = {}): string {
   let line = command;
 
   if (options.env && Object.keys(options.env).length > 0) {
     const exports = Object.entries(options.env)
-      .map(([key, value]) => `${key}="${escapeShellArg(String(value))}"`)
+      .map(([key, value]) => {
+        if (!ENV_NAME.test(key)) {
+          throw new TypeError(
+            `Invalid environment variable name ${JSON.stringify(key)}: `
+            + 'names must match /^[A-Za-z_][A-Za-z0-9_]*$/.',
+          );
+        }
+        return `${key}="${escapeShellArg(String(value))}"`;
+      })
       .join(' ');
     line = `export ${exports} && ${line}`;
   }
@@ -78,8 +93,8 @@ export async function runCommand(
   const payload = runtime === 'BASH' ? buildShellCommand(command, options) : command;
 
   const deadline = options.timeout ? startedAt + options.timeout : undefined;
-  const timedOutResult = () => ({
-    stdout: '', stderr: '', exitCode: TIMEOUT_EXIT_CODE, durationMs: Date.now() - startedAt,
+  const timedOutResult = (stdout = '', stderr = '') => ({
+    stdout, stderr, exitCode: TIMEOUT_EXIT_CODE, durationMs: Date.now() - startedAt,
   });
 
   // Buddy may hold the submission while the sandbox boots (up to the client's
@@ -147,15 +162,16 @@ export async function runCommand(
   })();
 
   // The SDK stream cannot be aborted, so on timeout the result is returned
-  // right away and the reader is left to finish on its own once the kill (best
-  // effort, retried) closes it or the next record arrives.
+  // right away — with whatever output arrived before the deadline — and the
+  // reader is left to finish on its own once the kill (best effort, retried)
+  // closes it or the next record arrives.
   try {
     const outcome = deadline ? await raceDeadline(drain, deadline) : await drain;
     if (outcome === DEADLINE_PASSED) {
       timedOut = true;
       void killCommand(running);
       drain.catch(() => {});
-      return timedOutResult();
+      return timedOutResult(stdout.join(''), stderr.join(''));
     }
   } catch (error) {
     // The stream broke mid-command. Buddy keeps running it, so stop it — best

--- a/packages/buddy/src/filesystem.ts
+++ b/packages/buddy/src/filesystem.ts
@@ -1,0 +1,83 @@
+/**
+ * Filesystem operations.
+ *
+ * These go through the SDK's `FileSystem`, which talks to Buddy's `content/`
+ * endpoints — one round trip per operation and binary-safe, unlike shelling out
+ * to `cat`/`tee`.
+ *
+ * Every call goes through the boot gate in `boot.ts`, because unlike commands
+ * these endpoints do not queue against a sandbox that is still starting.
+ */
+
+import type { FileEntry } from '@computesdk/provider';
+
+import { whenBooted } from './boot.js';
+import {
+  isNotFound,
+  normalizeSandboxPath,
+  toContentPath,
+  type BuddySandboxHandle,
+} from './utils.js';
+
+export async function readFile(sandbox: BuddySandboxHandle, path: string): Promise<string> {
+  const target = normalizeSandboxPath(path);
+  const buffer = await whenBooted(sandbox, () => sandbox.fs.downloadFile(target));
+  return buffer.toString('utf-8');
+}
+
+export async function writeFile(
+  sandbox: BuddySandboxHandle,
+  path: string,
+  content: string,
+): Promise<void> {
+  const target = normalizeSandboxPath(path);
+  const parent = target.slice(0, target.lastIndexOf('/'));
+
+  await whenBooted(sandbox, async () => {
+    // Buddy will not create missing parents for an upload, and mirroring
+    // `fs.writeFile` here is what callers expect.
+    if (parent) {
+      await sandbox.fs.createFolder(parent).catch(() => {});
+    }
+    await sandbox.fs.uploadFile(Buffer.from(content, 'utf-8'), target);
+  });
+}
+
+export async function mkdir(sandbox: BuddySandboxHandle, path: string): Promise<void> {
+  const target = normalizeSandboxPath(path);
+  await whenBooted(sandbox, () => sandbox.fs.createFolder(target));
+}
+
+export async function readdir(sandbox: BuddySandboxHandle, path: string): Promise<FileEntry[]> {
+  const target = normalizeSandboxPath(path);
+  const entries = await whenBooted(sandbox, () => sandbox.fs.listFiles(target));
+
+  return entries.map(entry => ({
+    name: entry.name ?? '',
+    type: entry.type === 'DIR' ? 'directory' as const : 'file' as const,
+    // The API reports sizes as bigint; ComputeSDK wants a number.
+    ...(entry.size == null ? {} : { size: Number(entry.size) }),
+  }));
+}
+
+export async function exists(sandbox: BuddySandboxHandle, path: string): Promise<boolean> {
+  const target = toContentPath(path);
+  try {
+    await whenBooted(sandbox, () =>
+      sandbox.client.getSandboxContent({ path: { sandbox_id: sandbox.sandboxId, path: target } }));
+    return true;
+  } catch (error) {
+    if (isNotFound(error)) return false;
+    throw error;
+  }
+}
+
+export async function remove(sandbox: BuddySandboxHandle, path: string): Promise<void> {
+  const target = normalizeSandboxPath(path);
+  try {
+    await whenBooted(sandbox, () => sandbox.fs.deleteFile(target));
+  } catch (error) {
+    // Removing something that is already gone is not an error for callers.
+    if (!isNotFound(error)) throw error;
+  }
+}

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -91,7 +91,7 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
           body: buildCreateBody(resolved, options),
         });
 
-        const sandbox = toHandle(resolved, created);
+        const sandbox = toHandle(resolved, created, new Date(), false);
         try {
           await ensureTimeout(sandbox, options?.timeout ?? resolved.timeout);
         } catch (error) {
@@ -153,6 +153,7 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
           createdAt: sandbox.createdAt,
           timeout: data.timeout != null ? data.timeout * 1000 : sandbox.timeout,
           metadata: {
+            createdAtIsReconnectTime: sandbox.createdAtIsReconnectTime,
             identifier: data.identifier ?? sandbox.identifier,
             name: data.name,
             os: data.os,

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -72,7 +72,14 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
         });
 
         const sandbox = toHandle(resolved, created);
-        await ensureTimeout(sandbox, options?.timeout ?? resolved.timeout);
+        try {
+          await ensureTimeout(sandbox, options?.timeout ?? resolved.timeout);
+        } catch (error) {
+          // The framework has no id yet, so nothing else could clean this up.
+          await sandbox.client.deleteSandboxById({ path: { id: sandbox.sandboxId } })
+            .catch(() => {});
+          throw error;
+        }
         return { sandbox, sandboxId: sandbox.sandboxId };
       },
 
@@ -209,6 +216,11 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
   },
 });
 
+/** Buddy takes whole seconds; rounding up keeps the sandbox alive at least as long as asked. */
+export function toSeconds(ms: number): number {
+  return Math.max(1, Math.ceil(ms / 1000));
+}
+
 function buildCreateBody(config: ResolvedBuddyConfig, options: CreateSandboxOptions = {}) {
   const name = options.name ?? generateSandboxName();
   const timeoutMs = options.timeout ?? config.timeout;
@@ -220,7 +232,7 @@ function buildCreateBody(config: ResolvedBuddyConfig, options: CreateSandboxOpti
     name,
     identifier: toIdentifier(name),
     os: options.image ?? config.os,
-    timeout: Math.max(1, Math.round(timeoutMs / 1000)),
+    timeout: toSeconds(timeoutMs),
   };
 
   const resources = resolveResources(options, config.resources);
@@ -253,8 +265,8 @@ export async function ensureTimeout(
   sandbox: BuddySandboxHandle,
   timeoutMs: number,
 ): Promise<void> {
-  const seconds = Math.max(1, Math.round(timeoutMs / 1000));
-  if (Math.round(sandbox.timeout / 1000) === seconds) return;
+  const seconds = toSeconds(timeoutMs);
+  if (toSeconds(sandbox.timeout) === seconds) return;
   const updated = await whenBooted(sandbox, () => sandbox.client.updateSandbox({
     path: { id: sandbox.sandboxId },
     body: { timeout: seconds } as any,

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -125,6 +125,11 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
         options?: BuddyRunCommandOptions,
       ) => runCommand(sandbox, command, options),
 
+      // `runCommand` already forwards `onStdout`/`onStderr` from Buddy's own
+      // log stream. Without this the factory would ignore that and bootstrap
+      // its Node-based streaming daemon inside the sandbox instead.
+      streamCommand: runCommand,
+
       getInfo: async (sandbox: BuddySandboxHandle): Promise<SandboxInfo> => {
         const data = await getSandboxData(sandbox.config, sandbox.sandboxId);
         sandbox.endpoints = data.endpoints ?? sandbox.endpoints;

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -16,6 +16,7 @@ import { defineProvider } from '@computesdk/provider';
 import type {
   CreateSandboxOptions,
   ListSnapshotsOptions,
+  ListTemplatesOptions,
   SandboxInfo,
 } from '@computesdk/provider';
 import type { Snapshot } from 'computesdk';
@@ -71,6 +72,7 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
         });
 
         const sandbox = toHandle(resolved, created);
+        await ensureTimeout(sandbox, options?.timeout ?? resolved.timeout);
         return { sandbox, sandboxId: sandbox.sandboxId };
       },
 
@@ -199,7 +201,8 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
           'then boot from it with compute.sandbox.create({ snapshotId: snapshot.id }).',
         );
       },
-      list: (config: BuddyConfig) => listSnapshots(resolveConfig(config)),
+      list: (config: BuddyConfig, options?: ListTemplatesOptions) =>
+        listSnapshots(resolveConfig(config), options),
       delete: (config: BuddyConfig, templateId: string) =>
         deleteSnapshot(resolveConfig(config), templateId),
     },
@@ -242,19 +245,49 @@ function buildCreateBody(config: ResolvedBuddyConfig, options: CreateSandboxOpti
 }
 
 /**
- * Endpoint updates in flight, per sandbox. Buddy replaces the whole endpoint
- * list on update, so two concurrent `getUrl` calls built from the same list
- * would each drop the other's port — they run one after another instead.
+ * Buddy's create-from-snapshot request has no `timeout` field (the SDK schema
+ * strips it), so a sandbox booted from a snapshot comes back with whatever the
+ * snapshot carried. Patch it afterwards when it differs from what was asked.
  */
-const endpointUpdates = new WeakMap<BuddySandboxHandle, Promise<unknown>>();
+export async function ensureTimeout(
+  sandbox: BuddySandboxHandle,
+  timeoutMs: number,
+): Promise<void> {
+  const seconds = Math.max(1, Math.round(timeoutMs / 1000));
+  if (Math.round(sandbox.timeout / 1000) === seconds) return;
+  const updated = await whenBooted(sandbox, () => sandbox.client.updateSandbox({
+    path: { id: sandbox.sandboxId },
+    body: { timeout: seconds } as any,
+  }));
+  sandbox.timeout = updated.timeout != null ? updated.timeout * 1000 : seconds * 1000;
+}
+
+/**
+ * Endpoint updates in flight, per remote sandbox. Buddy replaces the whole
+ * endpoint list on update, so two concurrent `getUrl` calls built from the same
+ * list would each drop the other's port — they run one after another instead.
+ * Keyed by installation + sandbox id rather than by handle: `getById` and
+ * `list` hand out a fresh handle each time for the same remote sandbox.
+ */
+const endpointUpdates = new Map<string, Promise<unknown>>();
+
+function endpointUpdateKey(sandbox: BuddySandboxHandle): string {
+  return `${sandbox.config.apiUrl}|${sandbox.config.workspace}|${sandbox.sandboxId}`;
+}
 
 function getUrl(
   sandbox: BuddySandboxHandle,
   options: { port: number; protocol?: string },
 ): Promise<string> {
-  const previous = endpointUpdates.get(sandbox) ?? Promise.resolve();
+  const key = endpointUpdateKey(sandbox);
+  const previous = endpointUpdates.get(key) ?? Promise.resolve();
   const next = previous.catch(() => {}).then(() => openPort(sandbox, options));
-  endpointUpdates.set(sandbox, next);
+  endpointUpdates.set(key, next);
+  // Drop the entry once nothing newer is queued behind it, so the map only
+  // ever holds sandboxes with an update actually in flight.
+  next.catch(() => {}).finally(() => {
+    if (endpointUpdates.get(key) === next) endpointUpdates.delete(key);
+  });
   return next;
 }
 

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -1,0 +1,296 @@
+/**
+ * Buddy provider for ComputeSDK.
+ *
+ * Buddy serves Ubuntu sandboxes from a pre-warmed pool, so `create` returns a
+ * sandbox that is already booting and commands submitted to it are queued until
+ * it is up. The provider does not wait for `RUNNING` on create — that keeps
+ * time-to-first-command at the warm-pool latency instead of a poll interval.
+ *
+ * Snapshots are Buddy's only reusable image, so `compute.template.*` is mapped
+ * onto them.
+ *
+ * @see https://buddy.works/docs/api/sandboxes
+ */
+
+import { defineProvider } from '@computesdk/provider';
+import type {
+  CreateSandboxOptions,
+  ListSnapshotsOptions,
+  SandboxInfo,
+} from '@computesdk/provider';
+import type { Snapshot } from 'computesdk';
+
+import { whenBooted } from './boot.js';
+import { runCommand, type BuddyRunCommandOptions } from './commands.js';
+import * as fs from './filesystem.js';
+import { createSnapshot, deleteSnapshot, listSnapshots } from './snapshots.js';
+import {
+  PROVIDER,
+  applyProtocol,
+  endpointMatchesPort,
+  endpointPublicUrl,
+  generateSandboxName,
+  getClient,
+  getSandboxData,
+  isNotFound,
+  isUnroutableId,
+  mapStatus,
+  normalizePort,
+  resolveConfig,
+  resolveResources,
+  sleep,
+  statusOf,
+  toEndpointPayload,
+  toHandle,
+  toIdentifier,
+  type BuddyConfig,
+  type BuddyEndpoint,
+  type BuddyPortInput,
+  type BuddySandboxHandle,
+  type ResolvedBuddyConfig,
+} from './utils.js';
+
+/** Deleting a just-created sandbox occasionally answers 5xx while succeeding. */
+const DESTROY_ATTEMPTS = 3;
+const DESTROY_RETRY_DELAY_MS = 500;
+
+/** A tunnel is registered instantly but takes a moment to get its public URL. */
+const URL_WAIT_TIMEOUT_MS = 15_000;
+const URL_WAIT_POLL_MS = 250;
+
+export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapshot>({
+  name: PROVIDER,
+
+  methods: {
+    sandbox: {
+      create: async (config: BuddyConfig, options?: CreateSandboxOptions) => {
+        const resolved = resolveConfig(config);
+        const created = await getClient(resolved).addSandbox({
+          body: buildCreateBody(resolved, options),
+        });
+
+        const sandbox = toHandle(resolved, created);
+        return { sandbox, sandboxId: sandbox.sandboxId };
+      },
+
+      getById: async (config: BuddyConfig, sandboxId: string) => {
+        const resolved = resolveConfig(config);
+        try {
+          const data = await getSandboxData(resolved, sandboxId);
+          const sandbox = toHandle(resolved, data);
+          return { sandbox, sandboxId: sandbox.sandboxId };
+        } catch (error) {
+          if (isNotFound(error) || isUnroutableId(error)) return null;
+          throw error;
+        }
+      },
+
+      list: async (config: BuddyConfig) => {
+        const resolved = resolveConfig(config);
+        const response = await getClient(resolved).getSandboxes({});
+
+        // The listing carries ids only; details are fetched on demand by
+        // getInfo, so listing a hundred sandboxes stays a single request.
+        return (response.sandboxes ?? [])
+          .filter(entry => Boolean(entry.id))
+          .map(entry => {
+            const sandbox = toHandle(resolved, entry);
+            return { sandbox, sandboxId: sandbox.sandboxId };
+          });
+      },
+
+      destroy: async (config: BuddyConfig, sandboxId: string) => {
+        const resolved = resolveConfig(config);
+        const client = getClient(resolved);
+
+        for (let attempt = 1; attempt <= DESTROY_ATTEMPTS; attempt++) {
+          try {
+            await client.deleteSandboxById({ path: { id: sandboxId } });
+            return;
+          } catch (error) {
+            // Already gone is the state the caller asked for.
+            if (isNotFound(error)) return;
+            const status = statusOf(error);
+            const retryable = status !== undefined && status >= 500;
+            if (!retryable || attempt === DESTROY_ATTEMPTS) throw error;
+            await sleep(DESTROY_RETRY_DELAY_MS);
+          }
+        }
+      },
+
+      runCommand: async (
+        sandbox: BuddySandboxHandle,
+        command: string,
+        options?: BuddyRunCommandOptions,
+      ) => runCommand(sandbox, command, options),
+
+      getInfo: async (sandbox: BuddySandboxHandle): Promise<SandboxInfo> => {
+        const data = await getSandboxData(sandbox.config, sandbox.sandboxId);
+        sandbox.endpoints = data.endpoints ?? sandbox.endpoints;
+
+        return {
+          id: sandbox.sandboxId,
+          provider: PROVIDER,
+          status: mapStatus(data.status),
+          createdAt: sandbox.createdAt,
+          timeout: data.timeout != null ? data.timeout * 1000 : sandbox.timeout,
+          metadata: {
+            identifier: data.identifier ?? sandbox.identifier,
+            name: data.name,
+            os: data.os,
+            resources: data.resources,
+            buddyStatus: data.status,
+            setupStatus: data.setup_status,
+            workspace: sandbox.config.workspace,
+            project: sandbox.config.project,
+            region: sandbox.config.region,
+            endpoints: (data.endpoints ?? []).map(endpoint => ({
+              name: endpoint.name,
+              port: Number(endpoint.endpoint),
+              type: endpoint.type,
+              url: endpointPublicUrl(endpoint),
+            })),
+          },
+        };
+      },
+
+      getUrl: async (sandbox: BuddySandboxHandle, options: { port: number; protocol?: string }) =>
+        getUrl(sandbox, options),
+
+      getInstance: (sandbox: BuddySandboxHandle) => sandbox,
+
+      filesystem: {
+        readFile: (sandbox: BuddySandboxHandle, path: string) => fs.readFile(sandbox, path),
+        writeFile: (sandbox: BuddySandboxHandle, path: string, content: string) =>
+          fs.writeFile(sandbox, path, content),
+        mkdir: (sandbox: BuddySandboxHandle, path: string) => fs.mkdir(sandbox, path),
+        readdir: (sandbox: BuddySandboxHandle, path: string) => fs.readdir(sandbox, path),
+        exists: (sandbox: BuddySandboxHandle, path: string) => fs.exists(sandbox, path),
+        remove: (sandbox: BuddySandboxHandle, path: string) => fs.remove(sandbox, path),
+      },
+    },
+
+    snapshot: {
+      create: (config: BuddyConfig, sandboxId: string, options?: { name?: string }) =>
+        createSnapshot(resolveConfig(config), sandboxId, options),
+      list: (config: BuddyConfig, options?: ListSnapshotsOptions) =>
+        listSnapshots(resolveConfig(config), options),
+      delete: (config: BuddyConfig, snapshotId: string) =>
+        deleteSnapshot(resolveConfig(config), snapshotId),
+    },
+
+    /**
+     * Buddy has no separate template entity — a snapshot is the reusable image,
+     * and `create({ templateId })` boots from one. So listing and deleting
+     * templates operate on snapshots, and creating one points the caller at
+     * `compute.snapshot.create`, which is where an image comes from.
+     */
+    template: {
+      create: async () => {
+        throw new Error(
+          'Buddy does not have templates as a separate entity. Snapshot a ' +
+          'configured sandbox instead: const snapshot = await compute.snapshot.create(sandboxId), ' +
+          'then boot from it with compute.sandbox.create({ snapshotId: snapshot.id }).',
+        );
+      },
+      list: (config: BuddyConfig) => listSnapshots(resolveConfig(config)),
+      delete: (config: BuddyConfig, templateId: string) =>
+        deleteSnapshot(resolveConfig(config), templateId),
+    },
+  },
+});
+
+function buildCreateBody(config: ResolvedBuddyConfig, options: CreateSandboxOptions = {}) {
+  const name = options.name ?? generateSandboxName();
+  const timeoutMs = options.timeout ?? config.timeout;
+  // `templateId` is accepted alongside `snapshotId` because Buddy's template
+  // methods are backed by snapshots — both carry a snapshot id.
+  const snapshotId = options.snapshotId ?? options.templateId;
+
+  const body: Record<string, unknown> = {
+    name,
+    identifier: toIdentifier(name),
+    os: options.image ?? config.os,
+    timeout: Math.max(1, Math.round(timeoutMs / 1000)),
+  };
+
+  const resources = resolveResources(options, config.resources);
+  if (resources) body.resources = resources;
+
+  // Buddy-specific create options, passed through as they are named in the API.
+  if (options.firstBootCommands) body.first_boot_commands = options.firstBootCommands;
+  if (options.appDir) body.app_dir = options.appDir;
+  if (options.tags) body.tags = options.tags;
+
+  const ports = options.ports ?? config.ports;
+  if (ports?.length) {
+    body.endpoints = ports.map((port: BuddyPortInput) =>
+      toEndpointPayload(normalizePort(port, config)));
+  }
+  if (options.envs && Object.keys(options.envs).length > 0) {
+    body.variables = Object.entries(options.envs).map(([key, value]) => ({ key, value }));
+  }
+  if (snapshotId) body.snapshot_id = snapshotId;
+
+  return body as any;
+}
+
+async function getUrl(
+  sandbox: BuddySandboxHandle,
+  options: { port: number; protocol?: string },
+): Promise<string> {
+  const { port, protocol } = options;
+  const existing = await findEndpointUrl(sandbox, port);
+  if (existing) return applyProtocol(existing, protocol);
+
+  const desired = normalizePort({ port }, sandbox.config);
+  // Buddy replaces the whole endpoint list on update, so previously opened
+  // tunnels have to be sent back or they would be torn down here.
+  const kept = sandbox.endpoints
+    .filter(endpoint => !endpointMatchesPort(endpoint, port))
+    .map(toEndpointUpdate);
+
+  // Buddy refuses configuration changes while the sandbox is still starting.
+  const updated = await whenBooted(sandbox, () => sandbox.client.updateSandbox({
+    path: { id: sandbox.sandboxId },
+    body: { endpoints: [...kept, toEndpointPayload(desired)] } as any,
+  }));
+  sandbox.endpoints = (updated.endpoints ?? sandbox.endpoints) as BuddyEndpoint[];
+
+  const deadline = Date.now() + URL_WAIT_TIMEOUT_MS;
+  for (;;) {
+    const url = await findEndpointUrl(sandbox, port);
+    if (url) return applyProtocol(url, protocol);
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Buddy opened a tunnel to port ${port} on sandbox ${sandbox.sandboxId} ` +
+        `but published no public URL within ${URL_WAIT_TIMEOUT_MS / 1000}s.`,
+      );
+    }
+    await sleep(URL_WAIT_POLL_MS);
+  }
+}
+
+async function findEndpointUrl(
+  sandbox: BuddySandboxHandle,
+  port: number,
+): Promise<string | undefined> {
+  const data = await getSandboxData(sandbox.config, sandbox.sandboxId);
+  sandbox.endpoints = data.endpoints ?? [];
+  const match = sandbox.endpoints.find(endpoint => endpointMatchesPort(endpoint, port));
+  return match ? endpointPublicUrl(match) : undefined;
+}
+
+/** Strips the read-only fields Buddy rejects when an endpoint is sent back. */
+function toEndpointUpdate(endpoint: BuddyEndpoint): BuddyEndpoint {
+  return {
+    name: endpoint.name,
+    endpoint: endpoint.endpoint,
+    type: endpoint.type,
+    region: endpoint.region,
+    ...(endpoint.whitelist ? { whitelist: endpoint.whitelist } : {}),
+  };
+}
+
+export type { BuddyConfig, BuddySandboxHandle as BuddySandbox } from './utils.js';
+export type { BuddyRunCommandOptions } from './commands.js';

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -41,6 +41,7 @@ import {
   sleep,
   statusOf,
   toEndpointPayload,
+  toEndpointUpdate,
   toHandle,
   toIdentifier,
   type BuddyConfig,
@@ -235,7 +236,24 @@ function buildCreateBody(config: ResolvedBuddyConfig, options: CreateSandboxOpti
   return body as any;
 }
 
-async function getUrl(
+/**
+ * Endpoint updates in flight, per sandbox. Buddy replaces the whole endpoint
+ * list on update, so two concurrent `getUrl` calls built from the same list
+ * would each drop the other's port — they run one after another instead.
+ */
+const endpointUpdates = new WeakMap<BuddySandboxHandle, Promise<unknown>>();
+
+function getUrl(
+  sandbox: BuddySandboxHandle,
+  options: { port: number; protocol?: string },
+): Promise<string> {
+  const previous = endpointUpdates.get(sandbox) ?? Promise.resolve();
+  const next = previous.catch(() => {}).then(() => openPort(sandbox, options));
+  endpointUpdates.set(sandbox, next);
+  return next;
+}
+
+async function openPort(
   sandbox: BuddySandboxHandle,
   options: { port: number; protocol?: string },
 ): Promise<string> {
@@ -279,17 +297,6 @@ async function findEndpointUrl(
   sandbox.endpoints = data.endpoints ?? [];
   const match = sandbox.endpoints.find(endpoint => endpointMatchesPort(endpoint, port));
   return match ? endpointPublicUrl(match) : undefined;
-}
-
-/** Strips the read-only fields Buddy rejects when an endpoint is sent back. */
-function toEndpointUpdate(endpoint: BuddyEndpoint): BuddyEndpoint {
-  return {
-    name: endpoint.name,
-    endpoint: endpoint.endpoint,
-    type: endpoint.type,
-    region: endpoint.region,
-    ...(endpoint.whitelist ? { whitelist: endpoint.whitelist } : {}),
-  };
 }
 
 export type { BuddyConfig, BuddySandboxHandle as BuddySandbox } from './utils.js';

--- a/packages/buddy/src/index.ts
+++ b/packages/buddy/src/index.ts
@@ -21,6 +21,7 @@ import type {
 } from '@computesdk/provider';
 import type { Snapshot } from 'computesdk';
 
+import type { BuddyApiClient } from '@buddy-works/sandbox-sdk';
 import { whenBooted } from './boot.js';
 import { runCommand, type BuddyRunCommandOptions } from './commands.js';
 import * as fs from './filesystem.js';
@@ -60,6 +61,25 @@ const DESTROY_RETRY_DELAY_MS = 500;
 const URL_WAIT_TIMEOUT_MS = 15_000;
 const URL_WAIT_POLL_MS = 250;
 
+/**
+ * Deletes a sandbox, retrying transient server failures. "Already gone" is the
+ * state the caller asked for, so it counts as success.
+ */
+export async function deleteSandbox(client: BuddyApiClient, sandboxId: string): Promise<void> {
+  for (let attempt = 1; attempt <= DESTROY_ATTEMPTS; attempt++) {
+    try {
+      await client.deleteSandboxById({ path: { id: sandboxId } });
+      return;
+    } catch (error) {
+      if (isNotFound(error)) return;
+      const status = statusOf(error);
+      const retryable = status !== undefined && status >= 500;
+      if (!retryable || attempt === DESTROY_ATTEMPTS) throw error;
+      await sleep(DESTROY_RETRY_DELAY_MS);
+    }
+  }
+}
+
 export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapshot>({
   name: PROVIDER,
 
@@ -76,8 +96,7 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
           await ensureTimeout(sandbox, options?.timeout ?? resolved.timeout);
         } catch (error) {
           // The framework has no id yet, so nothing else could clean this up.
-          await sandbox.client.deleteSandboxById({ path: { id: sandbox.sandboxId } })
-            .catch(() => {});
+          await deleteSandbox(sandbox.client, sandbox.sandboxId).catch(() => {});
           throw error;
         }
         return { sandbox, sandboxId: sandbox.sandboxId };
@@ -109,24 +128,8 @@ export const buddy = defineProvider<BuddySandboxHandle, BuddyConfig, any, Snapsh
           });
       },
 
-      destroy: async (config: BuddyConfig, sandboxId: string) => {
-        const resolved = resolveConfig(config);
-        const client = getClient(resolved);
-
-        for (let attempt = 1; attempt <= DESTROY_ATTEMPTS; attempt++) {
-          try {
-            await client.deleteSandboxById({ path: { id: sandboxId } });
-            return;
-          } catch (error) {
-            // Already gone is the state the caller asked for.
-            if (isNotFound(error)) return;
-            const status = statusOf(error);
-            const retryable = status !== undefined && status >= 500;
-            if (!retryable || attempt === DESTROY_ATTEMPTS) throw error;
-            await sleep(DESTROY_RETRY_DELAY_MS);
-          }
-        }
-      },
+      destroy: async (config: BuddyConfig, sandboxId: string) =>
+        deleteSandbox(getClient(resolveConfig(config)), sandboxId),
 
       runCommand: async (
         sandbox: BuddySandboxHandle,

--- a/packages/buddy/src/snapshots.ts
+++ b/packages/buddy/src/snapshots.ts
@@ -1,0 +1,126 @@
+/**
+ * Snapshots — filesystem images of a sandbox that a new sandbox can boot from.
+ *
+ * Buddy creates them asynchronously: the create call returns `status: CREATING`
+ * and the snapshot cannot be restored until it turns `CREATED`. The provider
+ * waits for that here so callers get a snapshot they can actually use. The
+ * wait uses a 500 ms poll rather than the SDK entity's 2 s one, because typical
+ * snapshots settle in well under a second.
+ */
+
+import type { CreateSnapshotOptions, ListSnapshotsOptions } from '@computesdk/provider';
+import type { Snapshot } from 'computesdk';
+
+import {
+  PROVIDER,
+  getClient,
+  isNotFound,
+  sleep,
+  toIdentifier,
+  type ResolvedBuddyConfig,
+} from './utils.js';
+
+const SNAPSHOT_WAIT_TIMEOUT_MS = 180_000;
+const SNAPSHOT_WAIT_POLL_MS = 500;
+
+interface BuddySnapshotData {
+  id?: string;
+  name?: string;
+  size?: number;
+  status?: string;
+  create_date?: Date | string;
+}
+
+function toSnapshot(data: BuddySnapshotData, sandboxId?: string): Snapshot {
+  if (!data.id) {
+    throw new Error('Buddy API returned a snapshot without an id.');
+  }
+  return {
+    id: data.id,
+    provider: PROVIDER,
+    createdAt: data.create_date ? new Date(data.create_date) : new Date(),
+    metadata: {
+      name: data.name,
+      status: data.status,
+      sizeGb: data.size,
+      ...(sandboxId ? { sandboxId } : {}),
+    },
+  };
+}
+
+export async function createSnapshot(
+  config: ResolvedBuddyConfig,
+  sandboxId: string,
+  options: CreateSnapshotOptions = {},
+): Promise<Snapshot> {
+  const client = getClient(config);
+  const created = await client.addSandboxSnapshot({
+    path: { sandbox_id: sandboxId },
+    body: { name: toIdentifier(options.name ?? `computesdk-${Date.now()}`) },
+  });
+
+  const snapshotId = created.id;
+  if (!snapshotId) {
+    throw new Error('Buddy accepted the snapshot but returned no snapshot id.');
+  }
+
+  const ready = await waitUntilCreated(config, sandboxId, snapshotId, created);
+  return toSnapshot(ready, sandboxId);
+}
+
+async function waitUntilCreated(
+  config: ResolvedBuddyConfig,
+  sandboxId: string,
+  snapshotId: string,
+  initial: BuddySnapshotData,
+): Promise<BuddySnapshotData> {
+  if (initial.status === 'CREATED') return initial;
+
+  const client = getClient(config);
+  const deadline = Date.now() + SNAPSHOT_WAIT_TIMEOUT_MS;
+  for (;;) {
+    const data = await client.getSandboxSnapshot({
+      path: { sandbox_id: sandboxId, id: snapshotId },
+    }) as BuddySnapshotData;
+
+    if (data.status === 'CREATED') return data;
+    if (data.status === 'FAILED') {
+      throw new Error(`Buddy snapshot ${snapshotId} failed to be created.`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Buddy snapshot ${snapshotId} was still ${data.status} after ` +
+        `${SNAPSHOT_WAIT_TIMEOUT_MS / 1000}s.`,
+      );
+    }
+    await sleep(SNAPSHOT_WAIT_POLL_MS);
+  }
+}
+
+export async function listSnapshots(
+  config: ResolvedBuddyConfig,
+  options: ListSnapshotsOptions = {},
+): Promise<Snapshot[]> {
+  const client = getClient(config);
+  // Default to the project-wide listing: snapshots outlive the sandbox they were
+  // taken from, so the per-sandbox endpoint would hide most of them.
+  const response = options.sandboxId
+    ? await client.getSandboxSnapshots({ path: { sandbox_id: options.sandboxId } })
+    : await client.getProjectSnapshots({});
+
+  const snapshots = (response.snapshots ?? [])
+    .map(snapshot => toSnapshot(snapshot as BuddySnapshotData, options.sandboxId));
+  return options.limit ? snapshots.slice(0, options.limit) : snapshots;
+}
+
+export async function deleteSnapshot(
+  config: ResolvedBuddyConfig,
+  snapshotId: string,
+): Promise<void> {
+  try {
+    await getClient(config).deleteSnapshot({ path: { id: snapshotId } });
+  } catch (error) {
+    // Deleting an already-deleted snapshot is the state the caller wanted.
+    if (!isNotFound(error)) throw error;
+  }
+}

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -264,10 +264,19 @@ export function isAuthError(error: unknown): boolean {
   return status === 401 || status === 403;
 }
 
-/** Resolves a caller-supplied path to an absolute one and collapses slashes. */
+/**
+ * Resolves a caller-supplied path to an absolute one: relative paths are taken
+ * from the sandbox home, `.` and `..` are resolved, and repeated slashes are
+ * collapsed, so `/tmp/..` is rejected the same way `/` is.
+ */
 export function normalizeSandboxPath(path: string): string {
   const absolute = path.startsWith('/') ? path : `${SANDBOX_HOME}/${path}`;
-  const segments = absolute.split('/').filter(Boolean);
+  const segments: string[] = [];
+  for (const segment of absolute.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') segments.pop();
+    else segments.push(segment);
+  }
   if (segments.length === 0) {
     throw new Error('Path must not be empty or the filesystem root.');
   }

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -169,6 +169,14 @@ function buildConfig(config: BuddyConfig): ResolvedBuddyConfig {
  */
 const clients = new WeakMap<ResolvedBuddyConfig, BuddyApiClient>();
 
+/**
+ * Per-request timeout for the SDK client. Its default is 30 s, which is too
+ * short for `POST /commands`: Buddy holds that request until the sandbox has
+ * booted, and a drained warm pool has been measured to take over 10 s. On a
+ * timeout the SDK retries the POST, which would submit the command twice.
+ */
+export const CLIENT_REQUEST_TIMEOUT_MS = 120_000;
+
 export function getClient(config: ResolvedBuddyConfig): BuddyApiClient {
   let client = clients.get(config);
   if (!client) {
@@ -177,6 +185,7 @@ export function getClient(config: ResolvedBuddyConfig): BuddyApiClient {
       project_name: config.project,
       apiUrl: config.apiUrl,
       token: config.token,
+      timeout: CLIENT_REQUEST_TIMEOUT_MS,
     });
     clients.set(config, client);
   }

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -24,7 +24,7 @@ export const SANDBOX_HOME = '/buddy';
  * a separate deployment with its own API host, workspaces and tokens — `US` is
  * not a placement hint within one API.
  */
-export type BuddyRegion = 'US' | 'EU' | 'AS';
+export type BuddyRegion = 'US' | 'EU';
 
 /** Interpreter Buddy runs a command with. `BASH` is the default. */
 export type BuddyCommandRuntime = 'BASH' | 'JAVASCRIPT' | 'TYPESCRIPT' | 'PYTHON';
@@ -352,7 +352,8 @@ export interface BuddyEndpoint {
   name?: string;
   endpoint?: string;
   type?: BuddyTunnelType;
-  region?: BuddyRegion;
+  /** As reported by the API, which may know installations this provider does not offer. */
+  region?: string;
   endpoint_url?: string;
   active?: boolean;
   whitelist?: string[];

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -1,0 +1,445 @@
+/**
+ * Shared types, config resolution and SDK plumbing for the Buddy provider.
+ *
+ * All API access goes through `@buddy-works/sandbox-sdk`. The provider uses the
+ * SDK's `BuddyApiClient` rather than its high-level `Sandbox` façade for sandbox
+ * creation: `Sandbox.create()` waits for `setup_status: SUCCESS` and
+ * `status: RUNNING` with a 1 s poll, and since a sandbox from Buddy's warm pool
+ * is usable in ~400 ms that wait would dominate time-to-first-command. The
+ * façade's `Command`, `FileSystem` and snapshot helpers are used as-is.
+ */
+
+import { API_URLS, BuddyApiClient, FileSystem } from '@buddy-works/sandbox-sdk';
+
+export const PROVIDER = 'buddy' as const;
+export const DEFAULT_OS = 'ubuntu:24.04';
+export const DEFAULT_REGION: BuddyRegion = 'US';
+/** Buddy stops a sandbox after this many ms of life unless overridden. */
+export const DEFAULT_TIMEOUT_MS = 3_600_000;
+/** Working directory of the default `buddy` user — relative paths resolve here. */
+export const SANDBOX_HOME = '/buddy';
+
+/**
+ * Buddy installation, in the spelling its tunnel API uses. Each installation is
+ * a separate deployment with its own API host, workspaces and tokens — `US` is
+ * not a placement hint within one API.
+ */
+export type BuddyRegion = 'US' | 'EU' | 'AS';
+
+/** Interpreter Buddy runs a command with. `BASH` is the default. */
+export type BuddyCommandRuntime = 'BASH' | 'JAVASCRIPT' | 'TYPESCRIPT' | 'PYTHON';
+
+/** Tunnel protocol. Only `HTTP` yields a public `endpoint_url`. */
+export type BuddyTunnelType = 'HTTP' | 'TLS' | 'TCP' | 'SSH';
+
+/**
+ * Buddy resource preset, `"{vCPU}x{RAM in GB}"`. RAM is always 2 GB per vCPU.
+ */
+export type BuddyResources =
+  | '1x2' | '2x4' | '3x6' | '4x8' | '5x10' | '6x12'
+  | '7x14' | '8x16' | '9x18' | '10x20' | '11x22' | '12x24';
+
+export const MAX_CPU = 12;
+
+/** A port to expose publicly. A bare number means `{ port, type: 'HTTP' }`. */
+export interface BuddyPort {
+  port: number;
+  /** Tunnel name. Becomes the first label of the public hostname. */
+  name?: string;
+  type?: BuddyTunnelType;
+  region?: BuddyRegion;
+}
+
+export type BuddyPortInput = number | BuddyPort;
+
+export interface BuddyConfig {
+  /** API token with the `SANDBOX_MANAGE` scope. Falls back to `BUDDY_TOKEN`. */
+  token?: string;
+  /** Workspace domain. Falls back to `BUDDY_WORKSPACE`. */
+  workspace?: string;
+  /** Project the sandboxes belong to. Falls back to `BUDDY_PROJECT`. */
+  project?: string;
+  /** Base OS image — `'ubuntu:24.04'` (default) or `'ubuntu:22.04'`. */
+  os?: string;
+  /** Resource preset. Buddy's own default applies when omitted. */
+  resources?: BuddyResources;
+  /**
+   * Buddy installation to use. Selects both the API host and where tunnels
+   * terminate. Defaults to `'US'`. A token is only valid on its own
+   * installation.
+   */
+  region?: BuddyRegion;
+  /** Sandbox lifetime in milliseconds, after which Buddy stops it. */
+  timeout?: number;
+  /** Ports to expose on every sandbox this provider creates. */
+  ports?: BuddyPortInput[];
+  /** API base URL. Overrides `region` — set it for on-premise installations. */
+  apiUrl?: string;
+}
+
+/** Config after env-var fallbacks and validation — what the methods receive. */
+export interface ResolvedBuddyConfig {
+  token: string;
+  workspace: string;
+  project: string;
+  os: string;
+  resources?: BuddyResources;
+  region: BuddyRegion;
+  timeout: number;
+  ports?: BuddyPortInput[];
+  apiUrl: string;
+}
+
+const SETUP_HINT =
+  'Create a token with the SANDBOX_MANAGE scope at ' +
+  'https://app.buddy.works/my-id/tokens';
+
+/** Maps our tunnel-spelled region to the SDK's API host table (`AS` → `AP`). */
+export function apiUrlForRegion(region: BuddyRegion): string {
+  return region === 'AS' ? API_URLS.AP : API_URLS[region];
+}
+
+/**
+ * One resolved config per config object handed to `buddy()`. The provider
+ * methods each receive the raw config, and resolving it to a stable object is
+ * what lets the SDK client below be reused across calls — a fresh client per
+ * call would give up Node's keep-alive connections between `create` and the
+ * first command.
+ */
+const resolved = new WeakMap<BuddyConfig, ResolvedBuddyConfig>();
+/** Stands in for `buddy()` called with no config, so that case caches too. */
+const ENV_ONLY: BuddyConfig = {};
+
+export function resolveConfig(config: BuddyConfig = ENV_ONLY): ResolvedBuddyConfig {
+  const cached = resolved.get(config);
+  if (cached) return cached;
+  const value = buildConfig(config);
+  resolved.set(config, value);
+  return value;
+}
+
+function buildConfig(config: BuddyConfig): ResolvedBuddyConfig {
+  const token = config.token ?? process.env.BUDDY_TOKEN;
+  const workspace = config.workspace ?? process.env.BUDDY_WORKSPACE;
+  const project = config.project ?? process.env.BUDDY_PROJECT;
+
+  if (!token) {
+    throw new Error(
+      'Missing Buddy API token.\n\n' +
+      `${SETUP_HINT}\n` +
+      'Then pass it: buddy({ token: "xxx" })\n' +
+      'Or set BUDDY_TOKEN in your environment.',
+    );
+  }
+  if (!workspace) {
+    throw new Error(
+      'Missing Buddy workspace domain.\n\n' +
+      'It is the workspace segment of your Buddy URL ' +
+      '(https://app.buddy.works/<workspace>/...).\n' +
+      'Pass it: buddy({ workspace: "my-workspace" }) or set BUDDY_WORKSPACE.',
+    );
+  }
+  if (!project) {
+    throw new Error(
+      'Missing Buddy project name.\n\n' +
+      'Sandboxes always belong to a project. Create one in the Buddy UI, then\n' +
+      'pass it: buddy({ project: "my-project" }) or set BUDDY_PROJECT.',
+    );
+  }
+
+  const region = config.region ?? DEFAULT_REGION;
+
+  return {
+    token,
+    workspace,
+    project,
+    os: config.os ?? DEFAULT_OS,
+    resources: config.resources,
+    region,
+    timeout: config.timeout ?? DEFAULT_TIMEOUT_MS,
+    ports: config.ports,
+    apiUrl: (config.apiUrl ?? apiUrlForRegion(region)).replace(/\/+$/, ''),
+  };
+}
+
+/**
+ * One SDK client per resolved config. Reusing it matters: creating a sandbox
+ * and running the first command is several round trips, and a shared client
+ * keeps Node's connection pool warm across them.
+ */
+const clients = new WeakMap<ResolvedBuddyConfig, BuddyApiClient>();
+
+export function getClient(config: ResolvedBuddyConfig): BuddyApiClient {
+  let client = clients.get(config);
+  if (!client) {
+    client = new BuddyApiClient({
+      workspace: config.workspace,
+      project_name: config.project,
+      apiUrl: config.apiUrl,
+      token: config.token,
+    });
+    clients.set(config, client);
+  }
+  return client;
+}
+
+/**
+ * HTTP status behind an SDK error. `BuddySDKError` carries `statusCode`; the
+ * lower-level `HttpError` the raw client throws carries `status` and is not
+ * exported, so both are read structurally.
+ */
+export function statusOf(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const candidate = error as { statusCode?: unknown; status?: unknown };
+  const status = candidate.statusCode ?? candidate.status;
+  return typeof status === 'number' && status > 0 ? status : undefined;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isNotFound(error: unknown): boolean {
+  const status = statusOf(error);
+  if (status === 404) return true;
+  // The content endpoints answer 400 "Path not find in browser" for a missing
+  // path instead of 404, so the message has to be inspected as well.
+  return status === 400 && /not (found|find)/i.test(messageOf(error));
+}
+
+/**
+ * Buddy sandbox ids are fixed-length, so an id of any other shape never reaches
+ * the handler and comes back as 400 "Invalid url" rather than 404. For a lookup
+ * both answers mean the same thing: no such sandbox.
+ */
+export function isUnroutableId(error: unknown): boolean {
+  return statusOf(error) === 400 && /invalid url/i.test(messageOf(error));
+}
+
+/**
+ * A sandbox that has not finished booting yet. Commands submitted to a
+ * `STARTING` sandbox are queued by Buddy, but the `content/` and `download/`
+ * endpoints reject outright with 400 "Instance is not running" — measured to
+ * last up to ~8 s when the warm pool is drained.
+ */
+export function isInstanceNotRunning(error: unknown): boolean {
+  return statusOf(error) === 400 && /instance is not running/i.test(messageOf(error));
+}
+
+/**
+ * A sandbox with a lifecycle operation in flight. Buddy rejects configuration
+ * changes, including opening a tunnel, until the boot or snapshot finishes.
+ */
+export function isOperationInProgress(error: unknown): boolean {
+  return statusOf(error) === 400 && /operation in progress/i.test(messageOf(error));
+}
+
+export function isAuthError(error: unknown): boolean {
+  const status = statusOf(error);
+  return status === 401 || status === 403;
+}
+
+/** Resolves a caller-supplied path to an absolute one and collapses slashes. */
+export function normalizeSandboxPath(path: string): string {
+  const absolute = path.startsWith('/') ? path : `${SANDBOX_HOME}/${path}`;
+  const segments = absolute.split('/').filter(Boolean);
+  if (segments.length === 0) {
+    throw new Error('Path must not be empty or the filesystem root.');
+  }
+  return `/${segments.join('/')}`;
+}
+
+/**
+ * The SDK takes content paths as a single URL segment it encodes itself, with
+ * no leading slash — a leading slash produces an empty segment and a 400 from
+ * the gateway.
+ */
+export function toContentPath(path: string): string {
+  return normalizeSandboxPath(path).slice(1);
+}
+
+export type SandboxStatus = 'running' | 'stopped' | 'error';
+
+/**
+ * Buddy exposes more states than ComputeSDK. `STARTING` and `RESTORING` map to
+ * `running` on purpose: the API queues commands submitted against a sandbox in
+ * those states, so it is already usable.
+ */
+export function mapStatus(status: string | undefined): SandboxStatus {
+  switch (status) {
+    case 'RUNNING':
+    case 'STARTING':
+    case 'RESTORING':
+      return 'running';
+    case 'STOPPED':
+    case 'STOPPING':
+      return 'stopped';
+    case 'FAILED':
+      return 'error';
+    default:
+      return 'stopped';
+  }
+}
+
+/**
+ * Picks a resource preset from the cross-provider `cpu`/`memory` knobs.
+ * Buddy only offers `N` vCPU with `2N` GB RAM, so whichever request is larger
+ * wins and the result is clamped to the largest preset.
+ */
+export function resolveResources(
+  options: Record<string, unknown> = {},
+  fallback?: BuddyResources,
+): BuddyResources | undefined {
+  if (typeof options.resources === 'string') return options.resources as BuddyResources;
+
+  const requestedCpu = firstPositiveNumber([options.cpu, options.vcpus, options.cpus]);
+  const requestedMemoryGb = memoryToGb(options);
+  if (requestedCpu === undefined && requestedMemoryGb === undefined) return fallback;
+
+  const cpuForMemory = requestedMemoryGb === undefined ? 0 : Math.ceil(requestedMemoryGb / 2);
+  const cpu = Math.min(MAX_CPU, Math.max(1, requestedCpu ?? 0, cpuForMemory));
+  return `${cpu}x${cpu * 2}` as BuddyResources;
+}
+
+function firstPositiveNumber(values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) return Math.ceil(value);
+  }
+  return undefined;
+}
+
+/** Memory knobs are unnormalized across providers — MB for some, MiB for others. */
+function memoryToGb(options: Record<string, unknown>): number | undefined {
+  const mb = firstPositiveNumber([options.memory, options.memoryMb]);
+  if (mb !== undefined) return mb / 1024;
+  const mib = firstPositiveNumber([options.memoryMiB, options.memMiB]);
+  if (mib !== undefined) return (mib * 1024 * 1024) / 1e9;
+  return undefined;
+}
+
+/** Buddy identifiers allow alphanumerics, `_` and inner `-` only. */
+export function toIdentifier(value: string): string {
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned.slice(0, 60) || 'computesdk';
+}
+
+export function generateSandboxName(): string {
+  return `computesdk-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function normalizePort(input: BuddyPortInput, config: ResolvedBuddyConfig): Required<BuddyPort> {
+  const port = typeof input === 'number' ? { port: input } : input;
+  return {
+    port: port.port,
+    name: port.name ?? `p${port.port}`,
+    type: port.type ?? 'HTTP',
+    region: port.region ?? config.region,
+  };
+}
+
+/** Buddy's tunnel object. `endpoint` holds the sandbox-side port as a string. */
+export interface BuddyEndpoint {
+  name?: string;
+  endpoint?: string;
+  type?: BuddyTunnelType;
+  region?: BuddyRegion;
+  endpoint_url?: string;
+  active?: boolean;
+  whitelist?: string[];
+  [key: string]: unknown;
+}
+
+export function toEndpointPayload(port: Required<BuddyPort>): BuddyEndpoint {
+  return {
+    name: port.name,
+    endpoint: String(port.port),
+    type: port.type,
+    region: port.region,
+  };
+}
+
+/** Only HTTP and TLS tunnels get a public URL; TCP and SSH report host and port. */
+export function endpointPublicUrl(endpoint: BuddyEndpoint): string | undefined {
+  return endpoint.endpoint_url;
+}
+
+export function endpointMatchesPort(endpoint: BuddyEndpoint, port: number): boolean {
+  return Number(endpoint.endpoint) === port;
+}
+
+/** Swaps the scheme of a URL, for callers asking for `wss` on an HTTP tunnel. */
+export function applyProtocol(url: string, protocol?: string): string {
+  if (!protocol) return url;
+  const normalized = protocol.replace(/:$/, '');
+  return url.replace(/^[a-z][a-z0-9+.-]*:\/\//i, `${normalized}://`);
+}
+
+/**
+ * What the provider passes between its own methods, and what `getInstance()`
+ * hands back to callers. `client` and `fs` come straight from the SDK, so
+ * consumers can drop down to it without building their own client.
+ */
+export interface BuddySandboxHandle {
+  sandboxId: string;
+  identifier: string;
+  config: ResolvedBuddyConfig;
+  client: BuddyApiClient;
+  fs: FileSystem;
+  createdAt: Date;
+  timeout: number;
+  os?: string;
+  resources?: string;
+  /** Tunnels known so far. `getUrl` extends this when it opens a new one. */
+  endpoints: BuddyEndpoint[];
+}
+
+/** Sandbox as the API returns it, narrowed to the fields the provider reads. */
+export interface BuddySandboxData {
+  id?: string;
+  identifier?: string;
+  name?: string;
+  status?: string;
+  setup_status?: string;
+  os?: string;
+  resources?: string;
+  timeout?: number;
+  endpoints?: BuddyEndpoint[];
+  ssh_host?: string;
+  ssh_port?: number;
+}
+
+export function toHandle(
+  config: ResolvedBuddyConfig,
+  sandbox: BuddySandboxData,
+  createdAt = new Date(),
+): BuddySandboxHandle {
+  const sandboxId = sandbox.id;
+  if (!sandboxId) {
+    throw new Error('Buddy API returned a sandbox without an id.');
+  }
+  const client = getClient(config);
+
+  return {
+    sandboxId,
+    identifier: sandbox.identifier ?? sandboxId,
+    config,
+    client,
+    fs: new FileSystem(client, sandboxId),
+    createdAt,
+    timeout: sandbox.timeout != null ? sandbox.timeout * 1000 : config.timeout,
+    os: sandbox.os,
+    resources: sandbox.resources,
+    endpoints: sandbox.endpoints ?? [],
+  };
+}
+
+export async function getSandboxData(
+  config: ResolvedBuddyConfig,
+  sandboxId: string,
+): Promise<BuddySandboxData> {
+  return await getClient(config).getSandboxById({ path: { id: sandboxId } }) as BuddySandboxData;
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -107,10 +107,26 @@ export function apiUrlForRegion(region: BuddyRegion): string {
  * first command.
  */
 const resolved = new WeakMap<BuddyConfig, ResolvedBuddyConfig>();
-/** Stands in for `buddy()` called with no config, so that case caches too. */
-const ENV_ONLY: BuddyConfig = {};
+/**
+ * `buddy()` with no config reads the environment on every call, so a token
+ * rotated in `process.env` is picked up; the result is cached by value so the
+ * SDK client (and its connection pool) is still shared while nothing changed.
+ */
+const resolvedFromEnv = new Map<string, ResolvedBuddyConfig>();
 
-export function resolveConfig(config: BuddyConfig = ENV_ONLY): ResolvedBuddyConfig {
+export function resolveConfig(config?: BuddyConfig): ResolvedBuddyConfig {
+  if (!config) {
+    const key = [
+      process.env.BUDDY_TOKEN, process.env.BUDDY_WORKSPACE, process.env.BUDDY_PROJECT,
+    ].join('\u0000');
+    let value = resolvedFromEnv.get(key);
+    if (!value) {
+      value = buildConfig({});
+      resolvedFromEnv.clear();
+      resolvedFromEnv.set(key, value);
+    }
+    return value;
+  }
   const cached = resolved.get(config);
   if (cached) return cached;
   const value = buildConfig(config);

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -94,9 +94,9 @@ const SETUP_HINT =
   'Create a token with the SANDBOX_MANAGE scope at ' +
   'https://app.buddy.works/my-id/tokens';
 
-/** Maps our tunnel-spelled region to the SDK's API host table (`AS` → `AP`). */
+/** The SDK's API host table is keyed by the same region names we use. */
 export function apiUrlForRegion(region: BuddyRegion): string {
-  return region === 'AS' ? API_URLS.AP : API_URLS[region];
+  return API_URLS[region];
 }
 
 /**

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -427,6 +427,8 @@ export interface BuddySandboxHandle {
   client: BuddyApiClient;
   fs: FileSystem;
   createdAt: Date;
+  /** True unless this process created the sandbox; Buddy reports no creation date. */
+  createdAtIsReconnectTime: boolean;
   timeout: number;
   os?: string;
   resources?: string;
@@ -451,13 +453,15 @@ export interface BuddySandboxData {
 
 /**
  * Buddy's sandbox resource carries no creation date (only projects and
- * snapshots do), so a handle rebuilt by `getById` or `list` can only record
- * when it was reconnected. `create` passes the real moment.
+ * snapshots do), and `SandboxInfo.createdAt` is a required `Date`, so a handle
+ * rebuilt by `getById` or `list` can only record when it was reconnected.
+ * `getInfo` marks that case with `metadata.createdAtIsReconnectTime`.
  */
 export function toHandle(
   config: ResolvedBuddyConfig,
   sandbox: BuddySandboxData,
   createdAt = new Date(),
+  createdAtIsReconnectTime = true,
 ): BuddySandboxHandle {
   const sandboxId = sandbox.id;
   if (!sandboxId) {
@@ -472,6 +476,7 @@ export function toHandle(
     client,
     fs: new FileSystem(client, sandboxId),
     createdAt,
+    createdAtIsReconnectTime,
     timeout: sandbox.timeout != null ? sandbox.timeout * 1000 : config.timeout,
     os: sandbox.os,
     resources: sandbox.resources,

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -449,6 +449,11 @@ export interface BuddySandboxData {
   ssh_port?: number;
 }
 
+/**
+ * Buddy's sandbox resource carries no creation date (only projects and
+ * snapshots do), so a handle rebuilt by `getById` or `list` can only record
+ * when it was reconnected. `create` passes the real moment.
+ */
 export function toHandle(
   config: ResolvedBuddyConfig,
   sandbox: BuddySandboxData,

--- a/packages/buddy/src/utils.ts
+++ b/packages/buddy/src/utils.ts
@@ -328,8 +328,9 @@ function memoryToGb(options: Record<string, unknown>): number | undefined {
 
 /** Buddy identifiers allow alphanumerics, `_` and inner `-` only. */
 export function toIdentifier(value: string): string {
-  const cleaned = value.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
-  return cleaned.slice(0, 60) || 'computesdk';
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
+  // Trim after truncating, or the cut can leave a hyphen in the last position.
+  return cleaned.slice(0, 60).replace(/^-+|-+$/g, '') || 'computesdk';
 }
 
 export function generateSandboxName(): string {
@@ -374,6 +375,20 @@ export function endpointPublicUrl(endpoint: BuddyEndpoint): string | undefined {
 
 export function endpointMatchesPort(endpoint: BuddyEndpoint, port: number): boolean {
   return Number(endpoint.endpoint) === port;
+}
+
+/** Fields Buddy reports but rejects when an endpoint is sent back in an update. */
+const READ_ONLY_ENDPOINT_FIELDS = ['endpoint_url', 'active', 'target_latency'] as const;
+
+/**
+ * Prepares an existing endpoint for the replace-all update. Everything
+ * writable — `whitelist`, `timeout`, `http`, `tls` and whatever Buddy adds
+ * later — has to survive, or opening a new port would reset those tunnels.
+ */
+export function toEndpointUpdate(endpoint: BuddyEndpoint): BuddyEndpoint {
+  const update: BuddyEndpoint = { ...endpoint };
+  for (const field of READ_ONLY_ENDPOINT_FIELDS) delete update[field];
+  return update;
 }
 
 /** Swaps the scheme of a URL, for callers asking for `wss` on an HTTP tunnel. */

--- a/packages/buddy/tsconfig.json
+++ b/packages/buddy/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+} 

--- a/packages/buddy/tsconfig.json
+++ b/packages/buddy/tsconfig.json
@@ -6,4 +6,4 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
-} 
+}

--- a/packages/buddy/tsup.config.ts
+++ b/packages/buddy/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+}) 

--- a/packages/buddy/tsup.config.ts
+++ b/packages/buddy/tsup.config.ts
@@ -7,4 +7,4 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-}) 
+})

--- a/packages/buddy/vitest.config.ts
+++ b/packages/buddy/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+	globals: true,
+	environment: 'node',
+	coverage: {
+	  reporter: ['text', 'json', 'html'],
+	  exclude: [
+		'node_modules/',
+		'dist/',
+		'**/*.d.ts',
+		'**/*.config.*'
+	  ]
+	}
+  },
+  resolve: {
+	alias: {
+	  '@': path.resolve(__dirname, './src')
+	}
+  }
+}) 

--- a/packages/buddy/vitest.config.ts
+++ b/packages/buddy/vitest.config.ts
@@ -20,4 +20,4 @@ export default defineConfig({
 	  '@': path.resolve(__dirname, './src')
 	}
   }
-}) 
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,8 +483,8 @@ importers:
   packages/buddy:
     dependencies:
       '@buddy-works/sandbox-sdk':
-        specifier: ^0.1.7
-        version: 0.1.7
+        specifier: ^0.1.8
+        version: 0.1.8
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2934,9 +2934,9 @@ packages:
   '@browserbasehq/sdk@2.9.0':
     resolution: {integrity: sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==}
 
-  '@buddy-works/sandbox-sdk@0.1.7':
-    resolution: {integrity: sha512-3yboyWz5x+BD93pRV3BYRE010RNcp/r0YIY+NXFsxTjiu+6FCEhZZwzQVcoYr4KLdT7DFsRqZ9zjdgEzeBOn0w==}
-    engines: {node: '>=20'}
+  '@buddy-works/sandbox-sdk@0.1.8':
+    resolution: {integrity: sha512-gkgmVDJYkM3IzxtNHOy3FWxuAsDaZQz0Pjm9qXTL12leZTnZAPunTAJxs/B86dwcWLLNPBU85lu32pui1YB57Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bufbuild/protobuf@2.12.1':
     resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
@@ -10263,7 +10263,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@buddy-works/sandbox-sdk@0.1.7':
+  '@buddy-works/sandbox-sdk@0.1.8':
     dependencies:
       p-retry: 7.1.1
       zod: 4.3.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,43 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/buddy:
+    dependencies:
+      '@buddy-works/sandbox-sdk':
+        specifier: ^0.1.7
+        version: 0.1.7
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/cli:
     dependencies:
       '@clack/prompts':
@@ -2896,6 +2933,10 @@ packages:
 
   '@browserbasehq/sdk@2.9.0':
     resolution: {integrity: sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==}
+
+  '@buddy-works/sandbox-sdk@0.1.7':
+    resolution: {integrity: sha512-3yboyWz5x+BD93pRV3BYRE010RNcp/r0YIY+NXFsxTjiu+6FCEhZZwzQVcoYr4KLdT7DFsRqZ9zjdgEzeBOn0w==}
+    engines: {node: '>=20'}
 
   '@bufbuild/protobuf@2.12.1':
     resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
@@ -7212,6 +7253,10 @@ packages:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -7939,6 +7984,10 @@ packages:
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -9480,6 +9529,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -10210,6 +10262,11 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@buddy-works/sandbox-sdk@0.1.7':
+    dependencies:
+      p-retry: 7.1.1
+      zod: 4.3.5
 
   '@bufbuild/protobuf@2.12.1': {}
 
@@ -15015,6 +15072,8 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
 
+  is-network-error@1.3.2: {}
+
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
@@ -15793,6 +15852,10 @@ snapshots:
       p-limit: 3.1.0
 
   p-map@2.1.0: {}
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-try@2.2.0: {}
 
@@ -17639,5 +17702,7 @@ snapshots:
   zod@3.22.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.5: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
## Provider: `@computesdk/buddy`

**Disclosure:** I work at Buddy, so this PR adds my own employer's service as a provider.
Credentials are available whenever you need them. Happy to answer anything about the
implementation.

**What is it?** [Buddy](https://buddy.works) sandboxes — full Ubuntu VMs served from a
pre-warmed hot pool, with public HTTP tunnels and independent installations (US, EU).

**Underlying SDK:** [`@buddy-works/sandbox-sdk`](https://www.npmjs.com/package/@buddy-works/sandbox-sdk),
Buddy's official TypeScript SDK, and the only runtime dependency. The provider uses the
SDK's `BuddyApiClient` for the lifecycle calls and its `Command`, `FileSystem` and
`Snapshot` helpers for the rest. The SDK ships ESM and CJS builds; the package inherits
its `engines.node` range (`^20.19.0 || >=22.12.0`).

**Credentials:** `{ token, workspace, project }`, each with an env-var fallback —
`BUDDY_TOKEN`, `BUDDY_WORKSPACE`, `BUDDY_PROJECT`. Tokens come from *My ID → Access
tokens* and need the `SANDBOX_MANAGE` scope. Buddy runs independent installations rather
than regions behind one API, so `region` (`US` default, `EU`) selects both the API
host and where tunnels terminate; `apiUrl` overrides it for on-premise.

### Capabilities

| Capability | Supported? | Notes |
|---|---|---|
| `runCommand` (required) | ✅ | Submits the command, then consumes the SDK's `logs({ follow: true })` stream until it exits — no polling loop. Real exit codes, stdout and stderr kept apart, `onStdout`/`onStderr`, `cwd`, `env`, `timeout`, `background` |
| Filesystem | ✅ | The SDK's `FileSystem`, i.e. Buddy's native content endpoints rather than shell wrappers: one round trip per call, no quoting concerns. UTF-8 text like the other providers; raw bytes via `getInstance().fs` |
| `getUrl` (port exposure) | ✅ | HTTP tunnels. Ports passed to `create` are exposed up front so `getUrl` needs no extra round trip; on a live sandbox it opens one and waits for the URL to publish |
| `list` / `getById` / `destroy` | ✅ | Scoped to the configured project |
| Snapshots | ✅ | `create` / `list` / `delete`. Buddy creates them asynchronously and they cannot be restored until they turn `CREATED`, so `create` waits for that. `list()` covers the project, `list({ sandboxId })` one sandbox |
| Templates | ⚠️ aliased | Buddy has no standalone template entity — a reusable base image *is* a snapshot taken from a live sandbox. `template.list` / `template.delete` alias the snapshot methods, and `create({ snapshotId })` (or `templateId`) boots from one. `template.create` throws with a message pointing at `snapshot.create`, mirroring the `daytona` provider |

### Checklist

- [x] New `packages/buddy/` package with `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, `README.md`, and `src/`
- [x] Core sandbox methods implemented: `create`, `getById`, `list`, `destroy`, `runCommand`, `getInfo`, `getUrl`, plus `getInstance()` for dropping down to the SDK client
- [x] Config validated early with a helpful error naming the missing field; env-var fallback supported
- [x] Shell interpolation uses `escapeShellArg` wrapped in double quotes
- [x] Tests via `runProviderTestSuite` plus unit tests for config resolution, resource presets, paths, command building, status mapping, error predicates, ports and identifiers — 61 tests. The integration half no-ops without credentials; with credentials it runs against the live API, two consecutive clean runs
- [x] A separate end-to-end pass over the whole surface with live credentials: command exit codes, `cwd`/`env`, filesystem round trip, filesystem seeing shell output, `getInfo`, a tunnel answering 200, `getById` (hit and miss), `list`, snapshot create/list/delete, and booting a second sandbox from the snapshot with its marker file intact. Everything it creates is destroyed
- [x] `pnpm build` passes
- [x] `pnpm --filter @computesdk/buddy run typecheck` passes
- [x] `pnpm --filter @computesdk/buddy run lint` passes
- [x] Root `README.md` "Supported Providers" table updated, plus `docs/README.md` and `docs/getting-started/installation.md`
- [x] Docs page added at `docs/providers/buddy.md`, linked from `docs/SUMMARY.md`
- [x] Changeset added (`patch`)

**Diff scope:** 19 files, ~2400 lines, zero deletions — nothing outside `packages/buddy/`,
`docs/`, root `README.md`, `.changeset/` and `pnpm-lock.yaml`.

### Notes for reviewers

- **`create` does not wait for `RUNNING`.** Buddy queues a command submitted against a
  sandbox that is still booting, so waiting on status would add latency for nothing. This
  is also why the lifecycle goes through `BuddyApiClient` instead of the SDK's
  higher-level `Sandbox.create()`, which polls readiness once a second.
- **`destroy` retries on 5xx** (3 attempts, 500 ms apart). A delete issued immediately
  after `create` can answer 500 while the deletion still goes through, so the retry keeps
  `destroy` idempotent. Across the live runs no sandbox was left behind.
- **Filesystem and `getUrl` wait for first-boot setup.** Commands queue against a booting
  sandbox, but two other endpoint groups do not: the content endpoints answer 400
  "Instance is not running" (or accept a write whose bytes never land, roughly once in
  twelve sandboxes), and the update call answers 400 "Cannot update sandbox, operation in
  progress". So `boot.ts` gates those calls on `RUNNING` + `setup_status: SUCCESS` once
  per sandbox and retries both races. Without the gate the conformance suite is flaky on
  fresh sandboxes; with it, consecutive full runs are clean.
- **`getById` returns `null` for both misses.** Buddy sandbox ids are fixed-length, so an
  id of another shape never reaches the handler and answers 400 "Invalid url" instead of
  404. Both mean "no such sandbox" for a lookup.
- **`getUrl` merges rather than replaces.** Updating a sandbox swaps the whole endpoint
  list, so the provider reads the current endpoints and re-sends them alongside the new
  one. Only `HTTP` and `TLS` tunnels get a public URL; `TCP` and `SSH` are reported by
  host and port in `getInfo`.
- **Multi-region.** Buddy runs independent installations with separate accounts and
  tokens; the US one carries the largest warm pool, so that is the one credentials would
  point at.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
