### PR TITLE
use the official Archil client

### DIFF
--- a/.changeset/archil-official-client.md
+++ b/.changeset/archil-official-client.md
@@ -1,0 +1,9 @@
+---
+"@computesdk/archil": patch
+---
+
+feat(archil): use the official `disk` client instead of hand-rolled fetch calls
+
+Replaces the provider's bespoke `callApi` helper with Archil's official `disk`
+package (`^1.1.2`), so auth headers, response envelopes, and endpoint paths are
+maintained upstream rather than duplicated here.

--- a/packages/archil/README.md
+++ b/packages/archil/README.md
@@ -13,9 +13,6 @@ managed by Archil. `getById` requires a disk id.
 npm install @computesdk/archil
 ```
 
-The provider talks to the Archil control plane directly over HTTP — no
-additional Archil SDK is required.
-
 ## Configuration
 
 | Option    | Env var            | Required | Description                                |

--- a/packages/archil/package.json
+++ b/packages/archil/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "computesdk": "workspace:*",
-    "@computesdk/provider": "workspace:*"
+    "@computesdk/provider": "workspace:*",
+    "disk": "^1.1.2"
   },
   "devDependencies": {
     "@computesdk/test-utils": "workspace:*",

--- a/packages/archil/src/__tests__/fetch-mock.ts
+++ b/packages/archil/src/__tests__/fetch-mock.ts
@@ -1,0 +1,16 @@
+export function adaptFetchMock(
+  fetchMock: typeof fetch,
+): typeof fetch {
+  return async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const body = request.body ? await request.clone().text() : undefined;
+    const dispatcher = (init as RequestInit & { dispatcher?: unknown })
+      ?.dispatcher;
+    return fetchMock(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body,
+      ...(dispatcher ? { dispatcher } : {}),
+    } as RequestInit);
+  };
+}

--- a/packages/archil/src/__tests__/index.test.ts
+++ b/packages/archil/src/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 import * as indexExports from '../index';
 import { archil } from '../index';
+import { adaptFetchMock } from './fetch-mock';
 
 const originalFetch = global.fetch;
 
@@ -46,7 +47,7 @@ describe('archil getById semantics', () => {
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.getById('disk_123');
@@ -64,7 +65,7 @@ describe('archil getById semantics', () => {
         headers: { 'Content-Type': 'application/json' },
       }),
     );
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.getById('my-workspace');
@@ -133,7 +134,7 @@ describe('archil filesystem mapping', () => {
         ? execResponse('5\n')
         : execResponse(Buffer.from('hello').toString('base64'));
     });
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -152,7 +153,7 @@ describe('archil filesystem mapping', () => {
 
   it('checks out and checks in mutating filesystem operations', async () => {
     const fetchMock = vi.fn(async () => execResponse());
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -186,7 +187,7 @@ describe('archil filesystem mapping', () => {
 
   it('chunks large writes within Archil exec limits', async () => {
     const fetchMock = vi.fn(async () => execResponse());
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -228,7 +229,7 @@ describe('archil filesystem mapping', () => {
         bytes.subarray(offset, offset + count).toString('base64'),
       );
     });
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -246,7 +247,7 @@ describe('archil filesystem mapping', () => {
 
   it('reads empty files without issuing a chunk command', async () => {
     const fetchMock = vi.fn(async () => execResponse('0\n'));
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -259,7 +260,7 @@ describe('archil filesystem mapping', () => {
 
   it('writes empty files without emitting a base64 chunk', async () => {
     const fetchMock = vi.fn(async () => execResponse());
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -280,7 +281,7 @@ describe('archil filesystem mapping', () => {
       .fn()
       .mockResolvedValueOnce(execResponse('', 1, 'destination is a directory'))
       .mockResolvedValueOnce(execResponse());
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -303,7 +304,7 @@ describe('archil filesystem mapping', () => {
       .fn()
       .mockResolvedValueOnce(execResponse('', 1, 'destination is a directory'))
       .mockResolvedValueOnce(execResponse());
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });
@@ -329,7 +330,7 @@ describe('archil filesystem mapping', () => {
         ? execResponse('', 1, 'chunk failed')
         : execResponse();
     });
-    global.fetch = fetchMock as typeof fetch;
+    global.fetch = adaptFetchMock(fetchMock as typeof fetch);
 
     const provider = archil({ apiKey: 'key_test', region: 'aws-us-east-1' });
     const sandbox = await provider.sandbox.create({ diskId: 'disk_abc123' });

--- a/packages/archil/src/index.ts
+++ b/packages/archil/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import { defineProvider } from '@computesdk/provider';
+import { Archil as ArchilClient } from 'disk';
 import { randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
 import type {
@@ -83,6 +84,7 @@ interface ResolvedConfig {
 }
 
 interface ArchilSandbox {
+  client: ArchilClient;
   disk: DiskHandle | DiskResponse;
   resolved: ResolvedConfig;
   createdAt: Date;
@@ -120,41 +122,9 @@ function resolveConfig(config: ArchilConfig): ResolvedConfig {
   return { apiKey, baseUrl };
 }
 
-function authHeader(apiKey: string): string {
-  return `key-${apiKey.replace(/^key-/, '')}`;
-}
-
-async function callApi<T>(
-  resolved: ResolvedConfig,
-  method: 'GET' | 'POST' | 'DELETE',
-  path: string,
-  body?: unknown,
-): Promise<T> {
-  const response = await fetch(`${resolved.baseUrl}${path}`, {
-    method,
-    headers: {
-      Authorization: authHeader(resolved.apiKey),
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-
-  type Envelope = { success?: boolean; data?: T; error?: string };
-  let payload: Envelope | null = null;
-  try {
-    payload = (await response.json()) as Envelope;
-  } catch {
-    payload = null;
-  }
-
-  if (!response.ok || !payload || payload.success === false) {
-    const message =
-      (payload && payload.error) ||
-      `Archil API ${method} ${path} failed with status ${response.status}`;
-    throw new Error(message);
-  }
-
-  return payload.data as T;
+function createClient(config: ArchilConfig, resolved: ResolvedConfig): ArchilClient {
+  const region = config.region ?? process.env.ARCHIL_REGION ?? 'aws-us-east-1';
+  return new ArchilClient({ ...resolved, region });
 }
 
 function resolveCreateDiskId(options?: ArchilCreateOptions): string {
@@ -297,12 +267,7 @@ function wrapCommand(command: string, options?: RunCommandOptions): string {
 }
 
 async function execOnDisk(sandbox: ArchilSandbox, command: string): Promise<ExecResponse> {
-  return callApi<ExecResponse>(
-    sandbox.resolved,
-    'POST',
-    `/api/disks/${encodeURIComponent(sandbox.disk.id)}/exec`,
-    { command },
-  );
+  return sandbox.client.disks.exec(sandbox.disk.id, command);
 }
 
 const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
@@ -311,23 +276,26 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
     sandbox: {
       create: async (config: ArchilConfig, options?: ArchilCreateOptions) => {
         const resolved = resolveConfig(config);
+        const client = createClient(config, resolved);
         const diskId = resolveCreateDiskId(options);
         return {
-          sandbox: { disk: { id: diskId }, resolved, createdAt: new Date() },
+          sandbox: {
+            client,
+            disk: { id: diskId },
+            resolved,
+            createdAt: new Date(),
+          },
           sandboxId: diskId,
         };
       },
 
       getById: async (config: ArchilConfig, sandboxId: string) => {
         const resolved = resolveConfig(config);
+        const client = createClient(config, resolved);
         try {
-          const disk = await callApi<DiskResponse>(
-            resolved,
-            'GET',
-            `/api/disks/${encodeURIComponent(sandboxId)}`,
-          );
+          const disk = await client.disks.get(sandboxId);
           return {
-            sandbox: { disk, resolved, createdAt: new Date() },
+            sandbox: { client, disk, resolved, createdAt: new Date() },
             sandboxId: disk.id,
           };
         } catch {
@@ -337,9 +305,10 @@ const _provider = defineProvider<ArchilSandbox, ArchilConfig>({
 
       list: async (config: ArchilConfig) => {
         const resolved = resolveConfig(config);
-        const disks = await callApi<DiskResponse[]>(resolved, 'GET', '/api/disks');
+        const client = createClient(config, resolved);
+        const disks = await client.disks.list();
         return disks.map((disk) => ({
-          sandbox: { disk, resolved, createdAt: new Date() },
+          sandbox: { client, disk, resolved, createdAt: new Date() },
           sandboxId: disk.id,
         }));
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       computesdk:
         specifier: workspace:*
         version: link:../computesdk
+      disk:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@computesdk/test-utils':
         specifier: workspace:*
@@ -2601,6 +2604,9 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@archildata/api-types@0.0.24':
+    resolution: {integrity: sha512-SqvAJltBzQ+hlPERHvuGQM1Z9HCIxq1oZGtA2ritELvqAswciTPed2ZyJo2ooSL2CEcy4iqyv9Ti+MQ8XRmOOA==}
+
   '@arker-ai/sdk@1.2.4':
     resolution: {integrity: sha512-mH6UKRfzQSIzDm+pdroe7+uArqJ8RQssUknx5i2q9IXRZpdua5pZpD6HLdr9sCRQCbF96c03vpiO1ijti1qgRQ==}
     engines: {node: '>=18'}
@@ -2991,10 +2997,18 @@ packages:
   '@clack/core@0.3.5':
     resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@0.7.0':
     resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
     bundledDependencies:
       - is-unicode-supported
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@cloudflare/containers@0.1.1':
     resolution: {integrity: sha512-YTdobRTnTlUOUPMFemufH367A9Z8pDfZ+UboYMLbGpO0VlvEXZDiioSmXPQMHld2vRtkL31mcRii3bcbQU6fdw==}
@@ -6207,6 +6221,10 @@ packages:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -6442,6 +6460,11 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  disk@1.1.2:
+    resolution: {integrity: sha512-913azkqQbNl9PpB7tTqO5pF6OAkvYSG5feQibc0aa6AbknX9flC4IBSh5sTtTOzPE5becLxzHhJX+I2Rf0xaeg==}
+    engines: {node: '>= 22'}
+    hasBin: true
 
   docker-modem@5.0.6:
     resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
@@ -6720,8 +6743,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.0.0:
     resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
@@ -7868,6 +7900,9 @@ packages:
   open@10.1.2:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
+
+  openapi-fetch@0.13.8:
+    resolution: {integrity: sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==}
 
   openapi-fetch@0.14.1:
     resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
@@ -9060,6 +9095,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.3.0:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
     engines: {node: '>=22.19.0'}
@@ -9112,6 +9151,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuidv7@1.1.0:
@@ -9494,6 +9537,8 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@archildata/api-types@0.0.24': {}
 
   '@arker-ai/sdk@1.2.4(@computesdk/daytona@1.7.33(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(computesdk@packages+computesdk)(utf-8-validate@6.0.6)':
     dependencies:
@@ -10380,10 +10425,22 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@clack/prompts@0.7.0':
     dependencies:
       '@clack/core': 0.3.5
       picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@cloudflare/containers@0.1.1': {}
@@ -13791,6 +13848,8 @@ snapshots:
 
   commander@14.0.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3:
     optional: true
 
@@ -14018,6 +14077,17 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  disk@1.1.2:
+    dependencies:
+      '@archildata/api-types': 0.0.24
+      '@clack/prompts': 1.7.0
+      commander: 14.0.3
+      fast-xml-parser: 5.7.2
+      openapi-fetch: 0.13.8
+      undici: 7.29.0
+      uuid: 11.1.1
+      zod: 4.4.3
 
   docker-modem@5.0.6:
     dependencies:
@@ -14481,7 +14551,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.0.0: {}
 
@@ -15711,6 +15791,10 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
+
+  openapi-fetch@0.13.8:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
 
   openapi-fetch@0.14.1:
     dependencies:
@@ -17110,6 +17194,8 @@ snapshots:
 
   undici@7.28.0: {}
 
+  undici@7.29.0: {}
+
   undici@8.3.0: {}
 
   unenv@2.0.0-rc.14:
@@ -17167,6 +17253,8 @@ snapshots:
   uuid@10.0.0: {}
 
   uuid@11.1.0: {}
+
+  uuid@11.1.1: {}
 
   uuidv7@1.1.0: {}
 


### PR DESCRIPTION
## What

Swaps the `@computesdk/archil` provider's hand-rolled `callApi` fetch helper for Archil's official [`disk`](https://www.npmjs.com/package/disk) package (`^1.1.2`).

Auth header shaping (`key-` prefixing), the `{ success, data, error }` envelope unwrapping, and the `/api/disks/...` endpoint paths were all duplicated in this provider. They now live upstream in the client:

- `client.disks.get(id)` for `getById`
- `client.disks.list()` for `list`
- `client.disks.exec(id, command)` for every filesystem/command operation

The client is built per operation from the resolved config plus a region (`config.region` → `ARCHIL_REGION` → `aws-us-east-1`) and carried on the sandbox handle so `exec` reuses it.

## Tests

Existing tests keep mocking `global.fetch`, so they still assert on the exact wire calls. The client issues `fetch(Request)` rather than `fetch(url, init)`, so `adaptFetchMock` (new, test-only) normalizes the call shape before handing it to the existing mocks — no assertions were rewritten.

`pnpm test` and `pnpm typecheck` pass for the package (30 tests).

## Notes

- Dropped the README line claiming no Archil SDK is required, since that is no longer true.
- Changeset included (patch).

## Open questions for review

- Is per-operation client construction fine, or should the client be memoized per resolved config?