### PR TITLE
fix(cloudflare): map bridge filesystem paths into /workspace

### DIFF
--- a/.changeset/cloudflare-workspace-paths.md
+++ b/.changeset/cloudflare-workspace-paths.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cloudflare": patch
+---
+
+Map bridge-mode filesystem paths outside `/workspace` into the workspace so the bridge Worker's path restriction no longer rejects them.

--- a/packages/cloudflare/src/__tests__/index.test.ts
+++ b/packages/cloudflare/src/__tests__/index.test.ts
@@ -442,6 +442,34 @@ describe('Standardized Test Suite', () => {
     }
   });
 
+  it('relocates bridge filesystem paths outside /workspace into the workspace', async () => {
+    if (skipIntegration) {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(bridgeCreateResponse())
+        .mockResolvedValueOnce(new Response(null, { status: 204 }))
+        .mockResolvedValueOnce(bridgeExecResponse([{ event: 'exit', data: JSON.stringify({ exit_code: 0 }) }]))
+        .mockResolvedValueOnce(new Response('x', { status: 200 }));
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      try {
+        const remoteProvider = cloudflare({ sandboxUrl: 'https://example.com', sandboxApiKey: 'secret' });
+        const created = await remoteProvider.sandbox.create();
+
+        await created.filesystem.writeFile('/tmp/bench/a.txt', 'x');
+        await created.filesystem.mkdir('/tmp/bench/../bench');
+        await created.filesystem.readFile('../../etc/passwd');
+
+        expect(fetchMock.mock.calls[1]?.[0]).toBe(`https://example.com/v1/sandbox/${created.sandboxId}/file/workspace/tmp/bench/a.txt`);
+        const body = JSON.parse(fetchMock.mock.calls[2]?.[1]?.body as string) as { argv: string[] };
+        expect(body.argv[2]).toBe("mkdir -p '/workspace/tmp/bench'");
+        expect(fetchMock.mock.calls[3]?.[0]).toBe(`https://example.com/v1/sandbox/${created.sandboxId}/file/workspace/etc/passwd`);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    }
+  });
+
   it('uses a bridge-compatible cwd for filesystem shell helpers', async () => {
     if (skipIntegration) {
       const fetchMock = vi.fn()

--- a/packages/cloudflare/src/__tests__/index.test.ts
+++ b/packages/cloudflare/src/__tests__/index.test.ts
@@ -464,6 +464,10 @@ describe('Standardized Test Suite', () => {
         const body = JSON.parse(fetchMock.mock.calls[2]?.[1]?.body as string) as { argv: string[] };
         expect(body.argv[2]).toBe("mkdir -p '/workspace/tmp/bench'");
         expect(fetchMock.mock.calls[3]?.[0]).toBe(`https://example.com/v1/sandbox/${created.sandboxId}/file/workspace/etc/passwd`);
+
+        await expect(created.filesystem.remove('/tmp/..')).rejects.toThrow('Refusing to remove /workspace root');
+        await expect(created.filesystem.remove('/workspace')).rejects.toThrow('Refusing to remove /workspace root');
+        expect(fetchMock).toHaveBeenCalledTimes(4);
       } finally {
         vi.unstubAllGlobals();
       }

--- a/packages/cloudflare/src/__tests__/index.test.ts
+++ b/packages/cloudflare/src/__tests__/index.test.ts
@@ -474,6 +474,32 @@ describe('Standardized Test Suite', () => {
     }
   });
 
+  it('rejects bridge readFile when the bridge returns an empty body for a missing file', async () => {
+    if (skipIntegration) {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(bridgeCreateResponse())
+        .mockResolvedValueOnce(new Response('', { status: 200 }))
+        .mockResolvedValueOnce(bridgeExecResponse([{ event: 'exit', data: JSON.stringify({ exit_code: 1 }) }]))
+        .mockResolvedValueOnce(new Response('', { status: 200 }))
+        .mockResolvedValueOnce(bridgeExecResponse([{ event: 'exit', data: JSON.stringify({ exit_code: 0 }) }]));
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      try {
+        const remoteProvider = cloudflare({ sandboxUrl: 'https://example.com', sandboxApiKey: 'secret' });
+        const created = await remoteProvider.sandbox.create();
+
+        await expect(created.filesystem.readFile('/nonexistent/file.txt')).rejects.toThrow('File not found');
+        const body = JSON.parse(fetchMock.mock.calls[2]?.[1]?.body as string) as { argv: string[] };
+        expect(body.argv[2]).toBe("test -f '/workspace/nonexistent/file.txt'");
+
+        await expect(created.filesystem.readFile('/workspace/empty.txt')).resolves.toBe('');
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    }
+  });
+
   it('uses a bridge-compatible cwd for filesystem shell helpers', async () => {
     if (skipIntegration) {
       const fetchMock = vi.fn()

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -214,6 +214,25 @@ async function bridgeJSONRequest(
   return JSON.parse(text);
 }
 
+const BRIDGE_WORKSPACE = '/workspace';
+
+/**
+ * The bridge Worker only accepts file paths inside /workspace. Resolve the
+ * requested path (including `..` segments) against `/` and relocate anything
+ * outside the workspace underneath it.
+ */
+function toWorkspacePath(path: string): string {
+  const segments: string[] = [];
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') { segments.pop(); continue; }
+    segments.push(segment);
+  }
+  const abs = `/${segments.join('/')}`;
+  if (abs === BRIDGE_WORKSPACE || abs.startsWith(`${BRIDGE_WORKSPACE}/`)) return abs;
+  return abs === '/' ? BRIDGE_WORKSPACE : `${BRIDGE_WORKSPACE}${abs}`;
+}
+
 function encodeFilePath(path: string): string {
   return path.replace(/^\/+/, '').split('/').map(encodeURIComponent).join('/');
 }
@@ -538,19 +557,19 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
       filesystem: {
         readFile: async (cfSandbox: CloudflareSandbox, path: string): Promise<string> => {
           if (cfSandbox.remote) {
-            const res = await bridgeRequest(cfSandbox, 'GET', `/v1/sandbox/${encodeURIComponent(cfSandbox.sandboxId)}/file/${encodeFilePath(path)}`);
+            const res = await bridgeRequest(cfSandbox, 'GET', `/v1/sandbox/${encodeURIComponent(cfSandbox.sandboxId)}/file/${encodeFilePath(toWorkspacePath(path))}`);
             return await res.text();
           }
           const file = await cfSandbox.sandbox.readFile(path);
           return file.content || '';
         },
         writeFile: async (cfSandbox: CloudflareSandbox, path: string, content: string): Promise<void> => {
-          if (cfSandbox.remote) { await bridgeRequest(cfSandbox, 'PUT', `/v1/sandbox/${encodeURIComponent(cfSandbox.sandboxId)}/file/${encodeFilePath(path)}`, content, { 'Content-Type': 'text/plain; charset=utf-8' }); return; }
+          if (cfSandbox.remote) { await bridgeRequest(cfSandbox, 'PUT', `/v1/sandbox/${encodeURIComponent(cfSandbox.sandboxId)}/file/${encodeFilePath(toWorkspacePath(path))}`, content, { 'Content-Type': 'text/plain; charset=utf-8' }); return; }
           await cfSandbox.sandbox.writeFile(path, content);
         },
         mkdir: async (cfSandbox: CloudflareSandbox, path: string): Promise<void> => {
           if (cfSandbox.remote) {
-            const result = await bridgeExec(cfSandbox, `mkdir -p ${shellQuote(path)}`, { cwd: '/workspace' });
+            const result = await bridgeExec(cfSandbox, `mkdir -p ${shellQuote(toWorkspacePath(path))}`, { cwd: '/workspace' });
             if (result.exitCode !== 0) throw new Error(`Directory creation failed: ${result.stderr}`);
             return;
           }
@@ -559,7 +578,7 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
         readdir: async (cfSandbox: CloudflareSandbox, path: string): Promise<FileEntry[]> => {
           let result: any;
           if (cfSandbox.remote) {
-            result = await bridgeExec(cfSandbox, `ls -la ${shellQuote(path)}`, { cwd: '/workspace' });
+            result = await bridgeExec(cfSandbox, `ls -la ${shellQuote(toWorkspacePath(path))}`, { cwd: '/workspace' });
           } else {
             result = await cfSandbox.sandbox.exec(`ls -la ${shellQuote(path)}`, { cwd: '/' });
           }
@@ -568,7 +587,7 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
         },
         exists: async (cfSandbox: CloudflareSandbox, path: string): Promise<boolean> => {
           if (cfSandbox.remote) {
-            const result = await bridgeExec(cfSandbox, `test -e ${shellQuote(path)}`, { cwd: '/workspace' });
+            const result = await bridgeExec(cfSandbox, `test -e ${shellQuote(toWorkspacePath(path))}`, { cwd: '/workspace' });
             return result.exitCode === 0;
           }
           const result = await cfSandbox.sandbox.exists(path);
@@ -576,7 +595,7 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
         },
         remove: async (cfSandbox: CloudflareSandbox, path: string): Promise<void> => {
           if (cfSandbox.remote) {
-            const result = await bridgeExec(cfSandbox, `rm -rf ${shellQuote(path)}`, { cwd: '/workspace' });
+            const result = await bridgeExec(cfSandbox, `rm -rf ${shellQuote(toWorkspacePath(path))}`, { cwd: '/workspace' });
             if (result.exitCode !== 0) throw new Error(`File removal failed: ${result.stderr}`);
             return;
           }

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -557,8 +557,14 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
       filesystem: {
         readFile: async (cfSandbox: CloudflareSandbox, path: string): Promise<string> => {
           if (cfSandbox.remote) {
-            const res = await bridgeRequest(cfSandbox, 'GET', `/v1/sandbox/${encodeURIComponent(cfSandbox.sandboxId)}/file/${encodeFilePath(toWorkspacePath(path))}`);
-            return await res.text();
+            const target = toWorkspacePath(path);
+            const res = await bridgeRequest(cfSandbox, 'GET', `/v1/sandbox/${encodeURIComponent(cfSandbox.sandboxId)}/file/${encodeFilePath(target)}`);
+            const content = await res.text();
+            if (content === '') {
+              const check = await bridgeExec(cfSandbox, `test -f ${shellQuote(target)}`, { cwd: '/workspace' });
+              if (check.exitCode !== 0) throw new Error(`File not found: ${path}`);
+            }
+            return content;
           }
           const file = await cfSandbox.sandbox.readFile(path);
           return file.content || '';

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -595,7 +595,9 @@ export const cloudflare = defineProvider<CloudflareSandbox, CloudflareConfig>({
         },
         remove: async (cfSandbox: CloudflareSandbox, path: string): Promise<void> => {
           if (cfSandbox.remote) {
-            const result = await bridgeExec(cfSandbox, `rm -rf ${shellQuote(toWorkspacePath(path))}`, { cwd: '/workspace' });
+            const target = toWorkspacePath(path);
+            if (target === BRIDGE_WORKSPACE) throw new Error(`Refusing to remove ${BRIDGE_WORKSPACE} root`);
+            const result = await bridgeExec(cfSandbox, `rm -rf ${shellQuote(target)}`, { cwd: '/workspace' });
             if (result.exitCode !== 0) throw new Error(`File removal failed: ${result.stderr}`);
             return;
           }


### PR DESCRIPTION
## Summary

The official Cloudflare Sandbox bridge Worker rejects `/file/<path>` requests whose path resolves outside `/workspace` (`403 {"error":"path must resolve to a location within /workspace"}`), so any `writeFile`/`readFile` to e.g. `/tmp/bench/...` fails in remote mode. `mkdir`/`exists`/`remove`/`readdir` go through `exec` and were unaffected, which made the failure surface only at the first write.

Remote-mode filesystem methods now run paths through `toWorkspacePath` before use:

```ts
toWorkspacePath('/workspace/a')     // '/workspace/a'   (unchanged)
toWorkspacePath('/tmp/bench/a.txt') // '/workspace/tmp/bench/a.txt'
toWorkspacePath('../../etc/passwd') // '/workspace/etc/passwd'  (`..` resolved against `/` first)
toWorkspacePath('/')                // '/workspace'
```

Direct mode (`@cloudflare/sandbox` binding) is untouched. Implemented without `node:path` since this package also targets the Workers runtime.

Patch changeset for `@computesdk/cloudflare`.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->