### PR TITLE
fix(tenki): map filesystem paths into /home/tenki workdir

### DIFF
--- a/.changeset/tenki-filesystem-workdir.md
+++ b/.changeset/tenki-filesystem-workdir.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/tenki": patch
+---
+
+Map filesystem paths outside the guest workdir into /home/tenki so sandbox filesystem operations work when callers provide absolute paths like /tmp/bench.

--- a/packages/tenki/src/__tests__/unit.test.ts
+++ b/packages/tenki/src/__tests__/unit.test.ts
@@ -13,6 +13,11 @@ class SessionNotFoundError extends Error {}
 let lastCreateOptions: any = null;
 let lastExec: { command: string; args?: string[]; env?: Record<string, string> } | null = null;
 let execOutputChunks: Array<{ data: Uint8Array; isStderr: boolean }> | null = null;
+let lastWritePath: string | null = null;
+let lastReadPath: string | null = null;
+let lastListPath: string | null = null;
+let lastMkdirPath: string | null = null;
+let lastRemovePath: string | null = null;
 
 class FakeSession {
   id = 'sbx_123';
@@ -62,17 +67,21 @@ class FakeSession {
   }
 
   async writeFile(path: string, data: Uint8Array | string) {
+    lastWritePath = path;
     this.files.set(path, typeof data === 'string' ? enc.encode(data) : data);
   }
   async readFile(path: string): Promise<Uint8Array> {
+    lastReadPath = path;
     const v = this.files.get(path);
     if (!v) throw new Error('not found');
     return v;
   }
   async mkdir(path: string) {
+    lastMkdirPath = path;
     this.dirs.add(path);
   }
   async remove(path: string) {
+    lastRemovePath = path;
     this.files.delete(path);
     this.dirs.delete(path);
   }
@@ -87,6 +96,7 @@ class FakeSession {
     };
   }
   async list(_path: string) {
+    lastListPath = _path;
     return [
       { path: '/work/a.txt', size: 5n, mode: 0o644, isDir: false, modifiedUnixNs: 1_700_000_000_000_000_000n },
       { path: '/work/sub', size: 0n, mode: 0o755, isDir: true, modifiedUnixNs: 1_700_000_000_000_000_000n },
@@ -139,6 +149,11 @@ describe('tenki provider (mocked SDK)', () => {
     lastCreateOptions = null;
     lastExec = null;
     execOutputChunks = null;
+    lastWritePath = null;
+    lastReadPath = null;
+    lastListPath = null;
+    lastMkdirPath = null;
+    lastRemovePath = null;
     shouldNotFind = false;
     sharedSession.closed = false;
   });
@@ -295,6 +310,34 @@ describe('tenki provider (mocked SDK)', () => {
 
     shouldNotFind = true;
     await expect(provider.sandbox.destroy('gone')).resolves.toBeUndefined();
+  });
+
+  it('maps filesystem paths outside /home/tenki into the workdir and contains .. traversal', async () => {
+    const provider = tenki({ apiKey: 'tk_test' });
+    const sandbox = await provider.sandbox.create();
+
+    await sandbox.filesystem.writeFile('/tmp/bench/file.txt', 'data');
+    expect(lastWritePath).toBe('/home/tenki/tmp/bench/file.txt');
+
+    await sandbox.filesystem.readFile('/tmp/bench/file.txt');
+    expect(lastReadPath).toBe('/home/tenki/tmp/bench/file.txt');
+
+    await sandbox.filesystem.mkdir('/tmp/bench/sub');
+    expect(lastMkdirPath).toBe('/home/tenki/tmp/bench/sub');
+
+    await sandbox.filesystem.readdir('/tmp/bench');
+    expect(lastListPath).toBe('/home/tenki/tmp/bench');
+
+    await sandbox.filesystem.remove('/tmp/bench/file.txt');
+    expect(lastRemovePath).toBe('/home/tenki/tmp/bench/file.txt');
+
+    await sandbox.filesystem.exists('../../../etc/passwd');
+    const testPath = lastExec?.args?.[1]?.match(/^test -e "(.+)"$/)?.[1];
+    expect(testPath).toBe('/home/tenki/etc/passwd');
+
+    await expect(sandbox.filesystem.remove('/')).rejects.toThrow(
+      /Refusing to remove the Tenki workdir/
+    );
   });
 
   it('throws a helpful error when no API key is configured', async () => {

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -233,20 +233,10 @@ function basename(path: string): string {
 // workdir. Map absolute paths outside /home/tenki so they fall under it.
 const TENKI_WORKDIR = "/home/tenki";
 function mapFilesystemPath(path: string): string {
-  if (path === "" || path === "/") return TENKI_WORKDIR;
-  // Treat relative paths as absolute from the workdir root so `..` segments
-  // are normalized against that root and cannot escape into `/etc/passwd`.
-  const normalized = posix.normalize(path.startsWith("/") ? path : `/${path}`);
-  if (
-    normalized === TENKI_WORKDIR ||
-    normalized.startsWith(`${TENKI_WORKDIR}/`)
-  ) {
-    return normalized;
-  }
-  if (normalized.startsWith("/")) {
-    return `${TENKI_WORKDIR}${normalized}`;
-  }
-  return posix.join(TENKI_WORKDIR, normalized);
+  const abs = posix.resolve("/", path);
+  return abs === TENKI_WORKDIR || abs.startsWith(`${TENKI_WORKDIR}/`)
+    ? abs
+    : posix.resolve(TENKI_WORKDIR, `.${abs}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -16,6 +16,7 @@
 
 import { defineProvider, escapeShellArg } from "@computesdk/provider";
 import type { RunCommandOptions, CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry } from "computesdk";
+import { posix } from "node:path";
 import {
   TenkiSandbox,
   Session,
@@ -228,6 +229,26 @@ function basename(path: string): string {
   return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
 }
 
+// Tenki sandboxes restrict data-plane filesystem operations to the guest
+// workdir. Map absolute paths outside /home/tenki so they fall under it.
+const TENKI_WORKDIR = "/home/tenki";
+function mapFilesystemPath(path: string): string {
+  if (path === "" || path === "/") return TENKI_WORKDIR;
+  // Treat relative paths as absolute from the workdir root so `..` segments
+  // are normalized against that root and cannot escape into `/etc/passwd`.
+  const normalized = posix.normalize(path.startsWith("/") ? path : `/${path}`);
+  if (
+    normalized === TENKI_WORKDIR ||
+    normalized.startsWith(`${TENKI_WORKDIR}/`)
+  ) {
+    return normalized;
+  }
+  if (normalized.startsWith("/")) {
+    return `${TENKI_WORKDIR}${normalized}`;
+  }
+  return posix.join(TENKI_WORKDIR, normalized);
+}
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -307,17 +328,17 @@ export const tenki = defineProvider<Session, TenkiConfig>({
       // hazards). The runCommand parameter is intentionally unused.
       filesystem: {
         readFile: async (sandbox, path) => {
-          const bytes = await sandbox.readFile(path);
+          const bytes = await sandbox.readFile(mapFilesystemPath(path));
           return new TextDecoder().decode(bytes);
         },
         writeFile: async (sandbox, path, content) => {
-          await sandbox.writeFile(path, content);
+          await sandbox.writeFile(mapFilesystemPath(path), content);
         },
         mkdir: async (sandbox, path) => {
-          await sandbox.mkdir(path);
+          await sandbox.mkdir(mapFilesystemPath(path));
         },
         readdir: async (sandbox, path): Promise<FileEntry[]> => {
-          const entries = await sandbox.list(path);
+          const entries = await sandbox.list(mapFilesystemPath(path));
           return entries.map((entry) => ({
             name: basename(entry.path),
             type: entry.isDir ? ("directory" as const) : ("file" as const),
@@ -329,11 +350,15 @@ export const tenki = defineProvider<Session, TenkiConfig>({
         // report a just-removed file as present, while `test -e` is always
         // consistent with the guest filesystem.
         exists: async (sandbox, path, runCommand) => {
-          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          const result = await runCommand(sandbox, `test -e "${escapeShellArg(mapFilesystemPath(path))}"`);
           return result.exitCode === 0;
         },
         remove: async (sandbox, path) => {
-          await sandbox.remove(path);
+          const mappedPath = mapFilesystemPath(path);
+          if (mappedPath === TENKI_WORKDIR) {
+            throw new Error("Refusing to remove the Tenki workdir.");
+          }
+          await sandbox.remove(mappedPath);
         },
       },
     },


### PR DESCRIPTION
## Summary

Tenki sandboxes enforce that data-plane filesystem operations must target paths under the guest workdir `/home/tenki`. The `@computesdk/tenki` provider was passing the raw `path` argument from the ComputeSDK filesystem abstraction straight to `sandbox.readFile` / `sandbox.writeFile` / `sandbox.mkdir` / `sandbox.list` / `sandbox.remove`, so a benchmark writing to `/tmp/bench/fs-...` got:

```
[permission_denied] guest_error: path outside workdir: /tmp/bench/fs-... (workdir: /home/tenki)
```

Add `mapFilesystemPath()` so any absolute path outside `/home/tenki` is rewritten under the guest workdir before being handed to Tenki. Paths already inside `/home/tenki` are left unchanged.

```ts
function mapFilesystemPath(path: string): string {
  if (path === "" || path === "/") return "/home/tenki";
  const normalized = posix.normalize(path);
  if (normalized === "/home/tenki" || normalized.startsWith("/home/tenki/")) {
    return normalized;
  }
  if (normalized.startsWith("/")) {
    return `/home/tenki${normalized}`;
  }
  return posix.join("/home/tenki", normalized);
}
```

All `filesystem` methods now call `mapFilesystemPath()` first, including the `exists` shell fallback. `pnpm --filter @computesdk/tenki typecheck`, `lint`, and `test` all pass.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->