### PR TITLE
fix(run-cloud): chunk writeFile payloads and normalize dash-leading paths

### DIFF
--- a/.changeset/run-cloud-chunk-writefile.md
+++ b/.changeset/run-cloud-chunk-writefile.md
@@ -1,0 +1,7 @@
+---
+"@computesdk/run-cloud": patch
+---
+
+Chunk `filesystem.writeFile` payloads into 48,000-character base64 commands to avoid "Command initialization frame is too large" errors when writing files larger than the Run Cloud command frame limit.
+
+Also normalizes dash-leading paths so they are not parsed as command options by `mkdir`, `cat`, `find`, `test`, or `rm`.

--- a/packages/run-cloud/src/__tests__/unit.test.ts
+++ b/packages/run-cloud/src/__tests__/unit.test.ts
@@ -428,7 +428,9 @@ describe('run-cloud provider', () => {
         expect.stringContaining(
           'printf \'%s\' "aGVsbG8=" | base64 -d',
         ),
-        expect.stringMatching(/mv -- ".*\/result\.txt\.tmp\.\w+" ".*\/result\.txt"/),
+        expect.stringMatching(
+          /cat < ".*\.computesdk-tmp\.\w+" > ".*\/result\.txt" && rm -f -- ".*\.computesdk-tmp\.\w+"/,
+        ),
         expect.stringContaining('find "/tmp/a b" -mindepth 1 -maxdepth 1'),
         expect.stringContaining('test -e "/tmp/a b/result.txt"'),
       ]),
@@ -438,7 +440,7 @@ describe('run-cloud provider', () => {
     const base64Command = commands.find((cmd) =>
       cmd.includes('printf \'%s\' "aGVsbG8=" | base64 -d'),
     );
-    expect(base64Command).toMatch(/\.tmp\.\w+"?$/);
+    expect(base64Command).toMatch(/\.computesdk-tmp\.\w+"?$/);
     expect(base64Command).not.toContain('> "/tmp/a b/result.txt"');
 
     expect(entries).toEqual([
@@ -477,8 +479,10 @@ describe('run-cloud provider', () => {
       .join('');
     expect(reconstructed).toBe(encoded);
 
-    const mvCommand = commands.find((cmd) => cmd.startsWith('mv --'));
-    expect(mvCommand).toMatch(/mv -- ".*\/file\.txt\.tmp\.\w+" ".*\/file\.txt"/);
+    const finalizeCommand = commands.find((cmd) => cmd.includes('cat <'));
+    expect(finalizeCommand).toMatch(
+      /cat < ".*\.computesdk-tmp\.\w+" > ".*\/file\.txt" && rm -f -- ".*\.computesdk-tmp\.\w+"/,
+    );
   });
 
   it('normalizes dash-leading paths for filesystem commands', async () => {

--- a/packages/run-cloud/src/__tests__/unit.test.ts
+++ b/packages/run-cloud/src/__tests__/unit.test.ts
@@ -391,6 +391,12 @@ describe('run-cloud provider', () => {
         exitCode: 0,
       })
       .mockResolvedValueOnce({
+        stdout: '',
+        stderr: '',
+        exit_code: 0,
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
         stdout:
           'app.ts\tf\t10\t1767225600.0000000000\n' +
           'src\td\t0\t1767225601.0000000000\n',
@@ -414,11 +420,27 @@ describe('run-cloud provider', () => {
     expect(await sandbox.filesystem.exists('/tmp/a b/result.txt')).toBe(true);
 
     expect(readFileMock).toHaveBeenCalledWith('sbx_123', '/tmp/result.txt');
-    expect(execMock.mock.calls[0][1]).toContain('mkdir -p "/tmp/a b"');
-    expect(execMock.mock.calls[0][1]).toContain(
-      'printf \'%s\' "aGVsbG8=" | base64 -d',
+
+    const commands = execMock.mock.calls.map((call) => call[1] as string);
+    expect(commands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('mkdir -p "/tmp/a b"'),
+        expect.stringContaining(
+          'printf \'%s\' "aGVsbG8=" | base64 -d',
+        ),
+        expect.stringMatching(/mv -- ".*\/result\.txt\.tmp\.\w+" ".*\/result\.txt"/),
+        expect.stringContaining('find "/tmp/a b" -mindepth 1 -maxdepth 1'),
+        expect.stringContaining('test -e "/tmp/a b/result.txt"'),
+      ]),
     );
-    expect(execMock.mock.calls[0][1]).toContain('> "/tmp/a b/result.txt"');
+
+    // The base64 payload must be written to a staging file, not the final path.
+    const base64Command = commands.find((cmd) =>
+      cmd.includes('printf \'%s\' "aGVsbG8=" | base64 -d'),
+    );
+    expect(base64Command).toMatch(/\.tmp\.\w+"?$/);
+    expect(base64Command).not.toContain('> "/tmp/a b/result.txt"');
+
     expect(entries).toEqual([
       {
         name: 'app.ts',
@@ -441,17 +463,22 @@ describe('run-cloud provider', () => {
     await sandbox.filesystem.writeFile('/tmp/bench/file.txt', content);
 
     const encoded = Buffer.from(content, 'utf8').toString('base64');
-    // 48,000-character base64 chunks; 100 KiB raw yields three commands.
-    expect(execMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    const commands = execMock.mock.calls.map((call) => call[1] as string);
 
-    const reconstructed = execMock.mock.calls
-      .map((call) => {
-        const cmd = call[1] as string;
+    // 48,000-character base64 chunks; 100 KiB raw yields three chunk commands
+    // plus one mv command.
+    expect(commands.length).toBeGreaterThanOrEqual(4);
+
+    const reconstructed = commands
+      .map((cmd) => {
         const match = cmd.match(/printf '%s' "(.*?)" \| base64 -d/);
         return match?.[1] ?? '';
       })
       .join('');
     expect(reconstructed).toBe(encoded);
+
+    const mvCommand = commands.find((cmd) => cmd.startsWith('mv --'));
+    expect(mvCommand).toMatch(/mv -- ".*\/file\.txt\.tmp\.\w+" ".*\/file\.txt"/);
   });
 
   it('normalizes dash-leading paths for filesystem commands', async () => {

--- a/packages/run-cloud/src/__tests__/unit.test.ts
+++ b/packages/run-cloud/src/__tests__/unit.test.ts
@@ -414,12 +414,11 @@ describe('run-cloud provider', () => {
     expect(await sandbox.filesystem.exists('/tmp/a b/result.txt')).toBe(true);
 
     expect(readFileMock).toHaveBeenCalledWith('sbx_123', '/tmp/result.txt');
-    expect(execMock.mock.calls[0][1]).toContain(
-      'mkdir -p "$(dirname "/tmp/a b/result.txt")"',
-    );
+    expect(execMock.mock.calls[0][1]).toContain('mkdir -p "/tmp/a b"');
     expect(execMock.mock.calls[0][1]).toContain(
       'printf \'%s\' "aGVsbG8=" | base64 -d',
     );
+    expect(execMock.mock.calls[0][1]).toContain('> "/tmp/a b/result.txt"');
     expect(entries).toEqual([
       {
         name: 'app.ts',
@@ -434,6 +433,39 @@ describe('run-cloud provider', () => {
         modified: new Date('2026-01-01T00:00:01.000Z'),
       },
     ]);
+  });
+
+  it('chunks large writeFile payloads into multiple runCommand calls', async () => {
+    const sandbox = await runCloud({ apiKey: 'rc_test' }).sandbox.create();
+    const content = 'x'.repeat(100 * 1024);
+    await sandbox.filesystem.writeFile('/tmp/bench/file.txt', content);
+
+    const encoded = Buffer.from(content, 'utf8').toString('base64');
+    // 48,000-character base64 chunks; 100 KiB raw yields three commands.
+    expect(execMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+    const reconstructed = execMock.mock.calls
+      .map((call) => {
+        const cmd = call[1] as string;
+        const match = cmd.match(/printf '%s' "(.*?)" \| base64 -d/);
+        return match?.[1] ?? '';
+      })
+      .join('');
+    expect(reconstructed).toBe(encoded);
+  });
+
+  it('normalizes dash-leading paths for filesystem commands', async () => {
+    const sandbox = await runCloud({ apiKey: 'rc_test' }).sandbox.create();
+    await sandbox.filesystem.mkdir('-v');
+    expect(execMock.mock.calls[0][1]).toBe('mkdir -p "./-v"');
+
+    execMock.mockClear();
+    await sandbox.filesystem.exists('-v');
+    expect(execMock.mock.calls[0][1]).toBe('test -e "./-v"');
+
+    execMock.mockClear();
+    await sandbox.filesystem.remove('-v');
+    expect(execMock.mock.calls[0][1]).toBe('rm -rf "./-v"');
   });
 
   it('creates, lists, limits, and idempotently deletes snapshots', async () => {

--- a/packages/run-cloud/src/index.ts
+++ b/packages/run-cloud/src/index.ts
@@ -579,10 +579,11 @@ const _provider = defineProvider<
             chunks.push(encoded.slice(offset, offset + FILESYSTEM_BASE64_CHUNK_SIZE));
           }
 
-          // Write each call's chunks to a unique staging file so concurrent
-          // writeFile calls cannot interleave chunks in the destination.
-          const stagingSuffix = `.tmp.${crypto.randomBytes(4).toString('hex')}`;
-          const stagingPath = `${normalizedPath}${stagingSuffix}`;
+          // Build a short, unique staging file in the destination directory.
+          // Keeping the staging basename independent of the destination avoids
+          // ENAMETOOLONG for valid filenames that are near the component limit.
+          const stagingBasename = `.computesdk-tmp.${crypto.randomBytes(4).toString('hex')}`;
+          const stagingPath = path.posix.join(dir, stagingBasename);
           const escapedStagingPath = shellQuotePath(stagingPath);
 
           try {
@@ -603,9 +604,13 @@ const _provider = defineProvider<
               first = false;
             }
 
+            // Copy the completed staging content into the destination and
+            // remove the staging file. Using shell redirection preserves the
+            // destination's existing inode, permissions, and links, and
+            // fails when the destination is an existing directory.
             const result = await runCommand(
               handle,
-              `mv -- ${escapedStagingPath} ${escapedPath}`,
+              `cat < ${escapedStagingPath} > ${escapedPath} && rm -f -- ${escapedStagingPath}`,
             );
             if (result.exitCode !== 0) {
               throw new Error(

--- a/packages/run-cloud/src/index.ts
+++ b/packages/run-cloud/src/index.ts
@@ -11,6 +11,7 @@ import type {
   SandboxTunnel as NativeTunnel,
   Snapshot as NativeSnapshot,
 } from '@run-cloud/sdk';
+import path from 'node:path';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 import type {
   CommandResult,
@@ -358,6 +359,30 @@ function singleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+// Chunk base64-encoded file writes so each runCommand stays under typical
+// shell argument / command-length limits. Must be a multiple of 4 to keep
+// base64 padding aligned across chunks.
+const FILESYSTEM_BASE64_CHUNK_SIZE = 48_000;
+
+function normalizeShellPath(input: string): string {
+  if (
+    input === '' ||
+    input.startsWith('/') ||
+    input.startsWith('./') ||
+    input.startsWith('../')
+  ) {
+    return input;
+  }
+  if (input.startsWith('-')) {
+    return `./${input}`;
+  }
+  return input;
+}
+
+function shellQuotePath(input: string): string {
+  return `"${escapeShellArg(normalizeShellPath(input))}"`;
+}
+
 function snapshotDate(snapshot: NativeSnapshot): Date {
   const record = snapshot as Record<string, unknown>;
   const value = record.createdAt ?? record.created_at;
@@ -519,52 +544,80 @@ const _provider = defineProvider<
       getInstance: (handle): RunCloudSandbox => handle,
 
       filesystem: {
-        readFile: async (handle, path): Promise<string> => {
+        readFile: async (handle, filePath): Promise<string> => {
           const bytes = await handle.client.sandboxes.readFile(
             handle.sandbox.id,
-            path,
+            filePath,
           );
           return new TextDecoder().decode(bytes);
         },
 
-        writeFile: async (handle, path, content, runCommand): Promise<void> => {
+        writeFile: async (handle, filePath, content, runCommand): Promise<void> => {
+          const normalizedPath = normalizeShellPath(filePath);
+          const escapedPath = shellQuotePath(normalizedPath);
+          const dir = path.posix.dirname(normalizedPath);
+          const escapedDir = shellQuotePath(dir);
+
+          if (content.length === 0) {
+            const result = await runCommand(
+              handle,
+              `mkdir -p ${escapedDir} && : > ${escapedPath}`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(
+                `Run Cloud writeFile failed for ${filePath}: ` +
+                  (result.stderr || `exit ${result.exitCode}`),
+              );
+            }
+            return;
+          }
+
           const encoded = Buffer.from(content, 'utf8').toString('base64');
-          const quotedPath = `"${escapeShellArg(path)}"`;
+          const chunks: string[] = [];
+          for (let offset = 0; offset < encoded.length; offset += FILESYSTEM_BASE64_CHUNK_SIZE) {
+            chunks.push(encoded.slice(offset, offset + FILESYSTEM_BASE64_CHUNK_SIZE));
+          }
+
+          let first = true;
+          for (const chunk of chunks) {
+            const redirect = first ? '>' : '>>';
+            const result = await runCommand(
+              handle,
+              `mkdir -p ${escapedDir} && ` +
+                `printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} ${escapedPath}`,
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(
+                `Run Cloud writeFile failed for ${filePath}: ` +
+                  (result.stderr || `exit ${result.exitCode}`),
+              );
+            }
+            first = false;
+          }
+        },
+
+        mkdir: async (handle, dirPath, runCommand): Promise<void> => {
           const result = await runCommand(
             handle,
-            `mkdir -p "$(dirname ${quotedPath})" && ` +
-              `printf '%s' "${encoded}" | base64 -d > ${quotedPath}`,
+            `mkdir -p ${shellQuotePath(dirPath)}`,
           );
           if (result.exitCode !== 0) {
             throw new Error(
-              `Run Cloud writeFile failed for ${path}: ` +
+              `Run Cloud mkdir failed for ${dirPath}: ` +
                 (result.stderr || `exit ${result.exitCode}`),
             );
           }
         },
 
-        mkdir: async (handle, path, runCommand): Promise<void> => {
+        readdir: async (handle, dirPath, runCommand): Promise<FileEntry[]> => {
           const result = await runCommand(
             handle,
-            `mkdir -p "${escapeShellArg(path)}"`,
-          );
-          if (result.exitCode !== 0) {
-            throw new Error(
-              `Run Cloud mkdir failed for ${path}: ` +
-                (result.stderr || `exit ${result.exitCode}`),
-            );
-          }
-        },
-
-        readdir: async (handle, path, runCommand): Promise<FileEntry[]> => {
-          const result = await runCommand(
-            handle,
-            `find "${escapeShellArg(path)}" -mindepth 1 -maxdepth 1 ` +
+            `find ${shellQuotePath(dirPath)} -mindepth 1 -maxdepth 1 ` +
               `-printf '%f\\t%y\\t%s\\t%T@\\n'`,
           );
           if (result.exitCode !== 0) {
             throw new Error(
-              `Run Cloud readdir failed for ${path}: ` +
+              `Run Cloud readdir failed for ${dirPath}: ` +
                 (result.stderr || `exit ${result.exitCode}`),
             );
           }
@@ -583,22 +636,22 @@ const _provider = defineProvider<
             });
         },
 
-        exists: async (handle, path, runCommand): Promise<boolean> => {
+        exists: async (handle, targetPath, runCommand): Promise<boolean> => {
           const result = await runCommand(
             handle,
-            `test -e "${escapeShellArg(path)}"`,
+            `test -e ${shellQuotePath(targetPath)}`,
           );
           return result.exitCode === 0;
         },
 
-        remove: async (handle, path, runCommand): Promise<void> => {
+        remove: async (handle, targetPath, runCommand): Promise<void> => {
           const result = await runCommand(
             handle,
-            `rm -rf "${escapeShellArg(path)}"`,
+            `rm -rf ${shellQuotePath(targetPath)}`,
           );
           if (result.exitCode !== 0) {
             throw new Error(
-              `Run Cloud remove failed for ${path}: ` +
+              `Run Cloud remove failed for ${targetPath}: ` +
                 (result.stderr || `exit ${result.exitCode}`),
             );
           }

--- a/packages/run-cloud/src/index.ts
+++ b/packages/run-cloud/src/index.ts
@@ -11,6 +11,7 @@ import type {
   SandboxTunnel as NativeTunnel,
   Snapshot as NativeSnapshot,
 } from '@run-cloud/sdk';
+import crypto from 'node:crypto';
 import path from 'node:path';
 import { defineProvider, escapeShellArg } from '@computesdk/provider';
 import type {
@@ -578,13 +579,33 @@ const _provider = defineProvider<
             chunks.push(encoded.slice(offset, offset + FILESYSTEM_BASE64_CHUNK_SIZE));
           }
 
-          let first = true;
-          for (const chunk of chunks) {
-            const redirect = first ? '>' : '>>';
+          // Write each call's chunks to a unique staging file so concurrent
+          // writeFile calls cannot interleave chunks in the destination.
+          const stagingSuffix = `.tmp.${crypto.randomBytes(4).toString('hex')}`;
+          const stagingPath = `${normalizedPath}${stagingSuffix}`;
+          const escapedStagingPath = shellQuotePath(stagingPath);
+
+          try {
+            let first = true;
+            for (const chunk of chunks) {
+              const redirect = first ? '>' : '>>';
+              const result = await runCommand(
+                handle,
+                `mkdir -p ${escapedDir} && ` +
+                  `printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} ${escapedStagingPath}`,
+              );
+              if (result.exitCode !== 0) {
+                throw new Error(
+                  `Run Cloud writeFile failed for ${filePath}: ` +
+                    (result.stderr || `exit ${result.exitCode}`),
+                );
+              }
+              first = false;
+            }
+
             const result = await runCommand(
               handle,
-              `mkdir -p ${escapedDir} && ` +
-                `printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} ${escapedPath}`,
+              `mv -- ${escapedStagingPath} ${escapedPath}`,
             );
             if (result.exitCode !== 0) {
               throw new Error(
@@ -592,7 +613,11 @@ const _provider = defineProvider<
                   (result.stderr || `exit ${result.exitCode}`),
               );
             }
-            first = false;
+          } catch (error) {
+            await runCommand(handle, `rm -f -- ${escapedStagingPath}`).catch(
+              () => {},
+            );
+            throw error;
           }
         },
 

--- a/packages/run-cloud/src/index.ts
+++ b/packages/run-cloud/src/index.ts
@@ -79,6 +79,36 @@ export interface RunCloudSnapshot {
   metadata: Record<string, unknown>;
 }
 
+// Serialize writeFile calls targeting the same path on the same sandbox.
+// This keeps chunk assembly and finalization from interleaving across
+// concurrent calls while still allowing writes to different paths to run
+// in parallel.
+const writeFileLocks = new WeakMap<RunCloudSandbox, Map<string, Promise<void>>>();
+
+function queueWrite(
+  handle: RunCloudSandbox,
+  targetPath: string,
+  write: () => Promise<void>,
+): Promise<void> {
+  let locks = writeFileLocks.get(handle);
+  if (!locks) {
+    locks = new Map();
+    writeFileLocks.set(handle, locks);
+  }
+
+  const previous = locks.get(targetPath) ?? Promise.resolve();
+  const next = previous
+    .catch(() => {})
+    .then(() => write())
+    .finally(() => {
+      if (locks!.get(targetPath) === next) {
+        locks!.delete(targetPath);
+      }
+    });
+  locks.set(targetPath, next);
+  return next;
+}
+
 function env(name: string): string | undefined {
   const value = typeof process !== 'undefined' ? process.env?.[name] : undefined;
   return value && value.trim() ? value.trim() : undefined;
@@ -555,45 +585,16 @@ const _provider = defineProvider<
 
         writeFile: async (handle, filePath, content, runCommand): Promise<void> => {
           const normalizedPath = normalizeShellPath(filePath);
-          const escapedPath = shellQuotePath(normalizedPath);
-          const dir = path.posix.dirname(normalizedPath);
-          const escapedDir = shellQuotePath(dir);
 
-          if (content.length === 0) {
-            const result = await runCommand(
-              handle,
-              `mkdir -p ${escapedDir} && : > ${escapedPath}`,
-            );
-            if (result.exitCode !== 0) {
-              throw new Error(
-                `Run Cloud writeFile failed for ${filePath}: ` +
-                  (result.stderr || `exit ${result.exitCode}`),
-              );
-            }
-            return;
-          }
+          return queueWrite(handle, normalizedPath, async () => {
+            const escapedPath = shellQuotePath(normalizedPath);
+            const dir = path.posix.dirname(normalizedPath);
+            const escapedDir = shellQuotePath(dir);
 
-          const encoded = Buffer.from(content, 'utf8').toString('base64');
-          const chunks: string[] = [];
-          for (let offset = 0; offset < encoded.length; offset += FILESYSTEM_BASE64_CHUNK_SIZE) {
-            chunks.push(encoded.slice(offset, offset + FILESYSTEM_BASE64_CHUNK_SIZE));
-          }
-
-          // Build a short, unique staging file in the destination directory.
-          // Keeping the staging basename independent of the destination avoids
-          // ENAMETOOLONG for valid filenames that are near the component limit.
-          const stagingBasename = `.computesdk-tmp.${crypto.randomBytes(4).toString('hex')}`;
-          const stagingPath = path.posix.join(dir, stagingBasename);
-          const escapedStagingPath = shellQuotePath(stagingPath);
-
-          try {
-            let first = true;
-            for (const chunk of chunks) {
-              const redirect = first ? '>' : '>>';
+            if (content.length === 0) {
               const result = await runCommand(
                 handle,
-                `mkdir -p ${escapedDir} && ` +
-                  `printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} ${escapedStagingPath}`,
+                `mkdir -p ${escapedDir} && : > ${escapedPath}`,
               );
               if (result.exitCode !== 0) {
                 throw new Error(
@@ -601,29 +602,61 @@ const _provider = defineProvider<
                     (result.stderr || `exit ${result.exitCode}`),
                 );
               }
-              first = false;
+              return;
             }
 
-            // Copy the completed staging content into the destination and
-            // remove the staging file. Using shell redirection preserves the
-            // destination's existing inode, permissions, and links, and
-            // fails when the destination is an existing directory.
-            const result = await runCommand(
-              handle,
-              `cat < ${escapedStagingPath} > ${escapedPath} && rm -f -- ${escapedStagingPath}`,
-            );
-            if (result.exitCode !== 0) {
-              throw new Error(
-                `Run Cloud writeFile failed for ${filePath}: ` +
-                  (result.stderr || `exit ${result.exitCode}`),
-              );
+            const encoded = Buffer.from(content, 'utf8').toString('base64');
+            const chunks: string[] = [];
+            for (let offset = 0; offset < encoded.length; offset += FILESYSTEM_BASE64_CHUNK_SIZE) {
+              chunks.push(encoded.slice(offset, offset + FILESYSTEM_BASE64_CHUNK_SIZE));
             }
-          } catch (error) {
-            await runCommand(handle, `rm -f -- ${escapedStagingPath}`).catch(
-              () => {},
-            );
-            throw error;
-          }
+
+            // Build a short, unique staging file in the destination directory.
+            // Keeping the staging basename independent of the destination avoids
+            // ENAMETOOLONG for valid filenames that are near the component limit.
+            const stagingBasename = `.computesdk-tmp.${crypto.randomBytes(4).toString('hex')}`;
+            const stagingPath = path.posix.join(dir, stagingBasename);
+            const escapedStagingPath = shellQuotePath(stagingPath);
+
+            try {
+              let first = true;
+              for (const chunk of chunks) {
+                const redirect = first ? '>' : '>>';
+                const result = await runCommand(
+                  handle,
+                  `mkdir -p ${escapedDir} && ` +
+                    `printf '%s' "${escapeShellArg(chunk)}" | base64 -d ${redirect} ${escapedStagingPath}`,
+                );
+                if (result.exitCode !== 0) {
+                  throw new Error(
+                    `Run Cloud writeFile failed for ${filePath}: ` +
+                      (result.stderr || `exit ${result.exitCode}`),
+                  );
+                }
+                first = false;
+              }
+
+              // Copy the completed staging content into the destination and
+              // remove the staging file. Using shell redirection preserves the
+              // destination's existing inode, permissions, and links, and
+              // fails when the destination is an existing directory.
+              const result = await runCommand(
+                handle,
+                `cat < ${escapedStagingPath} > ${escapedPath} && rm -f -- ${escapedStagingPath}`,
+              );
+              if (result.exitCode !== 0) {
+                throw new Error(
+                  `Run Cloud writeFile failed for ${filePath}: ` +
+                    (result.stderr || `exit ${result.exitCode}`),
+                );
+              }
+            } catch (error) {
+              await runCommand(handle, `rm -f -- ${escapedStagingPath}`).catch(
+                () => {},
+              );
+              throw error;
+            }
+          });
         },
 
         mkdir: async (handle, dirPath, runCommand): Promise<void> => {


### PR DESCRIPTION
## Summary

Run Cloud `filesystem.writeFile` was base64-encoding the entire file and sending it in one `exec()` command. Files larger than the Run Cloud command initialization frame limit (e.g. the 100 KiB files in the `sandbox-tmp-filesystem` benchmark) failed with:

```
run.cloud API 4400: Command initialization frame is too large
```

The fix chunks the base64 content into 48,000-character blocks and appends each decoded chunk to the target file. Each `runCommand` now stays comfortably below typical shell argument/frame limits.

```ts
// 100 KiB repeated-`x` content
const encoded = Buffer.from(content, 'utf8').toString('base64');
// split into 48K base64-character chunks
for (const chunk of chunks) {
  runCommand(`mkdir -p "<dir>" && printf '%s' "<chunk>" | base64 -d [>/>>] "<path>"`);
}
```

This also adds `normalizeShellPath` so relative paths that start with `-` are rewritten as `./-name` before being passed to `mkdir`, `cat`, `find`, `test`, or `rm`, preventing them from being parsed as command options.

## Release note

Added `.changeset/run-cloud-chunk-writefile.md` as a patch release for `@computesdk/run-cloud`. After it publishes, `benchmarks-sandbox-filesystem` can pick it up with `pnpm update @computesdk/run-cloud`.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->