### PR TITLE
chore(buddy): update @buddy-works/sandbox-sdk to 0.1.9

### DIFF
--- a/.changeset/buddy-sdk-0-1-9.md
+++ b/.changeset/buddy-sdk-0-1-9.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/buddy": patch
+---
+
+Update `@buddy-works/sandbox-sdk` to 0.1.9 and sharpen the package description.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ See individual provider READMEs for details:
 - **[@computesdk/archil](./packages/archil)** - Disk-attached command-execution sandboxes
 - **[@computesdk/beam](./packages/beam)** - Serverless cloud sandboxes
 - **[@computesdk/blaxel](./packages/blaxel)** - Agent sandboxes with custom images
-- **[@computesdk/buddy](./packages/buddy)** - Ubuntu sandboxes from a pre-warmed pool, with tunnels and snapshots
+- **[@computesdk/buddy](./packages/buddy)** - Persistent Ubuntu sandboxes for agents, booting in milliseconds, with preview URLs and snapshots
 - **[@computesdk/cloud-run](./packages/cloud-run)** - Google Cloud Run sandboxes
 - **[@computesdk/cloudflare](./packages/cloudflare)** - Edge computing sandboxes
 - **[@computesdk/codesandbox](./packages/codesandbox)** - Collaborative development

--- a/docs/providers/buddy.md
+++ b/docs/providers/buddy.md
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Install and use the Buddy provider for ComputeSDK: Ubuntu sandboxes from a
-  pre-warmed pool, public tunnels, native filesystem endpoints and snapshots.
+  Install and use the Buddy provider for ComputeSDK: persistent Ubuntu sandboxes
+  for agents, booting in milliseconds, with preview URLs and snapshots.
 layout:
   width: default
   title:
@@ -34,7 +34,7 @@ Each sandbox is an Ubuntu microVM in your Buddy project, served from a pre-warme
 npm install @computesdk/buddy
 ```
 
-Node 20.19 or newer is required, because the Buddy SDK ships ESM only.
+Node 20.19 or 22.12 and newer is required, matching the Buddy SDK (ESM and CommonJS builds are both shipped).
 
 1. Create an API token in **Buddy → My ID → Access tokens** with the `SANDBOX_MANAGE` scope
 2. Create (or pick) a Buddy project for your sandboxes

--- a/packages/buddy/README.md
+++ b/packages/buddy/README.md
@@ -12,7 +12,7 @@ Built on [`@buddy-works/sandbox-sdk`](https://www.npmjs.com/package/@buddy-works
 npm install @computesdk/buddy
 ```
 
-Node 20.19 or newer is required, because the Buddy SDK ships ESM only.
+Node 20.19 or 22.12 and newer is required, matching the Buddy SDK (ESM and CommonJS builds are both shipped).
 
 ## Setup
 

--- a/packages/buddy/package.json
+++ b/packages/buddy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@computesdk/buddy",
   "version": "1.0.1",
-  "description": "Buddy provider for ComputeSDK - Ubuntu sandboxes served from a pre-warmed hot pool, with public HTTP tunnels and snapshots",
+  "description": "Buddy provider for ComputeSDK - Persistent Ubuntu sandboxes for agents, booting in milliseconds, with preview URLs and snapshots",
   "author": "Lucas Czulak",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@buddy-works/sandbox-sdk": "^0.1.8",
+    "@buddy-works/sandbox-sdk": "^0.1.9",
     "@computesdk/provider": "workspace:*",
     "computesdk": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,8 +486,8 @@ importers:
   packages/buddy:
     dependencies:
       '@buddy-works/sandbox-sdk':
-        specifier: ^0.1.8
-        version: 0.1.8
+        specifier: ^0.1.9
+        version: 0.1.9
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2940,8 +2940,8 @@ packages:
   '@browserbasehq/sdk@2.9.0':
     resolution: {integrity: sha512-Xzm1+6suzQypXjley4Phqer++pjnYyST6S7CArUn3kWyGA8aruXjAV5wkmqE21lgXo9K3/OQJvCu48bKEZFNDQ==}
 
-  '@buddy-works/sandbox-sdk@0.1.8':
-    resolution: {integrity: sha512-gkgmVDJYkM3IzxtNHOy3FWxuAsDaZQz0Pjm9qXTL12leZTnZAPunTAJxs/B86dwcWLLNPBU85lu32pui1YB57Q==}
+  '@buddy-works/sandbox-sdk@0.1.9':
+    resolution: {integrity: sha512-x9pGTSSRBtYtGwDLWHPAhyCDXnyFe8DQKoLOP9DiwNKBVXuHah8rROnoLW1lNp4USYgS6w8zrnHxjykF2jGIhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bufbuild/protobuf@2.12.1':
@@ -10308,7 +10308,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@buddy-works/sandbox-sdk@0.1.8':
+  '@buddy-works/sandbox-sdk@0.1.9':
     dependencies:
       p-retry: 7.1.1
       zod: 4.3.5


### PR DESCRIPTION
Follow-up to #763.

- `@buddy-works/sandbox-sdk` `^0.1.8` → `^0.1.9`. The SDK's HTTP layer no longer retries a non-idempotent request after an ambiguous failure, so a `create` that times out can't end up creating two sandboxes.
- Package description reworded in the README provider list, `package.json` and the docs page: "Persistent Ubuntu sandboxes for agents, booting in milliseconds, with preview URLs and snapshots".
- The Node requirement note said the SDK ships ESM only. It ships ESM and CommonJS, so the note now points at the SDK's `engines` range instead.

Checked: 61 unit tests, `tsc` clean, and a create → `node -v` → destroy round trip against a real sandbox on 0.1.9.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->