### PR TITLE
ci(release): restore NPM_TOKEN fallback for packages without npm trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # Publishing uses npm Trusted Publisher OIDC. Every package in this
-          # monorepo must have a trusted publisher configured on npmjs.com
-          # (repo: computesdk/computesdk, workflow: release.yml) before it can
-          # be released. --provenance signs the attestation.
+          # Publishing uses npm Trusted Publisher OIDC where configured.
+          # Packages without a trusted publisher on npmjs.com fall back to the
+          # long-lived NPM_TOKEN. --provenance signs the attestation.
+          # TODO: once every package has a trusted publisher configured, remove
+          # NPM_TOKEN entirely.
           publish: pnpm changeset publish --provenance
           title: "Version Packages"
           commit: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
The release workflow currently relies solely on npm OIDC trusted publishing. Packages that don't yet have a trusted publisher configured on npmjs.com fail to publish with `ENEEDAUTH` (e.g. `@computesdk/buddy` in the latest `Version Packages` run).

This restores the `NPM_TOKEN` fallback so new packages can be published before their npm trusted publisher is set up. The provenance flag is kept, and the comment is updated to clarify the behavior.

```yaml
# .github/workflows/release.yml
- uses: changesets/action@v1
  with:
    publish: pnpm changeset publish --provenance
  env:
    GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN || secrets.GITHUB_TOKEN }}
    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```

## Release note
Once this is merged and `NPM_TOKEN` is configured in the repository secrets, the next push to `main` should publish `@computesdk/buddy@1.0.1` and any other unpublishable packages.

Link to Devin session: https://app.devin.ai/sessions/a00357221eff4402914d504ab29d24a1
Open in Devin Desktop: https://app.devin.ai/desktop/session/a00357221eff4402914d504ab29d24a1?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->