### PR TITLE
fix(modal): route filesystem ops through Sandbox.filesystem (V2 sandbox support)

### DIFF
--- a/.changeset/modal-v2-writefile.md
+++ b/.changeset/modal-v2-writefile.md
@@ -2,4 +2,4 @@
 "@computesdk/modal": patch
 ---
 
-Use Sandbox.filesystem readText/writeText for filesystem.readFile/writeFile so they work on V2 (scalable) sandboxes, where the deprecated Sandbox.open is unsupported.
+Route filesystem operations through Modal's Sandbox.filesystem API (readText/writeText/makeDirectory/listFiles/stat/remove) so they work on V2 (scalable) sandboxes, where the deprecated Sandbox.open and shell-backed fallbacks are unreliable.

--- a/.changeset/modal-v2-writefile.md
+++ b/.changeset/modal-v2-writefile.md
@@ -2,4 +2,4 @@
 "@computesdk/modal": patch
 ---
 
-Fall back to a stdin-fed shell write in filesystem.writeFile when Sandbox.open is unsupported (V2 / scalable sandboxes), and stop trimming content in the shell-backed readFile fallback.
+Use Sandbox.filesystem readText/writeText for filesystem.readFile/writeFile so they work on V2 (scalable) sandboxes, where the deprecated Sandbox.open is unsupported.

--- a/.changeset/modal-v2-writefile.md
+++ b/.changeset/modal-v2-writefile.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/modal": patch
+---
+
+Fall back to a stdin-fed shell write in filesystem.writeFile when Sandbox.open is unsupported (V2 / scalable sandboxes), and stop trimming content in the shell-backed readFile fallback.

--- a/packages/modal/src/__tests__/unit.test.ts
+++ b/packages/modal/src/__tests__/unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execCalls: { command: string[]; stdin: string }[] = [];
+let openSupported = true;
+
+class FakeProcess {
+  private buffered = '';
+  stdin = new WritableStream<string>({
+    write: (chunk) => { this.buffered += chunk; },
+    close: () => { this.record.stdin = this.buffered; },
+  });
+  stdout = { readText: async () => '' };
+  stderr = { readText: async () => '' };
+  constructor(private record: { command: string[]; stdin: string }) {}
+  async wait() { return 0; }
+}
+
+class FakeSandbox {
+  sandboxId = 'sb-test';
+  async open() {
+    if (!openSupported) throw new Error('Sandbox.open is not supported for V2 sandboxes');
+    return { write: async () => {}, close: async () => {} };
+  }
+  async exec(command: string[]) {
+    const record = { command, stdin: '' };
+    execCalls.push(record);
+    return new FakeProcess(record);
+  }
+}
+
+vi.mock('modal', () => ({
+  ModalClient: class {
+    apps = { fromName: async () => ({}) };
+    images = { fromRegistry: () => ({ build: async () => ({}) }) };
+    sandboxes = {
+      create: async () => new FakeSandbox(),
+      experimentalCreate: async () => new FakeSandbox(),
+      fromId: async () => new FakeSandbox(),
+    };
+  },
+  Image: class {},
+}));
+
+import { modal } from '../index';
+
+describe('modal filesystem.writeFile', () => {
+  beforeEach(() => { execCalls.length = 0; openSupported = true; });
+
+  it('falls back to a stdin-fed shell write when Sandbox.open is unsupported (V2)', async () => {
+    openSupported = false;
+    const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
+    const sandbox = await provider.sandbox.create();
+
+    await sandbox.filesystem.writeFile('/tmp/bench/file.txt', 'hello world');
+
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].command).toEqual(['sh', '-c', 'cat > "/tmp/bench/file.txt"']);
+    expect(execCalls[0].stdin).toBe('hello world');
+  });
+
+  it('uses Sandbox.open when it is supported', async () => {
+    const provider = modal({ tokenId: 't', tokenSecret: 's' });
+    const sandbox = await provider.sandbox.create();
+
+    await sandbox.filesystem.writeFile('/tmp/file.txt', 'data');
+
+    expect(execCalls).toHaveLength(0);
+  });
+});

--- a/packages/modal/src/__tests__/unit.test.ts
+++ b/packages/modal/src/__tests__/unit.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const files = new Map<string, string>();
 const dirs = new Set<string>();
 let openCalls = 0;
-let readLimit = Infinity;
 const execCalls: string[][] = [];
 
 class FakeSandbox {
@@ -13,7 +12,6 @@ class FakeSandbox {
     readText: async (path: string) => {
       const v = files.get(path);
       if (v === undefined) throw new Error(`SandboxFilesystemNotFoundError: ${path}`);
-      if (v.length > readLimit) throw new FakeFileTooLargeError('too large');
       return v;
     },
     makeDirectory: async (path: string, options?: { createParents?: boolean }) => {
@@ -54,7 +52,6 @@ class FakeSandbox {
 const fsCalls: string[][] = [];
 
 vi.mock('modal', () => ({
-  SandboxFilesystemFileTooLargeError: class extends Error {},
   SandboxFilesystemNotFoundError: class extends Error {},
   ModalClient: class {
     apps = { fromName: async () => ({}) };
@@ -69,13 +66,10 @@ vi.mock('modal', () => ({
 }));
 
 import { modal } from '../index';
-import {
-  SandboxFilesystemFileTooLargeError as FakeFileTooLargeError,
-  SandboxFilesystemNotFoundError as FakeNotFoundError,
-} from 'modal';
+import { SandboxFilesystemNotFoundError as FakeNotFoundError } from 'modal';
 
 describe('modal filesystem read/write', () => {
-  beforeEach(() => { files.clear(); dirs.clear(); openCalls = 0; readLimit = Infinity; execCalls.length = 0; fsCalls.length = 0; });
+  beforeEach(() => { files.clear(); dirs.clear(); openCalls = 0; execCalls.length = 0; fsCalls.length = 0; });
 
   it('uses Sandbox.filesystem (V1 and V2 compatible) instead of the deprecated Sandbox.open', async () => {
     const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
@@ -88,17 +82,6 @@ describe('modal filesystem read/write', () => {
     // Content round-trips untouched (no trimming).
     expect(await sandbox.filesystem.readFile('/tmp/bench/file.txt')).toBe(content);
     expect(openCalls).toBe(0);
-  });
-
-  it('falls back to cat when the file exceeds the filesystem read limit', async () => {
-    const provider = modal({ tokenId: 't', tokenSecret: 's' });
-    const sandbox = await provider.sandbox.create();
-    const content = '  big\n'.repeat(1000);
-    files.set('/big.txt', content);
-    readLimit = 10;
-
-    expect(await sandbox.filesystem.readFile('/big.txt')).toBe(content);
-    expect(execCalls).toEqual([['cat', '/big.txt']]);
   });
 
   it('routes mkdir/readdir/exists/remove through Sandbox.filesystem', async () => {

--- a/packages/modal/src/__tests__/unit.test.ts
+++ b/packages/modal/src/__tests__/unit.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const files = new Map<string, string>();
 let openCalls = 0;
+let readLimit = Infinity;
+const execCalls: string[][] = [];
+
+class FakeFileTooLargeError extends Error {}
 
 class FakeSandbox {
   sandboxId = 'sb-test';
@@ -10,9 +14,19 @@ class FakeSandbox {
     readText: async (path: string) => {
       const v = files.get(path);
       if (v === undefined) throw new Error(`SandboxFilesystemNotFoundError: ${path}`);
+      if (v.length > readLimit) throw new FakeFileTooLargeError('too large');
       return v;
     },
   };
+  async exec(command: string[]) {
+    execCalls.push(command);
+    const content = files.get(command[1]) ?? '';
+    return {
+      stdout: { readText: async () => content },
+      stderr: { readText: async () => '' },
+      wait: async () => 0,
+    };
+  }
   async open() {
     openCalls++;
     throw new Error('Sandbox.open is not supported for V2 sandboxes');
@@ -30,12 +44,13 @@ vi.mock('modal', () => ({
     };
   },
   Image: class {},
+  SandboxFilesystemFileTooLargeError: FakeFileTooLargeError,
 }));
 
 import { modal } from '../index';
 
 describe('modal filesystem read/write', () => {
-  beforeEach(() => { files.clear(); openCalls = 0; });
+  beforeEach(() => { files.clear(); openCalls = 0; readLimit = Infinity; execCalls.length = 0; });
 
   it('uses Sandbox.filesystem (V1 and V2 compatible) instead of the deprecated Sandbox.open', async () => {
     const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
@@ -48,6 +63,17 @@ describe('modal filesystem read/write', () => {
     // Content round-trips untouched (no trimming).
     expect(await sandbox.filesystem.readFile('/tmp/bench/file.txt')).toBe(content);
     expect(openCalls).toBe(0);
+  });
+
+  it('falls back to cat when the file exceeds the filesystem read limit', async () => {
+    const provider = modal({ tokenId: 't', tokenSecret: 's' });
+    const sandbox = await provider.sandbox.create();
+    const content = '  big\n'.repeat(1000);
+    files.set('/big.txt', content);
+    readLimit = 10;
+
+    expect(await sandbox.filesystem.readFile('/big.txt')).toBe(content);
+    expect(execCalls).toEqual([['cat', '/big.txt']]);
   });
 
   it('surfaces a descriptive error when a read fails', async () => {

--- a/packages/modal/src/__tests__/unit.test.ts
+++ b/packages/modal/src/__tests__/unit.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const execCalls: { command: string[]; stdin: string }[] = [];
+interface ExecRecord { command: string[]; mode?: string; chunks: Uint8Array[]; closedStdin: boolean }
+const execCalls: ExecRecord[] = [];
 let openSupported = true;
+let failStdinWrite = false;
 
 class FakeProcess {
-  private buffered = '';
-  stdin = new WritableStream<string>({
-    write: (chunk) => { this.buffered += chunk; },
-    close: () => { this.record.stdin = this.buffered; },
-  });
-  stdout = { readText: async () => '' };
-  stderr = { readText: async () => '' };
-  constructor(private record: { command: string[]; stdin: string }) {}
+  stdin: WritableStream<Uint8Array>;
+  stdout = { readText: async () => '', readBytes: async () => new Uint8Array() };
+  stderr = { readText: async () => '', readBytes: async () => new Uint8Array() };
+  constructor(private record: ExecRecord) {
+    this.stdin = new WritableStream<Uint8Array>({
+      write: (chunk) => {
+        if (failStdinWrite) throw new Error('rpc failed');
+        record.chunks.push(chunk);
+      },
+    });
+  }
+  async closeStdin() { this.record.closedStdin = true; }
   async wait() { return 0; }
 }
 
@@ -21,8 +27,8 @@ class FakeSandbox {
     if (!openSupported) throw new Error('Sandbox.open is not supported for V2 sandboxes');
     return { write: async () => {}, close: async () => {} };
   }
-  async exec(command: string[]) {
-    const record = { command, stdin: '' };
+  async exec(command: string[], params?: { mode?: string }) {
+    const record: ExecRecord = { command, mode: params?.mode, chunks: [], closedStdin: false };
     execCalls.push(record);
     return new FakeProcess(record);
   }
@@ -43,8 +49,10 @@ vi.mock('modal', () => ({
 
 import { modal } from '../index';
 
+const decode = (chunks: Uint8Array[]) => chunks.map((c) => new TextDecoder().decode(c)).join('');
+
 describe('modal filesystem.writeFile', () => {
-  beforeEach(() => { execCalls.length = 0; openSupported = true; });
+  beforeEach(() => { execCalls.length = 0; openSupported = true; failStdinWrite = false; });
 
   it('falls back to a stdin-fed shell write when Sandbox.open is unsupported (V2)', async () => {
     openSupported = false;
@@ -55,7 +63,32 @@ describe('modal filesystem.writeFile', () => {
 
     expect(execCalls).toHaveLength(1);
     expect(execCalls[0].command).toEqual(['sh', '-c', 'cat > "/tmp/bench/file.txt"']);
-    expect(execCalls[0].stdin).toBe('hello world');
+    expect(execCalls[0].mode).toBe('binary');
+    expect(decode(execCalls[0].chunks)).toBe('hello world');
+  });
+
+  it('streams large V2 writes in bounded chunks', async () => {
+    openSupported = false;
+    const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
+    const sandbox = await provider.sandbox.create();
+    const content = 'x'.repeat(9 * 1024 * 1024);
+
+    await sandbox.filesystem.writeFile('/tmp/big.txt', content);
+
+    const { chunks } = execCalls[0];
+    expect(chunks).toHaveLength(3);
+    expect(Math.max(...chunks.map((c) => c.length))).toBe(4 * 1024 * 1024);
+    expect(decode(chunks)).toBe(content);
+  });
+
+  it('closes stdin so cat exits when a V2 stdin write fails', async () => {
+    openSupported = false;
+    failStdinWrite = true;
+    const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
+    const sandbox = await provider.sandbox.create();
+
+    await expect(sandbox.filesystem.writeFile('/tmp/file.txt', 'data')).rejects.toThrow('rpc failed');
+    expect(execCalls[0].closedStdin).toBe(true);
   });
 
   it('uses Sandbox.open when it is supported', async () => {

--- a/packages/modal/src/__tests__/unit.test.ts
+++ b/packages/modal/src/__tests__/unit.test.ts
@@ -1,36 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-interface ExecRecord { command: string[]; mode?: string; chunks: Uint8Array[]; closedStdin: boolean }
-const execCalls: ExecRecord[] = [];
-let openSupported = true;
-let failStdinWrite = false;
-
-class FakeProcess {
-  stdin: WritableStream<Uint8Array>;
-  stdout = { readText: async () => '', readBytes: async () => new Uint8Array() };
-  stderr = { readText: async () => '', readBytes: async () => new Uint8Array() };
-  constructor(private record: ExecRecord) {
-    this.stdin = new WritableStream<Uint8Array>({
-      write: (chunk) => {
-        if (failStdinWrite) throw new Error('rpc failed');
-        record.chunks.push(chunk);
-      },
-    });
-  }
-  async closeStdin() { this.record.closedStdin = true; }
-  async wait() { return 0; }
-}
+const files = new Map<string, string>();
+let openCalls = 0;
 
 class FakeSandbox {
   sandboxId = 'sb-test';
+  filesystem = {
+    writeText: async (data: string, path: string) => { files.set(path, data); },
+    readText: async (path: string) => {
+      const v = files.get(path);
+      if (v === undefined) throw new Error(`SandboxFilesystemNotFoundError: ${path}`);
+      return v;
+    },
+  };
   async open() {
-    if (!openSupported) throw new Error('Sandbox.open is not supported for V2 sandboxes');
-    return { write: async () => {}, close: async () => {} };
-  }
-  async exec(command: string[], params?: { mode?: string }) {
-    const record: ExecRecord = { command, mode: params?.mode, chunks: [], closedStdin: false };
-    execCalls.push(record);
-    return new FakeProcess(record);
+    openCalls++;
+    throw new Error('Sandbox.open is not supported for V2 sandboxes');
   }
 }
 
@@ -49,54 +34,26 @@ vi.mock('modal', () => ({
 
 import { modal } from '../index';
 
-const decode = (chunks: Uint8Array[]) => chunks.map((c) => new TextDecoder().decode(c)).join('');
+describe('modal filesystem read/write', () => {
+  beforeEach(() => { files.clear(); openCalls = 0; });
 
-describe('modal filesystem.writeFile', () => {
-  beforeEach(() => { execCalls.length = 0; openSupported = true; failStdinWrite = false; });
-
-  it('falls back to a stdin-fed shell write when Sandbox.open is unsupported (V2)', async () => {
-    openSupported = false;
+  it('uses Sandbox.filesystem (V1 and V2 compatible) instead of the deprecated Sandbox.open', async () => {
     const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
     const sandbox = await provider.sandbox.create();
 
-    await sandbox.filesystem.writeFile('/tmp/bench/file.txt', 'hello world');
+    const content = '  x'.repeat(50_000) + '\n';
+    await sandbox.filesystem.writeFile('/tmp/bench/file.txt', content);
+    expect(files.get('/tmp/bench/file.txt')).toBe(content);
 
-    expect(execCalls).toHaveLength(1);
-    expect(execCalls[0].command).toEqual(['sh', '-c', 'cat > "/tmp/bench/file.txt"']);
-    expect(execCalls[0].mode).toBe('binary');
-    expect(decode(execCalls[0].chunks)).toBe('hello world');
+    // Content round-trips untouched (no trimming).
+    expect(await sandbox.filesystem.readFile('/tmp/bench/file.txt')).toBe(content);
+    expect(openCalls).toBe(0);
   });
 
-  it('streams large V2 writes in bounded chunks', async () => {
-    openSupported = false;
-    const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
-    const sandbox = await provider.sandbox.create();
-    const content = 'x'.repeat(9 * 1024 * 1024);
-
-    await sandbox.filesystem.writeFile('/tmp/big.txt', content);
-
-    const { chunks } = execCalls[0];
-    expect(chunks).toHaveLength(3);
-    expect(Math.max(...chunks.map((c) => c.length))).toBe(4 * 1024 * 1024);
-    expect(decode(chunks)).toBe(content);
-  });
-
-  it('closes stdin so cat exits when a V2 stdin write fails', async () => {
-    openSupported = false;
-    failStdinWrite = true;
-    const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
-    const sandbox = await provider.sandbox.create();
-
-    await expect(sandbox.filesystem.writeFile('/tmp/file.txt', 'data')).rejects.toThrow('rpc failed');
-    expect(execCalls[0].closedStdin).toBe(true);
-  });
-
-  it('uses Sandbox.open when it is supported', async () => {
+  it('surfaces a descriptive error when a read fails', async () => {
     const provider = modal({ tokenId: 't', tokenSecret: 's' });
     const sandbox = await provider.sandbox.create();
 
-    await sandbox.filesystem.writeFile('/tmp/file.txt', 'data');
-
-    expect(execCalls).toHaveLength(0);
+    await expect(sandbox.filesystem.readFile('/missing.txt')).rejects.toThrow(/Failed to read file \/missing\.txt/);
   });
 });

--- a/packages/modal/src/__tests__/unit.test.ts
+++ b/packages/modal/src/__tests__/unit.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const files = new Map<string, string>();
+const dirs = new Set<string>();
 let openCalls = 0;
 let readLimit = Infinity;
 const execCalls: string[][] = [];
-
-class FakeFileTooLargeError extends Error {}
 
 class FakeSandbox {
   sandboxId = 'sb-test';
@@ -16,6 +15,25 @@ class FakeSandbox {
       if (v === undefined) throw new Error(`SandboxFilesystemNotFoundError: ${path}`);
       if (v.length > readLimit) throw new FakeFileTooLargeError('too large');
       return v;
+    },
+    makeDirectory: async (path: string, options?: { createParents?: boolean }) => {
+      fsCalls.push(['makeDirectory', path, JSON.stringify(options)]);
+      dirs.add(path);
+    },
+    listFiles: async (path: string) => {
+      if (!dirs.has(path)) throw new FakeNotFoundError('missing');
+      return [
+        { name: 'a.txt', path: `${path}/a.txt`, type: 'file', size: 3, mode: 0o644, permissions: '-rw-r--r--', owner: 'root', group: 'root', modifiedTime: 1_700_000_000, symlinkTarget: null },
+        { name: 'sub dir', path: `${path}/sub dir`, type: 'directory', size: 0, mode: 0o755, permissions: 'drwxr-xr-x', owner: 'root', group: 'root', modifiedTime: 1_700_000_001, symlinkTarget: null },
+      ];
+    },
+    stat: async (path: string) => {
+      if (!files.has(path) && !dirs.has(path)) throw new FakeNotFoundError('missing');
+      return {};
+    },
+    remove: async (path: string, options?: { recursive?: boolean }) => {
+      fsCalls.push(['remove', path, JSON.stringify(options)]);
+      if (!files.delete(path) && !dirs.delete(path)) throw new FakeNotFoundError('missing');
     },
   };
   async exec(command: string[]) {
@@ -33,7 +51,11 @@ class FakeSandbox {
   }
 }
 
+const fsCalls: string[][] = [];
+
 vi.mock('modal', () => ({
+  SandboxFilesystemFileTooLargeError: class extends Error {},
+  SandboxFilesystemNotFoundError: class extends Error {},
   ModalClient: class {
     apps = { fromName: async () => ({}) };
     images = { fromRegistry: () => ({ build: async () => ({}) }) };
@@ -44,13 +66,16 @@ vi.mock('modal', () => ({
     };
   },
   Image: class {},
-  SandboxFilesystemFileTooLargeError: FakeFileTooLargeError,
 }));
 
 import { modal } from '../index';
+import {
+  SandboxFilesystemFileTooLargeError as FakeFileTooLargeError,
+  SandboxFilesystemNotFoundError as FakeNotFoundError,
+} from 'modal';
 
 describe('modal filesystem read/write', () => {
-  beforeEach(() => { files.clear(); openCalls = 0; readLimit = Infinity; execCalls.length = 0; });
+  beforeEach(() => { files.clear(); dirs.clear(); openCalls = 0; readLimit = Infinity; execCalls.length = 0; fsCalls.length = 0; });
 
   it('uses Sandbox.filesystem (V1 and V2 compatible) instead of the deprecated Sandbox.open', async () => {
     const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
@@ -74,6 +99,30 @@ describe('modal filesystem read/write', () => {
 
     expect(await sandbox.filesystem.readFile('/big.txt')).toBe(content);
     expect(execCalls).toEqual([['cat', '/big.txt']]);
+  });
+
+  it('routes mkdir/readdir/exists/remove through Sandbox.filesystem', async () => {
+    const provider = modal({ tokenId: 't', tokenSecret: 's', scalableSandboxes: true });
+    const sandbox = await provider.sandbox.create();
+
+    await sandbox.filesystem.mkdir('/tmp/bench/fs-1');
+    expect(fsCalls).toEqual([['makeDirectory', '/tmp/bench/fs-1', '{"createParents":true}']]);
+
+    expect(await sandbox.filesystem.readdir('/tmp/bench/fs-1')).toEqual([
+      { name: 'a.txt', type: 'file', size: 3, modified: new Date(1_700_000_000_000) },
+      { name: 'sub dir', type: 'directory', size: 0, modified: new Date(1_700_000_001_000) },
+    ]);
+
+    expect(await sandbox.filesystem.exists('/tmp/bench/fs-1')).toBe(true);
+    expect(await sandbox.filesystem.exists('/nope')).toBe(false);
+
+    await sandbox.filesystem.remove('/tmp/bench/fs-1');
+    expect(fsCalls[1]).toEqual(['remove', '/tmp/bench/fs-1', '{"recursive":true}']);
+    expect(await sandbox.filesystem.exists('/tmp/bench/fs-1')).toBe(false);
+
+    // Removing a missing path is a no-op, matching `rm -rf`.
+    await expect(sandbox.filesystem.remove('/tmp/bench/fs-1')).resolves.toBeUndefined();
+    expect(execCalls).toEqual([]);
   });
 
   it('surfaces a descriptive error when a read fails', async () => {

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -13,8 +13,6 @@ type ModalNativeSandbox = Sandbox;
 
 
 const DEFAULT_IMAGE = 'node:20';
-// Matches the chunk size the modal SDK uses for its own stdin-backed file writes.
-const STDIN_WRITE_CHUNK_SIZE = 4 * 1024 * 1024;
 const DEFAULT_APP_NAME = 'computesdk-modal';
 const DEFAULT_DAEMON_SSE_PORT = 38989;
 
@@ -216,55 +214,17 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
       filesystem: {
         readFile: async (modalSandbox: ModalSandbox, path: string): Promise<string> => {
           try {
-            const file = await modalSandbox.sandbox.open(path);
-            try {
-              const data = await file.read();
-              const content = new TextDecoder().decode(data);
-              return content;
-            } finally {
-              await file.close();
-            }
+            return await modalSandbox.sandbox.filesystem.readText(path);
           } catch (error) {
-            try {
-              const process = await modalSandbox.sandbox.exec(['cat', path], { stdout: 'pipe', stderr: 'pipe' });
-              const [content, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
-              if (exitCode !== 0) throw new Error(`cat failed: ${stderr}`);
-              return content;
-            } catch {
-              throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
-            }
+            throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
           }
         },
         writeFile: async (modalSandbox: ModalSandbox, path: string, content: string): Promise<void> => {
           try {
-            const file = await modalSandbox.sandbox.open(path, 'w');
-            try {
-              await file.write(new TextEncoder().encode(content));
-            } finally {
-              await file.close();
-            }
-            return;
+            await modalSandbox.sandbox.filesystem.writeText(content, path);
           } catch (error) {
-            // V2 sandboxes do not support Sandbox.open; stream the content via stdin instead.
-            if (!(error instanceof Error) || !error.message.includes('not supported for V2')) throw error;
+            throw new Error(`Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)}`);
           }
-          const process = await modalSandbox.sandbox.exec(['sh', '-c', `cat > "${escapeShellArg(path)}"`], { mode: 'binary', stdout: 'pipe', stderr: 'pipe' });
-          const bytes = new TextEncoder().encode(content);
-          const writer = process.stdin.getWriter();
-          try {
-            for (let offset = 0; offset < bytes.length; offset += STDIN_WRITE_CHUNK_SIZE) {
-              await writer.write(bytes.subarray(offset, offset + STDIN_WRITE_CHUNK_SIZE));
-            }
-            await writer.close();
-          } catch (err) {
-            await writer.abort(err).catch(() => {});
-            await process.closeStdin().catch(() => {});
-            throw err;
-          } finally {
-            writer.releaseLock();
-          }
-          const [, stderr, exitCode] = await Promise.all([process.stdout.readBytes(), process.stderr.readBytes(), process.wait()]);
-          if (exitCode !== 0) throw new Error(`Failed to write file ${path}: ${new TextDecoder().decode(stderr)}`);
         },
         mkdir: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
           const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], { stdout: 'pipe', stderr: 'pipe' });

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -6,7 +6,7 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-import { ModalClient, SandboxFilesystemFileTooLargeError } from 'modal';
+import { ModalClient, SandboxFilesystemFileTooLargeError, SandboxFilesystemNotFoundError } from 'modal';
 import type { Sandbox, App, Image, SandboxCreateParams } from 'modal';
 
 type ModalNativeSandbox = Sandbox;
@@ -233,32 +233,41 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           }
         },
         mkdir: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
-          const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
-          if (exitCode !== 0) throw new Error(`mkdir failed: ${stderr}`);
+          try {
+            await modalSandbox.sandbox.filesystem.makeDirectory(path, { createParents: true });
+          } catch (error) {
+            throw new Error(`mkdir failed: ${error instanceof Error ? error.message : String(error)}`);
+          }
         },
         readdir: async (modalSandbox: ModalSandbox, path: string): Promise<FileEntry[]> => {
-          const process = await modalSandbox.sandbox.exec(['ls', '-la', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [output, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
-          if (exitCode !== 0) throw new Error(`ls failed: ${stderr}`);
-          const lines = output.split('\n').slice(1);
-          return lines.filter((l: string) => l.trim()).map((line: string) => {
-            const parts = line.trim().split(/\s+/);
-            const permissions = parts[0] || '';
-            const size = parseInt(parts[4]) || 0;
-            const dateStr = (parts[5] || '') + ' ' + (parts[6] || '');
-            const date = dateStr.trim() ? new Date(dateStr) : new Date();
-            const name = parts.slice(8).join(' ') || parts[parts.length - 1] || 'unknown';
-            return { name, type: permissions.startsWith('d') ? 'directory' as const : 'file' as const, size, modified: isNaN(date.getTime()) ? new Date() : date };
-          });
+          try {
+            const entries = await modalSandbox.sandbox.filesystem.listFiles(path);
+            return entries.map((entry) => ({
+              name: entry.name,
+              type: entry.type === 'directory' ? 'directory' as const : 'file' as const,
+              size: entry.size,
+              modified: new Date(entry.modifiedTime * 1000),
+            }));
+          } catch (error) {
+            throw new Error(`ls failed: ${error instanceof Error ? error.message : String(error)}`);
+          }
         },
         exists: async (modalSandbox: ModalSandbox, path: string): Promise<boolean> => {
-          try { const process = await modalSandbox.sandbox.exec(['test', '-e', path]); return await process.wait() === 0; } catch { return false; }
+          try {
+            await modalSandbox.sandbox.filesystem.stat(path);
+            return true;
+          } catch (error) {
+            if (error instanceof SandboxFilesystemNotFoundError) return false;
+            throw error;
+          }
         },
         remove: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
-          const process = await modalSandbox.sandbox.exec(['rm', '-rf', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
-          if (exitCode !== 0) throw new Error(`rm failed: ${stderr}`);
+          try {
+            await modalSandbox.sandbox.filesystem.remove(path, { recursive: true });
+          } catch (error) {
+            if (error instanceof SandboxFilesystemNotFoundError) return;
+            throw new Error(`rm failed: ${error instanceof Error ? error.message : String(error)}`);
+          }
         }
       },
 

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -13,6 +13,8 @@ type ModalNativeSandbox = Sandbox;
 
 
 const DEFAULT_IMAGE = 'node:20';
+// Matches the chunk size the modal SDK uses for its own stdin-backed file writes.
+const STDIN_WRITE_CHUNK_SIZE = 4 * 1024 * 1024;
 const DEFAULT_APP_NAME = 'computesdk-modal';
 const DEFAULT_DAEMON_SSE_PORT = 38989;
 
@@ -246,15 +248,23 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
             // V2 sandboxes do not support Sandbox.open; stream the content via stdin instead.
             if (!(error instanceof Error) || !error.message.includes('not supported for V2')) throw error;
           }
-          const process = await modalSandbox.sandbox.exec(['sh', '-c', `cat > "${escapeShellArg(path)}"`], { stdout: 'pipe', stderr: 'pipe' });
+          const process = await modalSandbox.sandbox.exec(['sh', '-c', `cat > "${escapeShellArg(path)}"`], { mode: 'binary', stdout: 'pipe', stderr: 'pipe' });
+          const bytes = new TextEncoder().encode(content);
           const writer = process.stdin.getWriter();
           try {
-            await writer.write(content);
-          } finally {
+            for (let offset = 0; offset < bytes.length; offset += STDIN_WRITE_CHUNK_SIZE) {
+              await writer.write(bytes.subarray(offset, offset + STDIN_WRITE_CHUNK_SIZE));
+            }
             await writer.close();
+          } catch (err) {
+            await writer.abort(err).catch(() => {});
+            await process.closeStdin().catch(() => {});
+            throw err;
+          } finally {
+            writer.releaseLock();
           }
-          const [, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
-          if (exitCode !== 0) throw new Error(`Failed to write file ${path}: ${stderr}`);
+          const [, stderr, exitCode] = await Promise.all([process.stdout.readBytes(), process.stderr.readBytes(), process.wait()]);
+          if (exitCode !== 0) throw new Error(`Failed to write file ${path}: ${new TextDecoder().decode(stderr)}`);
         },
         mkdir: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
           const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], { stdout: 'pipe', stderr: 'pipe' });

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -227,19 +227,34 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
               const process = await modalSandbox.sandbox.exec(['cat', path], { stdout: 'pipe', stderr: 'pipe' });
               const [content, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
               if (exitCode !== 0) throw new Error(`cat failed: ${stderr}`);
-              return content.trim();
+              return content;
             } catch {
               throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
             }
           }
         },
         writeFile: async (modalSandbox: ModalSandbox, path: string, content: string): Promise<void> => {
-          const file = await modalSandbox.sandbox.open(path, 'w');
           try {
-            await file.write(new TextEncoder().encode(content));
-          } finally {
-            await file.close();
+            const file = await modalSandbox.sandbox.open(path, 'w');
+            try {
+              await file.write(new TextEncoder().encode(content));
+            } finally {
+              await file.close();
+            }
+            return;
+          } catch (error) {
+            // V2 sandboxes do not support Sandbox.open; stream the content via stdin instead.
+            if (!(error instanceof Error) || !error.message.includes('not supported for V2')) throw error;
           }
+          const process = await modalSandbox.sandbox.exec(['sh', '-c', `cat > "${escapeShellArg(path)}"`], { stdout: 'pipe', stderr: 'pipe' });
+          const writer = process.stdin.getWriter();
+          try {
+            await writer.write(content);
+          } finally {
+            await writer.close();
+          }
+          const [, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
+          if (exitCode !== 0) throw new Error(`Failed to write file ${path}: ${stderr}`);
         },
         mkdir: async (modalSandbox: ModalSandbox, path: string): Promise<void> => {
           const process = await modalSandbox.sandbox.exec(['mkdir', '-p', path], { stdout: 'pipe', stderr: 'pipe' });

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -6,7 +6,7 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-import { ModalClient, SandboxFilesystemFileTooLargeError, SandboxFilesystemNotFoundError } from 'modal';
+import { ModalClient, SandboxFilesystemNotFoundError } from 'modal';
 import type { Sandbox, App, Image, SandboxCreateParams } from 'modal';
 
 type ModalNativeSandbox = Sandbox;
@@ -216,14 +216,8 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           try {
             return await modalSandbox.sandbox.filesystem.readText(path);
           } catch (error) {
-            if (!(error instanceof SandboxFilesystemFileTooLargeError)) {
-              throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
-            }
+            throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
           }
-          const process = await modalSandbox.sandbox.exec(['cat', path], { stdout: 'pipe', stderr: 'pipe' });
-          const [content, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
-          if (exitCode !== 0) throw new Error(`Failed to read file ${path}: ${stderr}`);
-          return content;
         },
         writeFile: async (modalSandbox: ModalSandbox, path: string, content: string): Promise<void> => {
           try {

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -6,7 +6,7 @@ import { defineProvider, escapeShellArg } from '@computesdk/provider';
 
 import type { CommandResult, SandboxInfo, CreateSandboxOptions, FileEntry, RunCommandOptions } from '@computesdk/provider';
 
-import { ModalClient } from 'modal';
+import { ModalClient, SandboxFilesystemFileTooLargeError } from 'modal';
 import type { Sandbox, App, Image, SandboxCreateParams } from 'modal';
 
 type ModalNativeSandbox = Sandbox;
@@ -216,8 +216,14 @@ const _modal = defineProvider<ModalSandbox, ModalInternalConfig>({
           try {
             return await modalSandbox.sandbox.filesystem.readText(path);
           } catch (error) {
-            throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
+            if (!(error instanceof SandboxFilesystemFileTooLargeError)) {
+              throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
+            }
           }
+          const process = await modalSandbox.sandbox.exec(['cat', path], { stdout: 'pipe', stderr: 'pipe' });
+          const [content, stderr, exitCode] = await Promise.all([process.stdout.readText(), process.stderr.readText(), process.wait()]);
+          if (exitCode !== 0) throw new Error(`Failed to read file ${path}: ${stderr}`);
+          return content;
         },
         writeFile: async (modalSandbox: ModalSandbox, path: string, content: string): Promise<void> => {
           try {


### PR DESCRIPTION
## Summary

Modal sandboxes created with `scalableSandboxes: true` (`client.sandboxes.experimentalCreate`) are V2 sandboxes, and the `modal` SDK throws `Sandbox.open is not supported for V2 sandboxes` for them. `@computesdk/modal`'s `filesystem.writeFile` relied on the (now deprecated) `sandbox.open(path, 'w')` with no fallback, which is what broke the `sandbox-tmp-filesystem` benchmark for Modal.

Per Modal's migration guide (`open`/`ls`/`mkdir`/`rm` don't work on V2; use `Sandbox.filesystem`), all filesystem methods now go through the supported `Sandbox.filesystem` API, which works on both V1 and V2:

| method | before | after |
|---|---|---|
| `readFile` | `open().read()` → `cat` fallback (`.trim()`) | `filesystem.readText` (no trim; per Modal, the read limit is 5 GB so no shell fallback) |
| `writeFile` | `open(path,'w').write()` | `filesystem.writeText` |
| `mkdir` | `exec(mkdir -p)` | `filesystem.makeDirectory(path, { createParents: true })` |
| `readdir` | `exec(ls -la)` + column parsing | `filesystem.listFiles` → `{ name, type, size, modified }` (handles names with spaces, real mtimes) |
| `exists` | `exec(test -e)` | `filesystem.stat`; `false` on `SandboxFilesystemNotFoundError` |
| `remove` | `exec(rm -rf)` | `filesystem.remove(path, { recursive: true })`; missing path is a no-op (matches `rm -rf`) |

`SandboxFilesystem` handles chunking and stdin EOF internally, so no hand-rolled stdin streaming is needed.

Adds `packages/modal/src/__tests__/unit.test.ts` (mocked `modal` module) covering read/write round-trip without `open` and the mkdir/readdir/exists/remove mappings, plus a patch changeset for `@computesdk/modal`.

Verified by the live `modal` provider/computesdk integration CI jobs on this PR.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->