### PR TITLE
fix(namespace): implement sandbox filesystem methods via runCommand

### DIFF
--- a/.changeset/namespace-filesystem.md
+++ b/.changeset/namespace-filesystem.md
@@ -1,0 +1,7 @@
+---
+"@computesdk/namespace": patch
+---
+
+Implement `sandbox.filesystem` methods for Namespace using `runCommand`. This fixes filesystem benchmarks and workloads that call `mkdir`, `writeFile`, `readFile`, and `exists` on Namespace sandboxes.
+
+File writes are base64-encoded and split into commands that stay under typical shell argument length limits. `writeFile` is chunked on 48,000-character base64 boundaries so each `runCommand` stays safe for 100 KiB payloads.

--- a/packages/namespace/src/__tests__/filesystem.test.ts
+++ b/packages/namespace/src/__tests__/filesystem.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { namespace } from '../index';
+import type { NamespaceSandbox } from '../index';
+import type { CommandResult, RunCommandOptions } from '@computesdk/provider';
+
+function makeSandbox(): NamespaceSandbox {
+  return {
+    instanceId: 'i-123',
+    name: 'test',
+    commandServiceEndpoint: 'https://cmd.example',
+    token: 'token',
+    targetContainerName: 'main-container',
+    createdAt: new Date(),
+  };
+}
+
+type MockRunCommand = (
+  sandbox: NamespaceSandbox,
+  command: string,
+  options?: RunCommandOptions,
+) => Promise<CommandResult>;
+
+function captureRunCommand(): {
+  calls: string[];
+  runCommand: MockRunCommand;
+} {
+  const calls: string[] = [];
+  const runCommand = vi.fn(async (_sandbox: NamespaceSandbox, command: string): Promise<CommandResult> => {
+    calls.push(command);
+    return { exitCode: 0, stdout: '', stderr: '', durationMs: 0 };
+  });
+  return { calls, runCommand };
+}
+
+describe('namespace filesystem methods', () => {
+  it('normalizes dash-leading paths', async () => {
+    const sandbox = makeSandbox();
+    const { calls, runCommand } = captureRunCommand();
+    const fs = namespace({}).sandbox.methods.filesystem!;
+
+    await fs.mkdir(sandbox, '-v', runCommand);
+    expect(calls[0]).toBe('mkdir -p "./-v"');
+
+    calls.length = 0;
+    await fs.remove(sandbox, '-v', runCommand);
+    expect(calls[0]).toBe('rm -rf "./-v"');
+
+    calls.length = 0;
+    await fs.exists(sandbox, '-v', runCommand);
+    expect(calls[0]).toBe('test -e "./-v"');
+
+    calls.length = 0;
+    await fs.readFile(sandbox, '-v', runCommand);
+    expect(calls[0]).toBe('cat "./-v"');
+  });
+
+  it('writes content in base64 chunks', async () => {
+    const sandbox = makeSandbox();
+    const { calls, runCommand } = captureRunCommand();
+    const fs = namespace({}).sandbox.methods.filesystem!;
+
+    const content = 'x'.repeat(100 * 1024);
+    await fs.writeFile(sandbox, '/tmp/bench/file.txt', content, runCommand);
+
+    const encoded = Buffer.from(content, 'utf8').toString('base64');
+    // 48,000-character base64 chunks; 100 KiB raw yields three chunks.
+    expect(calls.length).toBe(3);
+
+    // First command uses >, subsequent commands append with >>.
+    expect(calls[0]).toContain('> "/tmp/bench/file.txt"');
+    expect(calls[1]).toContain('>> "/tmp/bench/file.txt"');
+    expect(calls[2]).toContain('>> "/tmp/bench/file.txt"');
+
+    // Verify the full encoded content is spread across the three commands.
+    const reconstructed = calls
+      .map((cmd) => {
+        const match = cmd.match(/printf '%s' "(.*?)" \| base64 -d/);
+        return match?.[1] ?? '';
+      })
+      .join('');
+    expect(reconstructed).toBe(encoded);
+  });
+
+  it('readdir decodes base64 names and classifies directories', async () => {
+    const sandbox = makeSandbox();
+    const calls: string[] = [];
+    const runCommand = vi.fn(async (_sandbox: NamespaceSandbox, command: string): Promise<CommandResult> => {
+      calls.push(command);
+      const dirName = 'foo';
+      const fileName = 'bar';
+      const dir64 = Buffer.from(dirName, 'utf8').toString('base64');
+      const file64 = Buffer.from(fileName, 'utf8').toString('base64');
+      return {
+        exitCode: 0,
+        stdout: `d\t${dir64}\0f\t${file64}\0`,
+        stderr: '',
+        durationMs: 0,
+      };
+    });
+    const fs = namespace({}).sandbox.methods.filesystem!;
+
+    const entries = await fs.readdir(sandbox, '/tmp/dir', runCommand);
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toContain('find "/tmp/dir"');
+    expect(entries).toEqual([
+      { name: 'foo', type: 'directory' },
+      { name: 'bar', type: 'file' },
+    ]);
+  });
+});

--- a/packages/namespace/src/index.ts
+++ b/packages/namespace/src/index.ts
@@ -344,7 +344,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
           const result = await namespaceRunCommand(
             sandbox,
             runCommand,
-            `mkdir -p "${escapeShellArg(dirPath)}"`,
+            `mkdir -p ${shellQuotePath(dirPath)}`,
           );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to create directory ${dirPath}: ${result.stderr}`);
@@ -353,14 +353,14 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
 
         writeFile: async (sandbox, filePath, content, runCommand) => {
           const dir = path.posix.dirname(filePath);
-          const escapedPath = escapeShellArg(filePath);
-          const escapedDir = escapeShellArg(dir);
+          const escapedPath = shellQuotePath(filePath);
+          const escapedDir = shellQuotePath(dir);
 
           if (content.length === 0) {
             const result = await namespaceRunCommand(
               sandbox,
               runCommand,
-              `mkdir -p "${escapedDir}" && : > "${escapedPath}"`,
+              `mkdir -p ${escapedDir} && : > ${escapedPath}`,
             );
             if (result.exitCode !== 0) {
               throw new Error(`Failed to write ${filePath}: ${result.stderr}`);
@@ -380,7 +380,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
             const result = await namespaceRunCommand(
               sandbox,
               runCommand,
-              `mkdir -p "${escapedDir}" && printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} "${escapedPath}"`,
+              `mkdir -p ${escapedDir} && printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} ${escapedPath}`,
             );
             if (result.exitCode !== 0) {
               throw new Error(`Failed to write ${filePath}: ${result.stderr}`);
@@ -393,7 +393,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
           const result = await namespaceRunCommand(
             sandbox,
             runCommand,
-            `cat "${escapeShellArg(filePath)}"`,
+            `cat ${shellQuotePath(filePath)}`,
           );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to read ${filePath}: ${result.stderr}`);
@@ -402,22 +402,26 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
         },
 
         readdir: async (sandbox, dirPath, runCommand): Promise<FileEntry[]> => {
-          const result = await namespaceRunCommand(
-            sandbox,
-            runCommand,
-            `find "${escapeShellArg(dirPath)}" -mindepth 1 -maxdepth 1 -type d -printf 'd\\t%f\\n' -o -type f -printf 'f\\t%f\\n'`,
-          );
+          const script =
+            "find " + shellQuotePath(dirPath) + " -mindepth 1 -maxdepth 1 -exec sh -c '" +
+            "for f; do " +
+            '[ -d "$f" ] && t=d || t=f; ' +
+            "name=${f##*/}; " +
+            'name64=$(printf "%s" "$name" | base64); ' +
+            'printf "%s\\t%s\\0" "$t" "$name64"; ' +
+            "done' _ {} +";
+          const result = await namespaceRunCommand(sandbox, runCommand, script);
           if (result.exitCode !== 0) {
             throw new Error(`Failed to list directory ${dirPath}: ${result.stderr}`);
           }
           const entries: FileEntry[] = [];
-          for (const line of result.stdout.split('\n')) {
-            if (!line) continue;
-            const [typeChar, ...nameParts] = line.split('\t');
-            const name = nameParts.join('\t');
-            if (!name) continue;
+          for (const record of result.stdout.split('\0')) {
+            if (!record) continue;
+            const [typeChar, ...name64Parts] = record.split('\t');
+            const name64 = name64Parts.join('\t').replace(/\n/g, '');
+            if (!name64) continue;
             entries.push({
-              name,
+              name: Buffer.from(name64, 'base64').toString('utf8'),
               type: typeChar === 'd' ? 'directory' : 'file',
             });
           }
@@ -428,7 +432,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
           const result = await namespaceRunCommand(
             sandbox,
             runCommand,
-            `test -e "${escapeShellArg(filePath)}"`,
+            `test -e ${shellQuotePath(filePath)}`,
           );
           return result.exitCode === 0;
         },
@@ -437,7 +441,7 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
           const result = await namespaceRunCommand(
             sandbox,
             runCommand,
-            `rm -rf "${escapeShellArg(targetPath)}"`,
+            `rm -rf ${shellQuotePath(targetPath)}`,
           );
           if (result.exitCode !== 0) {
             throw new Error(`Failed to remove ${targetPath}: ${result.stderr}`);
@@ -472,6 +476,20 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
  * Thin wrapper around the provider's runCommand that re-throws friendly errors
  * when the command service endpoint is unavailable.
  */
+function normalizeShellPath(input: string): string {
+  if (input === '' || input.startsWith('/') || input.startsWith('./') || input.startsWith('../')) {
+    return input;
+  }
+  if (input.startsWith('-')) {
+    return `./${input}`;
+  }
+  return input;
+}
+
+function shellQuotePath(input: string): string {
+  return `"${escapeShellArg(normalizeShellPath(input))}"`;
+}
+
 async function namespaceRunCommand(
   sandbox: NamespaceSandbox,
   runCommand: (sandbox: NamespaceSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>,

--- a/packages/namespace/src/index.ts
+++ b/packages/namespace/src/index.ts
@@ -6,8 +6,9 @@
  */
 
 import * as fs from 'fs/promises';
+import path from 'node:path';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
-import type { CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions } from '@computesdk/provider';
+import type { CommandResult, SandboxInfo, CreateSandboxOptions, RunCommandOptions, FileEntry } from '@computesdk/provider';
 
 /**
  * Namespace sandbox instance
@@ -55,6 +56,11 @@ const API_ENDPOINTS = {
 const COMMAND_SERVICE = {
   RUN_COMMAND_SYNC: '/namespace.cloud.compute.v1beta.CommandService/RunCommandSync',
 };
+
+// Chunk base64-encoded file writes so each runCommand stays under typical
+// shell argument / command-length limits. Must be a multiple of 4 to keep
+// base64 padding aligned across chunks.
+const FILESYSTEM_BASE64_CHUNK_SIZE = 48_000;
 
 /**
  * Load bearer token from a JSON token file (e.g. from `nsc login`)
@@ -333,6 +339,112 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
         }
       },
 
+      filesystem: {
+        mkdir: async (sandbox, dirPath, runCommand) => {
+          const result = await namespaceRunCommand(
+            sandbox,
+            runCommand,
+            `mkdir -p "${escapeShellArg(dirPath)}"`,
+          );
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to create directory ${dirPath}: ${result.stderr}`);
+          }
+        },
+
+        writeFile: async (sandbox, filePath, content, runCommand) => {
+          const dir = path.posix.dirname(filePath);
+          const escapedPath = escapeShellArg(filePath);
+          const escapedDir = escapeShellArg(dir);
+
+          if (content.length === 0) {
+            const result = await namespaceRunCommand(
+              sandbox,
+              runCommand,
+              `mkdir -p "${escapedDir}" && : > "${escapedPath}"`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to write ${filePath}: ${result.stderr}`);
+            }
+            return;
+          }
+
+          const encoded = Buffer.from(content, 'utf8').toString('base64');
+          const chunks: string[] = [];
+          for (let offset = 0; offset < encoded.length; offset += FILESYSTEM_BASE64_CHUNK_SIZE) {
+            chunks.push(encoded.slice(offset, offset + FILESYSTEM_BASE64_CHUNK_SIZE));
+          }
+
+          let first = true;
+          for (const chunk of chunks) {
+            const redirect = first ? '>' : '>>';
+            const result = await namespaceRunCommand(
+              sandbox,
+              runCommand,
+              `mkdir -p "${escapedDir}" && printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} "${escapedPath}"`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(`Failed to write ${filePath}: ${result.stderr}`);
+            }
+            first = false;
+          }
+        },
+
+        readFile: async (sandbox, filePath, runCommand) => {
+          const result = await namespaceRunCommand(
+            sandbox,
+            runCommand,
+            `cat "${escapeShellArg(filePath)}"`,
+          );
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to read ${filePath}: ${result.stderr}`);
+          }
+          return result.stdout ?? '';
+        },
+
+        readdir: async (sandbox, dirPath, runCommand): Promise<FileEntry[]> => {
+          const result = await namespaceRunCommand(
+            sandbox,
+            runCommand,
+            `find "${escapeShellArg(dirPath)}" -mindepth 1 -maxdepth 1 -type d -printf 'd\\t%f\\n' -o -type f -printf 'f\\t%f\\n'`,
+          );
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to list directory ${dirPath}: ${result.stderr}`);
+          }
+          const entries: FileEntry[] = [];
+          for (const line of result.stdout.split('\n')) {
+            if (!line) continue;
+            const [typeChar, ...nameParts] = line.split('\t');
+            const name = nameParts.join('\t');
+            if (!name) continue;
+            entries.push({
+              name,
+              type: typeChar === 'd' ? 'directory' : 'file',
+            });
+          }
+          return entries;
+        },
+
+        exists: async (sandbox, filePath, runCommand) => {
+          const result = await namespaceRunCommand(
+            sandbox,
+            runCommand,
+            `test -e "${escapeShellArg(filePath)}"`,
+          );
+          return result.exitCode === 0;
+        },
+
+        remove: async (sandbox, targetPath, runCommand) => {
+          const result = await namespaceRunCommand(
+            sandbox,
+            runCommand,
+            `rm -rf "${escapeShellArg(targetPath)}"`,
+          );
+          if (result.exitCode !== 0) {
+            throw new Error(`Failed to remove ${targetPath}: ${result.stderr}`);
+          }
+        },
+      },
+
       getInfo: async (sandbox: NamespaceSandbox): Promise<SandboxInfo> => {
         return {
           id: sandbox.instanceId,
@@ -355,3 +467,19 @@ export const namespace = defineProvider<NamespaceSandbox, NamespaceConfig>({
     }
   }
 });
+
+/**
+ * Thin wrapper around the provider's runCommand that re-throws friendly errors
+ * when the command service endpoint is unavailable.
+ */
+async function namespaceRunCommand(
+  sandbox: NamespaceSandbox,
+  runCommand: (sandbox: NamespaceSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>,
+  command: string,
+  options?: RunCommandOptions,
+): Promise<CommandResult> {
+  if (!sandbox.commandServiceEndpoint) {
+    throw new Error('Command service endpoint not available. Filesystem operations require command execution support.');
+  }
+  return runCommand(sandbox, command, options);
+}


### PR DESCRIPTION
## Summary

`@computesdk/namespace` did not define `methods.sandbox.filesystem`, so the provider factory injected `UnsupportedFileSystem`. Any call to `sandbox.filesystem.mkdir`/`writeFile`/`readFile`/`exists` failed with:

```
Filesystem operations are not supported by namespace's sandbox environment. namespace sandboxes are designed for code execution only.
```

This change adds `filesystem` implementations that delegate to `runCommand` inside the Namespace sandbox:

- `mkdir` → `mkdir -p`
- `writeFile` → base64-decode chunks into the target file (chunked on 48,000-character base64 boundaries to stay under typical shell command/argument limits)
- `readFile` → `cat`
- `exists` → `test -e`
- `readdir` → `find -exec sh -c` with per-entry classification and base64-encoded, null-terminated names
- `remove` → `rm -rf`

Relative paths that begin with `-` are normalized to `./<path>` before they are passed to `mkdir`, `cat`, `find`, `test`, or `rm`, so dash-leading names are never parsed as command options. `readdir` base64-encodes each entry name and delimits records with `\0`, preserving names that contain newlines or tabs.

```ts
// Resulting benchmark flow now works on namespace:
await sandbox.filesystem.mkdir('/tmp/bench/fs-xxx');
await sandbox.filesystem.writeFile('/tmp/bench/fs-xxx/file-0.txt', content);
const marker = await sandbox.filesystem.readFile('/tmp/bench/fs-xxx/marker.txt');
```

## Caveats

- The `readdir` implementation requires `sh`, `find`, `base64`, and `printf` in the sandbox image.
- No concurrency locks are added; concurrent writes to the same path may interleave.

## Release note

Added `.changeset/namespace-filesystem.md` as a patch release for `@computesdk/namespace`. After this publishes, the `benchmarks-sandbox-filesystem` repo will need `pnpm update @computesdk/namespace` (or a lockfile refresh) to pick up the fix.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->