### PR TITLE
Add Cocoon Stack provider

### DIFF
--- a/.changeset/add-cocoonstack.md
+++ b/.changeset/add-cocoonstack.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cocoonstack": patch
+---
+
+Add Cocoon Stack provider

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Install provider packages and pass instances into `compute.setConfig`:
 | **Blaxel** | `BL_API_KEY`, `BL_WORKSPACE` | Agent sandboxes with custom images |
 | **Cloud Run** | `CLOUD_RUN_SANDBOX_URL`, `CLOUD_RUN_SANDBOX_SECRET` | Google Cloud Run sandboxes |
 | **Cloudflare** | `CLOUDFLARE_SANDBOX_URL`, `CLOUDFLARE_SANDBOX_API_KEY` | Edge computing |
+| **Cocoon Stack** | `COCOONSTACK_API_URL`, `COCOONSTACK_API_KEY` | Self-hosted microVM sandboxes from warm pools |
 | **CodeSandbox** | `CSB_API_KEY` | Collaborative development |
 | **CreateOS** | `CREATEOS_SANDBOX_API_KEY`, `CREATEOS_SANDBOX_BASE_URL` | VM sandboxes with pause/resume/fork snapshots |
 | **Daytona** | `DAYTONA_API_KEY` | Development workspaces |
@@ -295,6 +296,7 @@ npm install @computesdk/blaxel           # Blaxel provider
 npm install @computesdk/buddy            # Buddy provider
 npm install @computesdk/cloud-run        # Google Cloud Run provider
 npm install @computesdk/cloudflare       # Cloudflare provider
+npm install @computesdk/cocoonstack      # Cocoon Stack provider
 npm install @computesdk/codesandbox      # CodeSandbox provider
 npm install @computesdk/createos-sandbox # CreateOS VM sandbox provider
 npm install @computesdk/daytona          # Daytona provider
@@ -336,6 +338,7 @@ See individual provider READMEs for details:
 - **[@computesdk/buddy](./packages/buddy)** - Ubuntu sandboxes from a pre-warmed pool, with tunnels and snapshots
 - **[@computesdk/cloud-run](./packages/cloud-run)** - Google Cloud Run sandboxes
 - **[@computesdk/cloudflare](./packages/cloudflare)** - Edge computing sandboxes
+- **[@computesdk/cocoonstack](./packages/cocoonstack)** - Self-hosted microVM sandboxes served from warm pools by sandboxd
 - **[@computesdk/codesandbox](./packages/codesandbox)** - Collaborative development
 - **[@computesdk/createos-sandbox](./packages/createos-sandbox)** - NodeOps VM sandboxes, with pause/resume/fork snapshots and a native-handle escape hatch
 - **[@computesdk/daytona](./packages/daytona)** - Development workspaces

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
   * [Buddy](providers/buddy.md)
   * [Cloud Run](providers/cloud-run.md)
   * [Cloudflare](providers/cloudflare.md)
+  * [Cocoon Stack](providers/cocoonstack.md)
   * [CodeSandbox](providers/codesandbox.md)
   * [Collimate](providers/collimate.md)
   * [CreateOS](providers/createos-sandbox.md)

--- a/docs/providers/cocoonstack.md
+++ b/docs/providers/cocoonstack.md
@@ -111,6 +111,7 @@ A claim is served from the node's warm pool for `(template, net, size)`; a reque
 
 ## Limitations
 
-- sandboxd scopes a sandbox to the token minted at claim time, so `destroy` and `runCommand` on a sandbox obtained through `getById` or `list` work only for sandboxes this process created.
+- sandboxd scopes a sandbox to the token minted at claim time, so `getById` and `list` return only the sandboxes this process claimed; `destroy` by id also works with a node token.
+- A command without an explicit `timeout` is bounded by `requestTimeoutMs` (120 s by default); tokens travel as bearer headers, so use an `https://` endpoint outside a private network.
 - A clustered node may redirect a claim to a peer; the provider refuses the redirect. Point `baseUrl` at a node that serves the pool.
 - Snapshots and templates are managed through sandboxd's own API and are not exposed here.

--- a/docs/providers/cocoonstack.md
+++ b/docs/providers/cocoonstack.md
@@ -92,6 +92,8 @@ interface CocoonstackConfig {
   ttlSeconds?: number;
   /** HTTP request timeout in milliseconds (default 120000) */
   requestTimeoutMs?: number;
+  /** Open the HTTP/2 session at construction; TLS endpoints only (default false) */
+  preconnect?: boolean;
 }
 ```
 

--- a/docs/providers/cocoonstack.md
+++ b/docs/providers/cocoonstack.md
@@ -1,0 +1,116 @@
+---
+description: >-
+  Cocoon Stack provider for ComputeSDK - self-hosted microVM sandboxes served
+  from warm pools by sandboxd, with command execution, filesystem access, and
+  preview URLs.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+  actions:
+    visible: true
+---
+
+# Cocoon Stack
+
+[Cocoon Stack](https://github.com/cocoonstack/sandbox) provider for ComputeSDK - self-hosted microVM sandboxes served from warm pools by sandboxd, the sandbox control plane of the Cocoon Stack.
+
+## Installation & Setup
+
+```bash
+npm install @computesdk/cocoonstack
+```
+
+Add your sandboxd endpoint and API token to a `.env` file:
+
+```bash
+COCOONSTACK_API_URL=https://sandbox.example.com
+COCOONSTACK_API_KEY=your_api_token
+```
+
+The endpoint is a sandboxd node you run yourself; see the [deployment guide](https://github.com/cocoonstack/sandbox/blob/main/docs/deploy.md) for pools, tenants, and TLS.
+
+## Usage
+
+```typescript
+import { cocoonstack } from '@computesdk/cocoonstack';
+
+const compute = cocoonstack({
+  baseUrl: process.env.COCOONSTACK_API_URL,
+  apiKey: process.env.COCOONSTACK_API_KEY,
+});
+
+// Create sandbox (uses the default template from config)
+const sandbox = await compute.sandbox.create();
+
+// Or pick a template and a size at create time
+const sandbox2 = await compute.sandbox.create({
+  templateId: 'python-rt:3.12',
+  vcpus: 4,
+  memoryMb: 4096,
+});
+
+// Run a command
+const result = await sandbox.runCommand('node -v');
+console.log(result.stdout);
+
+// Work with files
+await sandbox.filesystem.writeFile('/tmp/hello.py', 'print("Hello World")');
+const content = await sandbox.filesystem.readFile('/tmp/hello.py');
+
+// Clean up
+await sandbox.destroy();
+```
+
+### Configuration Options
+
+```typescript
+interface CocoonstackConfig {
+  /** sandboxd endpoint - if not provided, will use COCOONSTACK_API_URL env var */
+  baseUrl?: string;
+  /** Node or tenant API token - if not provided, will use COCOONSTACK_API_KEY env var */
+  apiKey?: string;
+  /** Default template, a pool key such as node-rt:24.04 (the default) */
+  template?: string;
+  /** Default network lane: 'none' (default) or 'egress' */
+  net?: 'none' | 'egress';
+  /** Default size tier: small (default), medium, large, xlarge, 2xlarge */
+  size?: 'small' | 'medium' | 'large' | 'xlarge' | '2xlarge';
+  /** Default claim lease in seconds (default 300) */
+  ttlSeconds?: number;
+  /** HTTP request timeout in milliseconds (default 120000) */
+  requestTimeoutMs?: number;
+}
+```
+
+### Size tiers
+
+`size` picks a tier by name. Without it, `vcpus`/`cpus`/`cpu` and `memoryMb`/`memoryMiB`/`memMiB`/`memory` map to the smallest tier that covers the request.
+
+| size | CPU | memory |
+|---|---|---|
+| `small` | 1 | 512 MB |
+| `medium` | 2 | 1 GB |
+| `large` | 4 | 4 GB |
+| `xlarge` | 4 | 8 GB |
+| `2xlarge` | 8 | 16 GB |
+
+A claim is served from the node's warm pool for `(template, net, size)`; a request outside the configured pools cold-boots the template. `timeout` on create becomes the claim lease in seconds, capped at 24 hours.
+
+## Limitations
+
+- sandboxd scopes a sandbox to the token minted at claim time, so `destroy` and `runCommand` on a sandbox obtained through `getById` or `list` work only for sandboxes this process created.
+- A clustered node may redirect a claim to a peer; the provider refuses the redirect. Point `baseUrl` at a node that serves the pool.
+- Snapshots and templates are managed through sandboxd's own API and are not exposed here.

--- a/packages/cocoonstack/README.md
+++ b/packages/cocoonstack/README.md
@@ -95,6 +95,8 @@ A claim is served from the node's warm pool for `(template, net, size)`; a reque
 
 ## Limitations
 
-- sandboxd scopes a sandbox to the token minted at claim time. `destroy` and `runCommand` on a sandbox obtained through `getById` or `list` work only for sandboxes this process created; other sandboxes need the node API token.
+- sandboxd scopes a sandbox to the token minted at claim time, so `getById` and `list` return only the sandboxes this process claimed (the node's own index is visible through the sandboxd API). `destroy` by id also works with a node token.
+- A command without an explicit `timeout` is bounded by `requestTimeoutMs` (120 s by default); pass `timeout` for longer builds.
+- Tokens travel as bearer headers: use an `https://` endpoint outside a private network.
 - A node in a cluster may answer a claim with a redirect to a peer; this provider refuses it. Point `baseUrl` at a node that serves the pool.
 - Snapshots and templates are managed through sandboxd's own API (checkpoints, promote) and are not exposed here.

--- a/packages/cocoonstack/README.md
+++ b/packages/cocoonstack/README.md
@@ -1,0 +1,100 @@
+# @computesdk/cocoonstack
+
+Cocoon Stack provider for ComputeSDK - self-hosted microVM sandboxes served from warm pools by [sandboxd](https://github.com/cocoonstack/sandbox), the sandbox control plane of the Cocoon Stack.
+
+## Installation
+
+```bash
+npm install @computesdk/cocoonstack
+```
+
+## Setup
+
+1. Run a sandboxd node (see the [deployment guide](https://github.com/cocoonstack/sandbox/blob/main/docs/deploy.md)) with a pool for the template you want to claim, and put it behind TLS.
+2. Set the endpoint and a node or tenant API token:
+
+```bash
+export COCOONSTACK_API_URL=https://sandbox.example.com
+export COCOONSTACK_API_KEY=your_api_token
+```
+
+## Quick Start
+
+```typescript
+import { compute } from 'computesdk';
+import { cocoonstack } from '@computesdk/cocoonstack';
+
+compute.setConfig({
+  provider: cocoonstack({
+    baseUrl: process.env.COCOONSTACK_API_URL,
+    apiKey: process.env.COCOONSTACK_API_KEY,
+  }),
+});
+
+const sandbox = await compute.sandbox.create();
+
+const result = await sandbox.runCommand('node -v');
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+Or call the provider factory directly:
+
+```typescript
+import { cocoonstack } from '@computesdk/cocoonstack';
+
+const sdk = cocoonstack({ baseUrl: process.env.COCOONSTACK_API_URL, apiKey: process.env.COCOONSTACK_API_KEY });
+const sandbox = await sdk.sandbox.create({ templateId: 'python-rt:3.12', vcpus: 4, memoryMb: 4096 });
+```
+
+## Configuration
+
+```typescript
+interface CocoonstackConfig {
+  /** sandboxd endpoint - if not provided, will use COCOONSTACK_API_URL env var */
+  baseUrl?: string;
+  /** Node or tenant API token - if not provided, will use COCOONSTACK_API_KEY env var */
+  apiKey?: string;
+  /** Default template, a pool key such as node-rt:24.04 (the default) */
+  template?: string;
+  /** Default network lane: 'none' (default) or 'egress' */
+  net?: 'none' | 'egress';
+  /** Default size tier: small (default), medium, large, xlarge, 2xlarge */
+  size?: 'small' | 'medium' | 'large' | 'xlarge' | '2xlarge';
+  /** Default claim lease in seconds (default 300); the node reaps the sandbox after it */
+  ttlSeconds?: number;
+  /** HTTP request timeout in milliseconds (default 120000) */
+  requestTimeoutMs?: number;
+}
+```
+
+### Create options
+
+- `templateId` (or `image`) picks the template, e.g. `node-rt:24.04`, `python-rt:3.12`, `rt:24.04`.
+- `size` picks a tier by name. Without it, `vcpus`/`cpus`/`cpu` and `memoryMb`/`memoryMiB`/`memMiB`/`memory` map to the smallest tier that covers the request:
+
+| size | CPU | memory |
+|---|---|---|
+| `small` | 1 | 512 MB |
+| `medium` | 2 | 1 GB |
+| `large` | 4 | 4 GB |
+| `xlarge` | 4 | 8 GB |
+| `2xlarge` | 8 | 16 GB |
+
+- `timeout` (milliseconds) becomes the claim lease, capped at 24 hours.
+
+A claim is served from the node's warm pool for `(template, net, size)`; a request outside the configured pools cold-boots the template, which takes longer.
+
+## Features
+
+- ✅ **Command Execution** - commands run as root through `bash -c` over the sandboxd agent relay, with native `cwd`, `env`, streaming `onStdout`/`onStderr`, `background`, and `timeout`
+- ✅ **Filesystem Operations** - shell-backed `readFile`, `writeFile`, `mkdir`, `readdir`, `exists`, `remove`
+- ✅ **Preview URLs** - `getUrl` mints a signed preview URL when the node has a preview listener
+- ✅ **Listing** - `list` and `getById` read the node's sandbox index
+
+## Limitations
+
+- sandboxd scopes a sandbox to the token minted at claim time. `destroy` and `runCommand` on a sandbox obtained through `getById` or `list` work only for sandboxes this process created; other sandboxes need the node API token.
+- A node in a cluster may answer a claim with a redirect to a peer; this provider refuses it. Point `baseUrl` at a node that serves the pool.
+- Snapshots and templates are managed through sandboxd's own API (checkpoints, promote) and are not exposed here.

--- a/packages/cocoonstack/README.md
+++ b/packages/cocoonstack/README.md
@@ -66,6 +66,8 @@ interface CocoonstackConfig {
   ttlSeconds?: number;
   /** HTTP request timeout in milliseconds (default 120000) */
   requestTimeoutMs?: number;
+  /** Open the HTTP/2 session at construction; TLS endpoints only (default false) */
+  preconnect?: boolean;
 }
 ```
 
@@ -97,6 +99,6 @@ A claim is served from the node's warm pool for `(template, net, size)`; a reque
 
 - sandboxd scopes a sandbox to the token minted at claim time, so `getById` and `list` return only the sandboxes this process claimed (the node's own index is visible through the sandboxd API). `destroy` by id also works with a node token.
 - A command without an explicit `timeout` is bounded by `requestTimeoutMs` (120 s by default); pass `timeout` for longer builds.
-- Tokens travel as bearer headers: use an `https://` endpoint outside a private network. With an `https://` endpoint the provider opens its HTTP/2 session when the factory runs, or already at import when `COCOONSTACK_API_URL` is set, so the first sandbox call skips DNS and the TLS handshake.
+- Tokens travel as bearer headers: use an `https://` endpoint outside a private network. Nothing connects until the first call; `preconnect: true` opens the HTTP/2 session when the factory runs instead, so the first sandbox call skips DNS and the TLS handshake.
 - A node in a cluster may answer a claim with a redirect to a peer; this provider refuses it. Point `baseUrl` at a node that serves the pool.
 - Snapshots and templates are managed through sandboxd's own API (checkpoints, promote) and are not exposed here.

--- a/packages/cocoonstack/README.md
+++ b/packages/cocoonstack/README.md
@@ -97,6 +97,6 @@ A claim is served from the node's warm pool for `(template, net, size)`; a reque
 
 - sandboxd scopes a sandbox to the token minted at claim time, so `getById` and `list` return only the sandboxes this process claimed (the node's own index is visible through the sandboxd API). `destroy` by id also works with a node token.
 - A command without an explicit `timeout` is bounded by `requestTimeoutMs` (120 s by default); pass `timeout` for longer builds.
-- Tokens travel as bearer headers: use an `https://` endpoint outside a private network.
+- Tokens travel as bearer headers: use an `https://` endpoint outside a private network. With an `https://` endpoint the provider opens its HTTP/2 session when the factory runs, or already at import when `COCOONSTACK_API_URL` is set, so the first sandbox call skips DNS and the TLS handshake.
 - A node in a cluster may answer a claim with a redirect to a peer; this provider refuses it. Point `baseUrl` at a node that serves the pool.
 - Snapshots and templates are managed through sandboxd's own API (checkpoints, promote) and are not exposed here.

--- a/packages/cocoonstack/package.json
+++ b/packages/cocoonstack/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@computesdk/cocoonstack",
+  "version": "1.0.0",
+  "description": "Cocoon Stack provider for ComputeSDK - self-hosted microVM sandboxes served from warm pools by sandboxd",
+  "author": "CMGS",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint"
+  },
+  "keywords": [
+    "computesdk",
+    "cocoonstack",
+    "cocoon",
+    "sandbox",
+    "microvm",
+    "cloud-hypervisor",
+    "self-hosted",
+    "code-execution",
+    "compute",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/computesdk.git",
+    "directory": "packages/cocoonstack"
+  },
+  "homepage": "https://github.com/cocoonstack/sandbox",
+  "bugs": {
+    "url": "https://github.com/computesdk/computesdk/issues"
+  },
+  "dependencies": {
+    "@computesdk/provider": "workspace:*",
+    "computesdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@computesdk/test-utils": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -432,7 +432,8 @@ describe('Cocoon Stack ComputeSDK provider', () => {
     expect(h2.connects).toEqual([]);
 
     cocoonstack({ baseUrl: 'https://127.0.0.1:1', apiKey: 'x', preconnect: true });
-    expect(h2.connects).toEqual(['https://127.0.0.1:1']);
+    cocoonstack({ baseUrl: 'HTTPS://127.0.0.1:2/', apiKey: 'x', preconnect: true });
+    expect(h2.connects).toEqual(['https://127.0.0.1:1', 'https://127.0.0.1:2']);
   });
 
   it('refuses a claim the node redirected to a peer', async () => {

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -173,9 +173,10 @@ async function fakeSandboxd(): Promise<Fake> {
         socket.write(frame({ type: 'stdout', data: b64('two\n') }) + frame({ type: 'exit', code: 0 }));
         return;
       }
-      if (command === 'truncated') {
-        socket.write(frame({ type: 'stdout', data: Buffer.from('é', 'utf8').subarray(0, 1).toString('base64') }));
-        socket.write(frame({ type: 'stderr', data: Buffer.from('ü', 'utf8').subarray(0, 1).toString('base64') }));
+      if (command === 'truncated' || command === 'truncated-err-first') {
+        const outFrame = frame({ type: 'stdout', data: Buffer.from('é', 'utf8').subarray(0, 1).toString('base64') });
+        const errFrame = frame({ type: 'stderr', data: Buffer.from('ü', 'utf8').subarray(0, 1).toString('base64') });
+        socket.write(command === 'truncated' ? outFrame + errFrame : errFrame + outFrame);
         socket.write(frame({ type: 'exit', code: 0 }));
         return;
       }
@@ -238,6 +239,8 @@ describe('Cocoon Stack ComputeSDK provider', () => {
   });
 
   const config = () => ({ baseUrl: fake.url, apiKey: 'node-token' });
+  const execCommands = () =>
+    fake.calls.filter((call) => call.path.endsWith('/exec')).map((call) => (call.body?.argv as string[])[2]);
 
   it('claims, runs node -v as one buffered exec, and releases with the claim token', async () => {
     const sdk = compute({ provider: cocoonstack(config()) });
@@ -485,6 +488,32 @@ describe('Cocoon Stack ComputeSDK provider', () => {
       { name: 'plain.txt', type: 'file', size: 6, modified: new Date(1757000000500) },
       { name: 'sub', type: 'directory', size: 4096, modified: new Date(1757000001000) },
       { name: 'odd\nname.txt', type: 'file', size: 0, modified: new Date(1757000002000) },
+    ]);
+  });
+
+  it('replays the bytes flushed at exit in the order their streams arrived', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    const order: string[] = [];
+    await sandbox.runCommand('truncated-err-first', {
+      onStdout: () => order.push('stdout'),
+      onStderr: () => order.push('stderr'),
+    });
+
+    expect(order).toEqual(['stderr', 'stdout']);
+  });
+
+  it('anchors a relative path so a leading dash or paren is not read as an option', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    await sandbox.filesystem.mkdir('-dash');
+    await sandbox.filesystem.remove('(');
+    await sandbox.filesystem.writeFile('bar.txt', 'x');
+    await sandbox.filesystem.readFile('/tmp/abs.txt');
+
+    expect(execCommands()).toEqual([
+      'mkdir -p "./-dash"',
+      'rm -rf "./("',
+      'mkdir -p "./." && printf %s "eA==" | base64 -d > "./bar.txt"',
+      'cat "/tmp/abs.txt"',
     ]);
   });
 

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -1,7 +1,18 @@
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import type { Duplex } from 'node:stream';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h2 = vi.hoisted(() => ({ connects: [] as string[] }));
+vi.mock('node:http2', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:http2') & { default?: typeof import('node:http2') }>();
+  const real = actual.connect as (...args: Parameters<typeof actual.connect>) => ReturnType<typeof actual.connect>;
+  const connect = ((...args: Parameters<typeof actual.connect>) => {
+    h2.connects.push(String(args[0]));
+    return real(...args);
+  }) as typeof actual.connect;
+  return { ...actual, connect, default: { ...(actual.default ?? actual), connect } };
+});
 import { compute } from 'computesdk';
 import { runProviderTestSuite } from '@computesdk/test-utils';
 import { cocoonstack, CocoonstackApiError } from '../index.js';
@@ -103,6 +114,9 @@ async function fakeSandboxd(): Promise<Fake> {
       if (result.error) return respond(res, 502, { error: result.error });
       if ((body?.argv as string[])[2] === 'huge') {
         return respond(res, 200, { exit_code: 0, stdout: 'x'.repeat(17 << 20), stderr: '' });
+      }
+      if ((body?.argv as string[])[2] === 'huge-utf8') {
+        return respond(res, 200, { exit_code: 0, stdout: '\u20ac'.repeat(6 << 20), stderr: '' });
       }
       return respond(res, 200, { exit_code: result.exit ?? 0, stdout: result.stdout ?? '', stderr: result.stderr ?? '' });
     }
@@ -408,6 +422,17 @@ describe('Cocoon Stack ComputeSDK provider', () => {
     const sandbox = await cocoonstack(config()).sandbox.create();
 
     await expect(sandbox.runCommand('huge')).rejects.toThrow(/exceeds 16 MiB/);
+    await expect(sandbox.runCommand('huge-utf8')).rejects.toThrow(/exceeds 16 MiB/);
+  });
+
+  it('opens no connection at construction unless preconnect is set', () => {
+    h2.connects.length = 0;
+    cocoonstack({ baseUrl: 'https://127.0.0.1:1', apiKey: 'x' });
+    cocoonstack({ baseUrl: 'https://', apiKey: 'x', preconnect: true });
+    expect(h2.connects).toEqual([]);
+
+    cocoonstack({ baseUrl: 'https://127.0.0.1:1', apiKey: 'x', preconnect: true });
+    expect(h2.connects).toEqual(['https://127.0.0.1:1']);
   });
 
   it('refuses a claim the node redirected to a peer', async () => {

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -1,0 +1,418 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Duplex } from 'node:stream';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { compute } from 'computesdk';
+import { runProviderTestSuite } from '@computesdk/test-utils';
+import { cocoonstack, CocoonstackApiError } from '../index.js';
+
+interface Call {
+  method: string;
+  path: string;
+  auth?: string;
+  body?: Record<string, unknown>;
+}
+
+interface Rpc {
+  auth?: string;
+  request: Record<string, unknown>;
+}
+
+interface Fake {
+  url: string;
+  calls: Call[];
+  rpcs: Rpc[];
+  close: () => Promise<void>;
+}
+
+interface Outcome {
+  stdout?: string;
+  stderr?: string;
+  exit?: number;
+  error?: string;
+  hang?: boolean;
+}
+
+const TOKEN = 'tok_1';
+
+function frame(value: Record<string, unknown>): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+function b64(text: string): string {
+  return Buffer.from(text, 'utf8').toString('base64');
+}
+
+function outcome(request: Record<string, unknown>): Outcome {
+  const argv = request.argv as string[];
+  const command = argv[2] ?? '';
+  if (command === 'node -v') return { stdout: 'v22.23.2\n', exit: 0 };
+  if (command === 'exit 3') return { stderr: 'boom\n', exit: 3 };
+  if (command === 'fail') return { error: 'internal: spawn failed' };
+  if (command === 'hang') return { hang: true };
+  return { stdout: JSON.stringify({ command, cwd: request.cwd, env: request.env }), exit: 0 };
+}
+
+function respond(res: http.ServerResponse, status: number, body?: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(body === undefined ? undefined : JSON.stringify(body));
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((fulfill) => {
+    let text = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk: string) => {
+      text += chunk;
+    });
+    req.on('end', () => fulfill(text));
+  });
+}
+
+async function fakeSandboxd(): Promise<Fake> {
+  const calls: Call[] = [];
+  const rpcs: Rpc[] = [];
+  const relays = new Set<Duplex>();
+  const server = http.createServer(async (req, res) => {
+    const text = await readBody(req);
+    const body = text ? (JSON.parse(text) as Record<string, unknown>) : undefined;
+    const path = req.url ?? '';
+    calls.push({ method: req.method ?? '', path, auth: req.headers.authorization, body });
+    if (req.method === 'POST' && path === '/v1/claim') {
+      if (body?.template === 'elsewhere:24.04') return respond(res, 200, { redirect: ['10.0.0.6:7777'] });
+      if (body?.template === 'missing:24.04') return respond(res, 404, { error: 'unknown template' });
+      const ttl = Number(body?.ttl_seconds ?? 300);
+      const stale = body?.template === 'stale:24.04';
+      return respond(res, 200, {
+        id: stale ? 'sb_2' : 'sb_1',
+        token: stale ? 'tok_2' : TOKEN,
+        deadline: new Date(Date.now() + ttl * 1000).toISOString(),
+        owner_addr: '10.0.0.5:7777',
+      });
+    }
+    if (req.method === 'POST' && path === '/v1/sandboxes/sb_1/exec') {
+      if (req.headers.authorization !== `Bearer ${TOKEN}`) return respond(res, 404, { error: 'unknown sandbox' });
+      rpcs.push({ auth: req.headers.authorization, request: { op: 'exec', ...body } });
+      const result = outcome(body ?? {});
+      if (result.hang) {
+        setTimeout(() => respond(res, 504, { error: 'command timed out' }), Number(body?.timeout_seconds ?? 1) * 1000);
+        return;
+      }
+      if (result.error) return respond(res, 502, { error: result.error });
+      return respond(res, 200, { exit_code: result.exit ?? 0, stdout: result.stdout ?? '', stderr: result.stderr ?? '' });
+    }
+    if (req.method === 'POST' && path.endsWith('/exec')) return respond(res, 404, { error: 'unknown sandbox' });
+    if (req.method === 'POST' && path === '/v1/sandboxes/sb_1/release') {
+      return respond(res, req.headers.authorization === `Bearer ${TOKEN}` ? 204 : 404, undefined);
+    }
+    if (req.method === 'POST' && path.endsWith('/release')) return respond(res, 404, { error: 'unknown sandbox' });
+    if (req.method === 'GET' && path === '/v1/sandboxes') {
+      return respond(res, 200, {
+        sandboxes: [
+          { id: 'sb_1', key: { template: 'node-rt:24.04', net: 'none', size: 'small' }, deadline: '2026-01-01T00:05:00Z', hibernated: false },
+        ],
+      });
+    }
+    if (req.method === 'POST' && path === '/v1/sandboxes/sb_1/preview') {
+      return respond(res, 200, { url: `http://preview.test/p/${String(body?.port)}/` });
+    }
+    respond(res, 404, { error: 'no route' });
+  });
+  server.on('upgrade', (req, socket, head) => {
+    if (req.url !== '/v1/sandboxes/sb_1/agent' || req.headers.authorization !== `Bearer ${TOKEN}`) {
+      socket.end('HTTP/1.1 404 Not Found\r\ncontent-type: application/json\r\ncontent-length: 27\r\n\r\n{"error":"unknown sandbox"}');
+      return;
+    }
+    relays.add(socket);
+    socket.on('close', () => relays.delete(socket));
+    socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: silkd\r\nConnection: Upgrade\r\n\r\n');
+    let pending = head.toString('utf8');
+    const onLine = (line: string) => {
+      const request = JSON.parse(line) as Record<string, unknown>;
+      rpcs.push({ auth: req.headers.authorization, request });
+      if (request.detach) {
+        socket.write(frame({ type: 'started', pid: 42 }));
+        return;
+      }
+      socket.write(frame({ type: 'started', pid: 7 }));
+      const command = (request.argv as string[])[2] ?? '';
+      if (command === 'stream') {
+        socket.write(frame({ type: 'stdout', data: b64('one\n') }));
+        socket.write(frame({ type: 'stderr', data: b64('warn\n') }));
+        socket.write(frame({ type: 'stdout', data: b64('two\n') }) + frame({ type: 'exit', code: 0 }));
+        return;
+      }
+      if (command === 'split') {
+        const bytes = Buffer.from('é', 'utf8');
+        socket.write(frame({ type: 'stdout', data: bytes.subarray(0, 1).toString('base64') }));
+        socket.write(frame({ type: 'stdout', data: bytes.subarray(1).toString('base64') }));
+        socket.write(frame({ type: 'exit', code: 0 }));
+        return;
+      }
+      const result = outcome(request);
+      if (result.hang) return;
+      if (result.error) {
+        socket.write(frame({ type: 'error', kind: 'internal', message: 'spawn failed' }));
+        return;
+      }
+      if (result.stdout) socket.write(frame({ type: 'stdout', data: b64(result.stdout) }));
+      if (result.stderr) socket.write(frame({ type: 'stderr', data: b64(result.stderr) }));
+      socket.write(frame({ type: 'exit', code: result.exit ?? 0 }));
+    };
+    socket.on('data', (chunk: Buffer) => {
+      pending += chunk.toString('utf8');
+      let newline = pending.indexOf('\n');
+      while (newline >= 0) {
+        onLine(pending.slice(0, newline));
+        pending = pending.slice(newline + 1);
+        newline = pending.indexOf('\n');
+      }
+    });
+    socket.on('error', () => undefined);
+  });
+  await new Promise<void>((fulfill) => server.listen(0, '127.0.0.1', fulfill));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    calls,
+    rpcs,
+    close: () => {
+      for (const relay of relays) relay.destroy();
+      server.closeAllConnections();
+      return new Promise((fulfill) => server.close(() => fulfill()));
+    },
+  };
+}
+
+describe('Cocoon Stack ComputeSDK provider', () => {
+  let fake: Fake;
+
+  beforeAll(async () => {
+    fake = await fakeSandboxd();
+  });
+
+  afterAll(async () => {
+    await fake.close();
+  });
+
+  beforeEach(() => {
+    fake.calls.length = 0;
+    fake.rpcs.length = 0;
+  });
+
+  const config = () => ({ baseUrl: fake.url, apiKey: 'node-token' });
+
+  it('claims, runs node -v as one buffered exec, and releases with the claim token', async () => {
+    const sdk = compute({ provider: cocoonstack(config()) });
+    const sandbox = await sdk.sandbox.create();
+    const result = await sandbox.runCommand('node -v');
+    await sandbox.destroy();
+
+    expect(result.stdout).toBe('v22.23.2\n');
+    expect(result.exitCode).toBe(0);
+    expect(fake.calls.map((call) => [call.method, call.path, call.auth])).toEqual([
+      ['POST', '/v1/claim', 'Bearer node-token'],
+      ['POST', '/v1/sandboxes/sb_1/exec', `Bearer ${TOKEN}`],
+      ['POST', '/v1/sandboxes/sb_1/release', `Bearer ${TOKEN}`],
+    ]);
+    expect(fake.calls[0].body).toEqual({ template: 'node-rt:24.04', net: 'none', size: 'small', ttl_seconds: 300 });
+    expect(fake.calls[1].body).toEqual({ argv: ['bash', '-c', 'node -v'] });
+  });
+
+  it('maps resource requests to the smallest covering size tier', async () => {
+    const provider = cocoonstack(config());
+    await provider.sandbox.create({ vcpus: 8, memoryMb: 16384 });
+    await provider.sandbox.create({ size: 'medium' });
+    await provider.sandbox.create({ cpus: 2 });
+    await provider.sandbox.create({ memoryMiB: 6000 });
+    await provider.sandbox.create({ cpu: 1, memory: 512 });
+
+    expect(fake.calls.map((call) => call.body?.size)).toEqual(['2xlarge', 'medium', 'medium', 'xlarge', 'small']);
+    await expect(provider.sandbox.create({ vcpus: 16 })).rejects.toThrow(/largest is 2xlarge/);
+    await expect(provider.sandbox.create({ size: 'huge' })).rejects.toThrow(/Unknown Cocoon Stack size/);
+  });
+
+  it('turns the create timeout into the claim lease', async () => {
+    const provider = cocoonstack(config());
+    await provider.sandbox.create({ timeout: 600_000 });
+    await provider.sandbox.create({ timeout: 1_500 });
+    await provider.sandbox.create({ timeout: 10 * 86_400_000 });
+    await cocoonstack({ ...config(), ttlSeconds: 900 }).sandbox.create();
+
+    expect(fake.calls.map((call) => call.body?.ttl_seconds)).toEqual([600, 2, 86_400, 900]);
+  });
+
+  it('boots the template the caller names, else the configured default', async () => {
+    await cocoonstack(config()).sandbox.create({ templateId: 'python-rt:3.12' });
+    await cocoonstack(config()).sandbox.create({ image: 'base:24.04' });
+    await cocoonstack({ ...config(), template: 'rt:24.04', net: 'egress', size: 'large' }).sandbox.create();
+
+    expect(fake.calls.map((call) => [call.body?.template, call.body?.net, call.body?.size])).toEqual([
+      ['python-rt:3.12', 'none', 'small'],
+      ['base:24.04', 'none', 'small'],
+      ['rt:24.04', 'egress', 'large'],
+    ]);
+  });
+
+  it('answers getInfo from the claim without another request', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create({ timeout: 600_000 });
+    const info = await sandbox.getInfo();
+
+    expect(fake.calls).toHaveLength(1);
+    expect(info.id).toBe('sb_1');
+    expect(info.provider).toBe('cocoonstack');
+    expect(info.status).toBe('running');
+    expect(info.createdAt).toBeInstanceOf(Date);
+    expect(info.timeout).toBeGreaterThan(590_000);
+    expect(info.metadata).toMatchObject({ template: 'node-rt:24.04', net: 'none', size: 'small' });
+  });
+
+  it('forwards cwd, env and the timeout to the exec endpoint', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    const result = await sandbox.runCommand('pwd', { cwd: '/work', env: { FOO: 'bar' }, timeout: 2_500 });
+
+    expect(JSON.parse(result.stdout)).toEqual({ command: 'pwd', cwd: '/work', env: { FOO: 'bar' } });
+    expect(fake.calls[1].body).toEqual({ argv: ['bash', '-c', 'pwd'], cwd: '/work', env: { FOO: 'bar' }, timeout_seconds: 3 });
+  });
+
+  it('reports a failing command through exitCode and stderr', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    const result = await sandbox.runCommand('exit 3');
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toBe('boom\n');
+  });
+
+  it('streams output chunks over the relay in order', async () => {
+    const seen: string[] = [];
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    const result = await sandbox.runCommand('stream', {
+      onStdout: (data) => seen.push(`out:${data}`),
+      onStderr: (data) => seen.push(`err:${data}`),
+    });
+
+    expect(seen).toEqual(['out:one\n', 'err:warn\n', 'out:two\n']);
+    expect(result.stdout).toBe('one\ntwo\n');
+    expect(result.stderr).toBe('warn\n');
+    expect(fake.rpcs[0].request).toEqual({ v: 1, op: 'exec', argv: ['bash', '-c', 'stream'] });
+  });
+
+  it('reassembles a multi-byte character split across relay frames', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    const result = await sandbox.runCommand('split', { onStdout: () => undefined });
+
+    expect(result.stdout).toBe('é');
+  });
+
+  it('starts a background command detached and returns its pid', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    const result = await sandbox.runCommand('sleep 60', { background: true });
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: '42', stderr: '' });
+    expect(fake.rpcs[0].request).toMatchObject({ detach: true });
+  });
+
+  it('times out a buffered command that never exits', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    await expect(sandbox.runCommand('hang', { timeout: 1_000 })).rejects.toThrow(/timed out after 1000 ms/);
+  });
+
+  it('times out a streamed command that never exits', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    await expect(sandbox.runCommand('hang', { timeout: 100, onStdout: () => undefined })).rejects.toThrow(
+      /timed out after 100 ms/,
+    );
+  });
+
+  it('surfaces a guest-side exec failure with its status', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    await expect(sandbox.runCommand('fail')).rejects.toSatisfy(
+      (error: unknown) => error instanceof CocoonstackApiError && error.status === 502 && /spawn failed/.test(error.message),
+    );
+  });
+
+  it('surfaces a silkd error frame on the relay', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    await expect(sandbox.runCommand('fail', { onStderr: () => undefined })).rejects.toThrow(/silkd internal: spawn failed/);
+  });
+
+  it('surfaces a refused exec with its status', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create({ templateId: 'stale:24.04' });
+
+    await expect(sandbox.runCommand('node -v')).rejects.toSatisfy(
+      (error: unknown) => error instanceof CocoonstackApiError && error.status === 404,
+    );
+  });
+
+  it('treats a release of an already-gone sandbox as done', async () => {
+    const provider = cocoonstack(config());
+
+    await expect(provider.sandbox.destroy('sb_gone')).resolves.toBeUndefined();
+    expect(fake.calls[0].auth).toBe('Bearer node-token');
+  });
+
+  it('finds a live sandbox through the tenant index', async () => {
+    const provider = cocoonstack(config());
+    const found = await provider.sandbox.getById('sb_1');
+    const missing = await provider.sandbox.getById('sb_2');
+    const listed = await provider.sandbox.list();
+
+    expect(found?.sandboxId).toBe('sb_1');
+    expect(missing).toBeNull();
+    expect(listed.map((entry) => entry.sandboxId)).toEqual(['sb_1']);
+  });
+
+  it('refuses a claim the node redirected to a peer', async () => {
+    await expect(cocoonstack(config()).sandbox.create({ templateId: 'elsewhere:24.04' })).rejects.toThrow(
+      /redirected the claim to 10.0.0.6:7777/,
+    );
+  });
+
+  it('keeps the node error in a failed claim', async () => {
+    await expect(cocoonstack(config()).sandbox.create({ templateId: 'missing:24.04' })).rejects.toThrow(
+      /failed \(404\): unknown template/,
+    );
+  });
+
+  it('mints a preview URL for a port', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    expect(await sandbox.getUrl({ port: 3000 })).toBe('http://preview.test/p/3000/');
+    expect(fake.calls[1].body).toEqual({ token: TOKEN, port: 3000, ttl_seconds: 0 });
+  });
+
+  it('drives the filesystem verbs through the shell', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    await sandbox.filesystem.writeFile('/tmp/dir/a.txt', 'hello');
+    await sandbox.filesystem.readFile('/tmp/dir/a.txt');
+    await sandbox.filesystem.exists('/tmp/dir/a.txt');
+    await sandbox.filesystem.remove('/tmp/dir');
+
+    const commands = fake.rpcs.map((rpc) => (rpc.request.argv as string[])[2]);
+    expect(commands[0]).toBe(`mkdir -p "/tmp/dir" && printf %s "${Buffer.from('hello').toString('base64')}" | base64 -d > "/tmp/dir/a.txt"`);
+    expect(commands[1]).toBe('cat "/tmp/dir/a.txt"');
+    expect(commands[2]).toBe('test -e "/tmp/dir/a.txt"');
+    expect(commands[3]).toBe('rm -rf "/tmp/dir"');
+  });
+
+  it('names the missing endpoint', async () => {
+    const previous = process.env.COCOONSTACK_API_URL;
+    delete process.env.COCOONSTACK_API_URL;
+    try {
+      await expect(cocoonstack({}).sandbox.list()).rejects.toThrow(/COCOONSTACK_API_URL/);
+    } finally {
+      if (previous !== undefined) process.env.COCOONSTACK_API_URL = previous;
+    }
+  });
+});
+
+runProviderTestSuite({
+  name: 'cocoonstack',
+  provider: cocoonstack({ baseUrl: process.env.COCOONSTACK_API_URL ?? 'http://127.0.0.1:1' }),
+  supportsFilesystem: true,
+  skipIntegration: !process.env.COCOONSTACK_API_URL,
+});

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -34,6 +34,7 @@ interface Outcome {
 }
 
 const TOKEN = 'tok_1';
+let flakyReleases = 0;
 
 function frame(value: Record<string, unknown>): string {
   return `${JSON.stringify(value)}\n`;
@@ -83,9 +84,10 @@ async function fakeSandboxd(): Promise<Fake> {
       if (body?.template === 'missing:24.04') return respond(res, 404, { error: 'unknown template' });
       const ttl = Number(body?.ttl_seconds ?? 300);
       const stale = body?.template === 'stale:24.04';
+      const flaky = body?.template === 'flaky:24.04';
       return respond(res, 200, {
-        id: stale ? 'sb_2' : 'sb_1',
-        token: stale ? 'tok_2' : TOKEN,
+        id: flaky ? 'sb_flaky' : stale ? 'sb_2' : 'sb_1',
+        token: flaky ? 'tok_flaky' : stale ? 'tok_2' : TOKEN,
         deadline: new Date(Date.now() + ttl * 1000).toISOString(),
         owner_addr: '10.0.0.5:7777',
       });
@@ -99,17 +101,26 @@ async function fakeSandboxd(): Promise<Fake> {
         return;
       }
       if (result.error) return respond(res, 502, { error: result.error });
+      if ((body?.argv as string[])[2] === 'huge') {
+        return respond(res, 200, { exit_code: 0, stdout: 'x'.repeat(17 << 20), stderr: '' });
+      }
       return respond(res, 200, { exit_code: result.exit ?? 0, stdout: result.stdout ?? '', stderr: result.stderr ?? '' });
     }
     if (req.method === 'POST' && path.endsWith('/exec')) return respond(res, 404, { error: 'unknown sandbox' });
     if (req.method === 'POST' && path === '/v1/sandboxes/sb_1/release') {
       return respond(res, req.headers.authorization === `Bearer ${TOKEN}` ? 204 : 404, undefined);
     }
+    if (req.method === 'POST' && path === '/v1/sandboxes/sb_flaky/release') {
+      flakyReleases += 1;
+      if (flakyReleases === 1) return respond(res, 503, { error: 'node busy' });
+      return respond(res, req.headers.authorization === 'Bearer tok_flaky' ? 204 : 404, undefined);
+    }
     if (req.method === 'POST' && path.endsWith('/release')) return respond(res, 404, { error: 'unknown sandbox' });
     if (req.method === 'GET' && path === '/v1/sandboxes') {
       return respond(res, 200, {
         sandboxes: [
           { id: 'sb_1', key: { template: 'node-rt:24.04', net: 'none', size: 'small' }, deadline: '2026-01-01T00:05:00Z', hibernated: false },
+          { id: 'sb_9', key: { template: 'node-rt:24.04', net: 'none', size: 'small' }, deadline: '2026-01-01T00:05:00Z', hibernated: false },
         ],
       });
     }
@@ -355,15 +366,48 @@ describe('Cocoon Stack ComputeSDK provider', () => {
     expect(fake.calls[0].auth).toBe('Bearer node-token');
   });
 
-  it('finds a live sandbox through the tenant index', async () => {
+  it('finds only the sandboxes this process claimed', async () => {
     const provider = cocoonstack(config());
+    await provider.sandbox.create();
     const found = await provider.sandbox.getById('sb_1');
-    const missing = await provider.sandbox.getById('sb_2');
+    const foreign = await provider.sandbox.getById('sb_9');
     const listed = await provider.sandbox.list();
 
     expect(found?.sandboxId).toBe('sb_1');
-    expect(missing).toBeNull();
+    expect(foreign).toBeNull();
     expect(listed.map((entry) => entry.sandboxId)).toEqual(['sb_1']);
+    expect(fake.calls.filter((call) => call.path === '/v1/sandboxes')).toHaveLength(2);
+  });
+
+  it('forgets a claim once its lease has passed', async () => {
+    const provider = cocoonstack(config());
+    await provider.sandbox.create({ timeout: 1_000 });
+    await new Promise((fulfill) => setTimeout(fulfill, 1_100));
+
+    expect(await provider.sandbox.getById('sb_1')).toBeNull();
+  });
+
+  it('keeps the claim token when a release fails', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create({ templateId: 'flaky:24.04' });
+
+    await expect(sandbox.destroy()).rejects.toSatisfy((error: unknown) => error instanceof CocoonstackApiError && error.status === 503);
+    await expect(sandbox.destroy()).resolves.toBeUndefined();
+    expect(fake.calls.filter((call) => call.path === '/v1/sandboxes/sb_flaky/release').map((call) => call.auth)).toEqual([
+      'Bearer tok_flaky',
+      'Bearer tok_flaky',
+    ]);
+  });
+
+  it('bounds a streamed command by the request timeout when none is given', async () => {
+    const sandbox = await cocoonstack({ ...config(), requestTimeoutMs: 200 }).sandbox.create();
+
+    await expect(sandbox.runCommand('hang', { onStdout: () => undefined })).rejects.toThrow(/timed out after 200 ms/);
+  });
+
+  it('refuses a response larger than 16 MiB', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    await expect(sandbox.runCommand('huge')).rejects.toThrow(/exceeds 16 MiB/);
   });
 
   it('refuses a claim the node redirected to a peer', async () => {

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -167,6 +167,12 @@ async function fakeSandboxd(): Promise<Fake> {
         socket.write(frame({ type: 'stdout', data: b64('two\n') }) + frame({ type: 'exit', code: 0 }));
         return;
       }
+      if (command === 'truncated') {
+        socket.write(frame({ type: 'stdout', data: Buffer.from('é', 'utf8').subarray(0, 1).toString('base64') }));
+        socket.write(frame({ type: 'stderr', data: Buffer.from('ü', 'utf8').subarray(0, 1).toString('base64') }));
+        socket.write(frame({ type: 'exit', code: 0 }));
+        return;
+      }
       if (command === 'split') {
         const bytes = Buffer.from('é', 'utf8');
         socket.write(frame({ type: 'stdout', data: bytes.subarray(0, 1).toString('base64') }));
@@ -327,6 +333,24 @@ describe('Cocoon Stack ComputeSDK provider', () => {
     const result = await sandbox.runCommand('split', { onStdout: () => undefined });
 
     expect(result.stdout).toBe('é');
+  });
+
+  it('streams the bytes flushed at exit to the callbacks too', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+    let streamedOut = '';
+    let streamedErr = '';
+    const result = await sandbox.runCommand('truncated', {
+      onStdout: (text) => {
+        streamedOut += text;
+      },
+      onStderr: (text) => {
+        streamedErr += text;
+      },
+    });
+
+    expect(streamedOut).toBe(result.stdout);
+    expect(streamedErr).toBe(result.stderr);
+    expect(result.stdout).toBe('\ufffd');
   });
 
   it('starts a background command detached and returns its pid', async () => {

--- a/packages/cocoonstack/src/__tests__/index.test.ts
+++ b/packages/cocoonstack/src/__tests__/index.test.ts
@@ -62,6 +62,12 @@ function outcome(request: Record<string, unknown>): Outcome {
   if (command === 'exit 3') return { stderr: 'boom\n', exit: 3 };
   if (command === 'fail') return { error: 'internal: spawn failed' };
   if (command === 'hang') return { hang: true };
+  if (command.startsWith('find "/list"')) {
+    return {
+      stdout: 'f\t6\t1757000000.5\tplain.txt\0d\t4096\t1757000001\tsub\0f\t0\t1757000002\todd\nname.txt\0',
+      exit: 0,
+    };
+  }
   return { stdout: JSON.stringify({ command, cwd: request.cwd, env: request.env }), exit: 0 };
 }
 
@@ -470,6 +476,16 @@ describe('Cocoon Stack ComputeSDK provider', () => {
     await expect(cocoonstack(config()).sandbox.create({ templateId: 'missing:24.04' })).rejects.toThrow(
       /failed \(404\): unknown template/,
     );
+  });
+
+  it('lists a directory, keeping a name that holds a newline', async () => {
+    const sandbox = await cocoonstack(config()).sandbox.create();
+
+    expect(await sandbox.filesystem.readdir('/list')).toEqual([
+      { name: 'plain.txt', type: 'file', size: 6, modified: new Date(1757000000500) },
+      { name: 'sub', type: 'directory', size: 4096, modified: new Date(1757000001000) },
+      { name: 'odd\nname.txt', type: 'file', size: 0, modified: new Date(1757000002000) },
+    ]);
   });
 
   it('mints a preview URL for a port', async () => {

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -46,6 +46,8 @@ export interface CocoonstackConfig {
   ttlSeconds?: number;
   /** HTTP request timeout. */
   requestTimeoutMs?: number;
+  /** Open the HTTP/2 session at construction so the first call skips DNS and the TLS handshake; TLS endpoints only. */
+  preconnect?: boolean;
 }
 
 export interface CocoonstackSandbox {
@@ -190,6 +192,7 @@ function session(origin: string, lane: Lane): http2.ClientHttp2Session {
   const live = sessions.get(key);
   if (live && !live.closed && !live.destroyed) return live;
   const created = http2.connect(origin, { secureContext });
+  applyHold(created);
   const drop = () => {
     if (sessions.get(key) === created) sessions.delete(key);
   };
@@ -233,7 +236,8 @@ function h2Request(
     const release = holdSession(live);
     const stream = live.request({ ':method': method, ':path': path, ...headers });
     let status = 0;
-    let text = '';
+    let bytes = 0;
+    const chunks: Buffer[] = [];
     const abort = () => stream.close(http2.constants.NGHTTP2_CANCEL);
     signal?.addEventListener('abort', abort, { once: true });
     let released = false;
@@ -243,7 +247,6 @@ function h2Request(
       signal?.removeEventListener('abort', abort);
       release();
     };
-    stream.setEncoding('utf8');
     stream.setTimeout(timeoutMs, () => {
       stream.close(http2.constants.NGHTTP2_CANCEL);
       reject(new Error('sandboxd request timed out'));
@@ -251,16 +254,18 @@ function h2Request(
     stream.on('response', (responseHeaders) => {
       status = Number(responseHeaders[':status'] ?? 0);
     });
-    stream.on('data', (chunk: string) => {
-      text += chunk;
-      if (text.length > MAX_RESPONSE_BYTES) {
+    stream.on('data', (chunk: Buffer) => {
+      bytes += chunk.length;
+      if (bytes > MAX_RESPONSE_BYTES) {
         stream.close(http2.constants.NGHTTP2_CANCEL);
         reject(new Error(`sandboxd response exceeds ${MAX_RESPONSE_BYTES >> 20} MiB`));
+        return;
       }
+      chunks.push(chunk);
     });
     stream.on('end', () => {
       done();
-      fulfill({ status, text });
+      fulfill({ status, text: Buffer.concat(chunks).toString('utf8') });
     });
     stream.on('error', (error: Error) => {
       done();
@@ -294,16 +299,18 @@ function h1Request(
         },
       },
       (response) => {
-        let text = '';
-        response.setEncoding('utf8');
-        response.on('data', (chunk: string) => {
-          text += chunk;
-          if (text.length > MAX_RESPONSE_BYTES) {
+        let bytes = 0;
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk: Buffer) => {
+          bytes += chunk.length;
+          if (bytes > MAX_RESPONSE_BYTES) {
             client.destroy(new Error(`sandboxd response exceeds ${MAX_RESPONSE_BYTES >> 20} MiB`));
+            return;
           }
+          chunks.push(chunk);
         });
         response.on('error', reject);
-        response.on('end', () => fulfill({ status: response.statusCode ?? 0, text }));
+        response.on('end', () => fulfill({ status: response.statusCode ?? 0, text: Buffer.concat(chunks).toString('utf8') }));
       },
     );
     client.on('timeout', () => client.destroy(new Error('sandboxd request timed out')));
@@ -723,17 +730,22 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
   },
 });
 
-/** Cocoon Stack provider; on a TLS endpoint the first call finds the HTTP/2 session already open. */
+/** Cocoon Stack provider; `preconnect` opens the HTTP/2 session at construction instead of on the first call. */
 export const cocoonstack: typeof provider = (config) => {
-  preopen(config.baseUrl || env('COCOONSTACK_API_URL') || '');
+  if (config.preconnect) preconnect(config.baseUrl || env('COCOONSTACK_API_URL') || '');
   return provider(config);
 };
 
 export default cocoonstack;
 
-// the first call then skips DNS and the TLS handshake; an idle session never holds the process open
-function preopen(baseUrl: string): void {
-  if (baseUrl.startsWith('https://')) session(new URL(baseUrl).origin, 'main');
+// a malformed endpoint is reported by the first call, not by the warm-up
+function preconnect(baseUrl: string): void {
+  if (!baseUrl.startsWith('https://')) return;
+  let origin: string;
+  try {
+    origin = new URL(baseUrl).origin;
+  } catch {
+    return;
+  }
+  session(origin, 'main');
 }
-
-preopen(env('COCOONSTACK_API_URL') || '');

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -725,9 +725,15 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
 
 /** Cocoon Stack provider; on a TLS endpoint the first call finds the HTTP/2 session already open. */
 export const cocoonstack: typeof provider = (config) => {
-  const baseUrl = config.baseUrl || env('COCOONSTACK_API_URL') || '';
-  if (baseUrl.startsWith('https://')) session(new URL(baseUrl).origin, 'main');
+  preopen(config.baseUrl || env('COCOONSTACK_API_URL') || '');
   return provider(config);
 };
 
 export default cocoonstack;
+
+// the first call then skips DNS and the TLS handshake; an idle session never holds the process open
+function preopen(baseUrl: string): void {
+  if (baseUrl.startsWith('https://')) session(new URL(baseUrl).origin, 'main');
+}
+
+preopen(env('COCOONSTACK_API_URL') || '');

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -700,28 +700,27 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
         },
 
         readdir: async (sandbox, path, runCommand): Promise<FileEntry[]> => {
+          // NUL-separated records: a name may hold spaces or newlines, which a line-based listing loses
           const listing = await shell(
             runCommand,
             sandbox,
-            `ls -Ap --time-style=+%s -l "${escapeShellArg(path)}"`,
+            `find "${escapeShellArg(path)}" -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\0'`,
             `Failed to list ${path}`,
           );
-          return listing
-            .split('\n')
-            .slice(1)
-            .flatMap((line) => {
-              const parts = line.trim().split(/\s+/);
-              if (parts.length < 7) return [];
-              const name = parts.slice(6).join(' ');
-              return [
-                {
-                  name: name.replace(/\/$/, ''),
-                  type: name.endsWith('/') ? ('directory' as const) : ('file' as const),
-                  size: Number.parseInt(parts[4], 10) || 0,
-                  modified: new Date(Number.parseInt(parts[5], 10) * 1000),
-                },
-              ];
-            });
+          return listing.split('\0').flatMap((record) => {
+            if (!record) return [];
+            const [kind, size, modified, ...rest] = record.split('\t');
+            const name = rest.join('\t');
+            if (!name) return [];
+            return [
+              {
+                name,
+                type: kind === 'd' ? ('directory' as const) : ('file' as const),
+                size: Number.parseInt(size, 10) || 0,
+                modified: new Date(Number.parseFloat(modified) * 1000),
+              },
+            ];
+          });
         },
 
         exists: async (sandbox, path, runCommand): Promise<boolean> => {

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -466,12 +466,21 @@ function relay(
             if (text) options.onStderr?.(text);
             break;
           }
-          case 'exit':
-            stdout += out.end();
-            stderr += err.end();
+          case 'exit': {
+            const tailOut = out.end();
+            const tailErr = err.end();
+            if (tailOut) {
+              stdout += tailOut;
+              options.onStdout?.(tailOut);
+            }
+            if (tailErr) {
+              stderr += tailErr;
+              options.onStderr?.(tailErr);
+            }
             finish(() => fulfill({ exitCode: frame.code ?? 0, stdout, stderr }));
             socket.destroy();
             break;
+          }
           case 'error':
             finish(() => reject(new Error(`silkd ${frame.kind ?? 'error'}: ${frame.message ?? ''}`)));
             socket.destroy();

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -1,0 +1,689 @@
+import http from 'node:http';
+import http2 from 'node:http2';
+import https from 'node:https';
+import { performance } from 'node:perf_hooks';
+import { StringDecoder } from 'node:string_decoder';
+import tls from 'node:tls';
+import { defineProvider, escapeShellArg } from '@computesdk/provider';
+import type {
+  CommandResult,
+  CreateSandboxOptions,
+  FileEntry,
+  RunCommandOptions,
+  SandboxInfo,
+} from '@computesdk/provider';
+
+const PROVIDER = 'cocoonstack' as const;
+const DEFAULT_TEMPLATE = 'node-rt:24.04';
+const DEFAULT_TTL_SECONDS = 300;
+const MAX_TTL_SECONDS = 86_400;
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+const COMMAND_HTTP_TIMEOUT_BUFFER_MS = 5_000;
+const SIZES = [
+  { size: 'small', cpu: 1, memoryMb: 512 },
+  { size: 'medium', cpu: 2, memoryMb: 1024 },
+  { size: 'large', cpu: 4, memoryMb: 4096 },
+  { size: 'xlarge', cpu: 4, memoryMb: 8192 },
+  { size: '2xlarge', cpu: 8, memoryMb: 16384 },
+] as const;
+
+export type CocoonstackSize = (typeof SIZES)[number]['size'];
+export type CocoonstackNet = 'none' | 'egress';
+
+export interface CocoonstackConfig {
+  /** sandboxd endpoint, e.g. https://sandbox.example.com. Falls back to COCOONSTACK_API_URL. */
+  baseUrl?: string;
+  /** Node or tenant API token. Falls back to COCOONSTACK_API_KEY. */
+  apiKey?: string;
+  /** Default template, a pool key such as node-rt:24.04. */
+  template?: string;
+  /** Default network lane. */
+  net?: CocoonstackNet;
+  /** Default size tier. */
+  size?: CocoonstackSize;
+  /** Default claim lease in seconds; the node reaps the sandbox after it. */
+  ttlSeconds?: number;
+  /** HTTP request timeout. */
+  requestTimeoutMs?: number;
+}
+
+export interface CocoonstackSandbox {
+  id: string;
+  /** The claim token; every call on the sandbox authenticates with it. */
+  token: string;
+  template: string;
+  net: CocoonstackNet;
+  size: CocoonstackSize;
+  createdAt: Date;
+  deadline: Date;
+  config: CocoonstackConfig;
+}
+
+export class CocoonstackApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CocoonstackApiError';
+  }
+}
+
+interface Resolved {
+  baseUrl: string;
+  apiKey: string;
+  template: string;
+  net: CocoonstackNet;
+  size: CocoonstackSize;
+  ttlSeconds: number;
+  requestTimeoutMs: number;
+}
+
+interface ClaimResponse {
+  id: string;
+  token: string;
+  deadline: string;
+  redirect?: string[];
+}
+
+interface ExecResponse {
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface SandboxRow {
+  id: string;
+  key: { template: string; net: CocoonstackNet; size: CocoonstackSize };
+  deadline: string;
+}
+
+interface Frame {
+  type: string;
+  data?: string;
+  code?: number;
+  pid?: number;
+  kind?: string;
+  message?: string;
+}
+
+interface RelayOptions {
+  timeoutMs?: number;
+  detach?: boolean;
+  onStdout?: (data: string) => void;
+  onStderr?: (data: string) => void;
+}
+
+type Exec = (sandbox: CocoonstackSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>;
+
+type Lane = 'main' | 'release';
+
+// sandboxd scopes a sandbox to its claim token; by-id calls look it up here.
+const claimTokens = new Map<string, string>();
+// one HTTP/2 session per origin and lane: a burst multiplexes over one TLS connection,
+// and releases ride their own session so a slow teardown never queues a claim or exec
+const sessions = new Map<string, http2.ClientHttp2Session>();
+const sessionStreams = new WeakMap<http2.ClientHttp2Session, number>();
+// building a TLS context parses the CA store; one per process, not one per session
+const secureContext = tls.createSecureContext();
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+
+function env(name: string): string | undefined {
+  return typeof process === 'undefined' ? undefined : process.env[name];
+}
+
+function resolve(config: CocoonstackConfig): Resolved {
+  const baseUrl = config.baseUrl || env('COCOONSTACK_API_URL') || '';
+  if (!baseUrl) {
+    throw new Error(
+      'Missing Cocoon Stack endpoint. Pass baseUrl or set COCOONSTACK_API_URL to your sandboxd address.',
+    );
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    apiKey: config.apiKey || env('COCOONSTACK_API_KEY') || '',
+    template: config.template ?? DEFAULT_TEMPLATE,
+    net: config.net ?? 'none',
+    size: config.size ?? 'small',
+    ttlSeconds: config.ttlSeconds ?? DEFAULT_TTL_SECONDS,
+    requestTimeoutMs: config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+  };
+}
+
+function detail(body: string): string {
+  const match = /"error"\s*:\s*"([^"]*)"/.exec(body);
+  return match?.[1] ?? body;
+}
+
+function session(origin: string, lane: Lane): http2.ClientHttp2Session {
+  const key = `${lane} ${origin}`;
+  const live = sessions.get(key);
+  if (live && !live.closed && !live.destroyed) return live;
+  const created = http2.connect(origin, { secureContext });
+  const drop = () => {
+    if (sessions.get(key) === created) sessions.delete(key);
+  };
+  created.on('connect', () => applyHold(created));
+  created.on('close', drop);
+  created.on('goaway', drop);
+  created.on('error', drop);
+  sessions.set(key, created);
+  return created;
+}
+
+// an idle session must not keep the process alive; a session with streams in flight must
+function holdSession(live: http2.ClientHttp2Session): () => void {
+  sessionStreams.set(live, (sessionStreams.get(live) ?? 0) + 1);
+  applyHold(live);
+  return () => {
+    sessionStreams.set(live, Math.max(0, (sessionStreams.get(live) ?? 1) - 1));
+    applyHold(live);
+  };
+}
+
+function applyHold(live: http2.ClientHttp2Session): void {
+  const socket = live.socket as { ref?: () => void; unref?: () => void } | undefined;
+  if (!socket) return;
+  if ((sessionStreams.get(live) ?? 0) > 0) socket.ref?.();
+  else socket.unref?.();
+}
+
+function h2Request(
+  origin: string,
+  lane: Lane,
+  method: string,
+  path: string,
+  headers: Record<string, string>,
+  payload: string | undefined,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{ status: number; text: string }> {
+  return new Promise((fulfill, reject) => {
+    const live = session(origin, lane);
+    const release = holdSession(live);
+    const stream = live.request({ ':method': method, ':path': path, ...headers });
+    let status = 0;
+    let text = '';
+    const abort = () => stream.close(http2.constants.NGHTTP2_CANCEL);
+    signal?.addEventListener('abort', abort, { once: true });
+    let released = false;
+    const done = () => {
+      if (released) return;
+      released = true;
+      signal?.removeEventListener('abort', abort);
+      release();
+    };
+    stream.setEncoding('utf8');
+    stream.setTimeout(timeoutMs, () => {
+      stream.close(http2.constants.NGHTTP2_CANCEL);
+      reject(new Error('sandboxd request timed out'));
+    });
+    stream.on('response', (responseHeaders) => {
+      status = Number(responseHeaders[':status'] ?? 0);
+    });
+    stream.on('data', (chunk: string) => {
+      text += chunk;
+    });
+    stream.on('end', () => {
+      done();
+      fulfill({ status, text });
+    });
+    stream.on('error', (error: Error) => {
+      done();
+      reject(signal?.aborted ? (signal.reason instanceof Error ? signal.reason : new Error('aborted')) : error);
+    });
+    stream.on('close', done);
+    stream.end(payload);
+  });
+}
+
+function h1Request(
+  url: URL,
+  method: string,
+  headers: Record<string, string>,
+  payload: string | undefined,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{ status: number; text: string }> {
+  return new Promise((fulfill, reject) => {
+    const secure = url.protocol === 'https:';
+    const client = (secure ? https : http).request(
+      url,
+      {
+        method,
+        agent: secure ? httpsAgent : httpAgent,
+        timeout: timeoutMs,
+        signal,
+        headers: {
+          ...headers,
+          ...(payload === undefined ? {} : { 'content-length': Buffer.byteLength(payload) }),
+        },
+      },
+      (response) => {
+        let text = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk: string) => {
+          text += chunk;
+        });
+        response.on('error', reject);
+        response.on('end', () => fulfill({ status: response.statusCode ?? 0, text }));
+      },
+    );
+    client.on('timeout', () => client.destroy(new Error('sandboxd request timed out')));
+    client.on('error', reject);
+    client.end(payload);
+  });
+}
+
+/** JSON call to sandboxd: HTTP/2 on TLS origins, HTTP/1.1 keep-alive otherwise. */
+async function request<T>(
+  resolved: Resolved,
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+  signal?: AbortSignal,
+  timeoutMs = resolved.requestTimeoutMs,
+  lane: Lane = 'main',
+): Promise<T> {
+  const url = new URL(`${resolved.baseUrl}${path}`);
+  const payload = body === undefined ? undefined : JSON.stringify(body);
+  const headers = {
+    'content-type': 'application/json',
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  const { status, text } =
+    url.protocol === 'https:'
+      ? await h2Request(url.origin, lane, method, `${url.pathname}${url.search}`, headers, payload, timeoutMs, signal)
+      : await h1Request(url, method, headers, payload, timeoutMs, signal);
+  if (status < 200 || status >= 300) {
+    throw new CocoonstackApiError(status, `sandboxd ${method} ${path} failed (${status}): ${detail(text)}`);
+  }
+  return (text ? JSON.parse(text) : undefined) as T;
+}
+
+function isSize(value: string): value is CocoonstackSize {
+  return SIZES.some((tier) => tier.size === value);
+}
+
+function sizeFor(resolved: Resolved, options?: CreateSandboxOptions): CocoonstackSize {
+  if (options?.size !== undefined) {
+    if (!isSize(options.size)) {
+      throw new Error(
+        `Unknown Cocoon Stack size ${JSON.stringify(options.size)}; one of ${SIZES.map((tier) => tier.size).join(', ')}.`,
+      );
+    }
+    return options.size;
+  }
+  const cpu = options?.vcpus ?? options?.cpus ?? options?.cpu;
+  const memoryMb = options?.memoryMb ?? options?.memoryMiB ?? options?.memMiB ?? options?.memory;
+  if (cpu === undefined && memoryMb === undefined) return resolved.size;
+  const tier = SIZES.find((candidate) => candidate.cpu >= (cpu ?? 0) && candidate.memoryMb >= (memoryMb ?? 0));
+  if (!tier) {
+    throw new Error(
+      `No Cocoon Stack size tier offers ${cpu ?? '-'} CPU / ${memoryMb ?? '-'} MB; the largest is 2xlarge (8 CPU / 16384 MB).`,
+    );
+  }
+  return tier.size;
+}
+
+function ttlFor(resolved: Resolved, options?: CreateSandboxOptions): number {
+  if (!options?.timeout) return resolved.ttlSeconds;
+  return Math.min(MAX_TTL_SECONDS, Math.ceil(options.timeout / 1000));
+}
+
+function fromRow(config: CocoonstackConfig, row: SandboxRow): CocoonstackSandbox {
+  return {
+    id: row.id,
+    token: claimTokens.get(row.id) ?? '',
+    template: row.key.template,
+    net: row.key.net,
+    size: row.key.size,
+    createdAt: new Date(),
+    deadline: new Date(row.deadline),
+    config,
+  };
+}
+
+async function index(resolved: Resolved): Promise<SandboxRow[]> {
+  const listing = await request<{ sandboxes: SandboxRow[] }>(resolved, resolved.apiKey, 'GET', '/v1/sandboxes');
+  return listing.sandboxes;
+}
+
+/** One silkd RPC per connection: HTTP Upgrade, one JSON request line, newline-delimited frames back. */
+function relay(
+  sandbox: CocoonstackSandbox,
+  resolved: Resolved,
+  rpc: Record<string, unknown>,
+  options: RelayOptions,
+): Promise<Omit<CommandResult, 'durationMs'>> {
+  return new Promise((fulfill, reject) => {
+    const url = new URL(`${resolved.baseUrl}/v1/sandboxes/${encodeURIComponent(sandbox.id)}/agent`);
+    const secure = url.protocol === 'https:';
+    const client = (secure ? https : http).request(url, {
+      method: 'GET',
+      agent: secure ? httpsAgent : httpAgent,
+      headers: { upgrade: 'silkd', connection: 'Upgrade', authorization: `Bearer ${sandbox.token}` },
+    });
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const finish = (outcome: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      outcome();
+    };
+    if (options.timeoutMs) {
+      timer = setTimeout(() => {
+        finish(() => reject(new Error(`Command timed out after ${options.timeoutMs} ms`)));
+        client.destroy();
+      }, options.timeoutMs);
+    }
+    client.on('response', (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk: string) => {
+        body += chunk;
+      });
+      response.on('end', () =>
+        finish(() =>
+          reject(
+            new CocoonstackApiError(
+              response.statusCode ?? 0,
+              `sandboxd agent relay refused (${response.statusCode}): ${detail(body)}`,
+            ),
+          ),
+        ),
+      );
+    });
+    client.on('upgrade', (_response, socket, head) => {
+      const out = new StringDecoder('utf8');
+      const err = new StringDecoder('utf8');
+      let stdout = '';
+      let stderr = '';
+      let pending = head.toString('utf8');
+      const handle = (frame: Frame) => {
+        switch (frame.type) {
+          case 'started':
+            if (options.detach) {
+              finish(() => fulfill({ exitCode: 0, stdout: String(frame.pid ?? ''), stderr: '' }));
+              socket.destroy();
+            }
+            break;
+          case 'stdout': {
+            const text = out.write(Buffer.from(frame.data ?? '', 'base64'));
+            stdout += text;
+            if (text) options.onStdout?.(text);
+            break;
+          }
+          case 'stderr': {
+            const text = err.write(Buffer.from(frame.data ?? '', 'base64'));
+            stderr += text;
+            if (text) options.onStderr?.(text);
+            break;
+          }
+          case 'exit':
+            stdout += out.end();
+            stderr += err.end();
+            finish(() => fulfill({ exitCode: frame.code ?? 0, stdout, stderr }));
+            socket.destroy();
+            break;
+          case 'error':
+            finish(() => reject(new Error(`silkd ${frame.kind ?? 'error'}: ${frame.message ?? ''}`)));
+            socket.destroy();
+            break;
+          default:
+            break;
+        }
+      };
+      socket.setEncoding('utf8');
+      socket.on('data', (chunk: string) => {
+        pending += chunk;
+        let newline = pending.indexOf('\n');
+        while (newline >= 0) {
+          const line = pending.slice(0, newline);
+          pending = pending.slice(newline + 1);
+          if (line.trim()) {
+            try {
+              handle(JSON.parse(line) as Frame);
+            } catch (error: unknown) {
+              finish(() => reject(error instanceof Error ? error : new Error(String(error))));
+              socket.destroy();
+              return;
+            }
+          }
+          newline = pending.indexOf('\n');
+        }
+      });
+      socket.on('error', (error: Error) => finish(() => reject(error)));
+      socket.on('close', () => finish(() => reject(new Error('Agent relay closed before the command exited'))));
+      socket.write(`${JSON.stringify({ v: 1, ...rpc })}\n`);
+    });
+    client.on('error', (error: Error) => finish(() => reject(error)));
+    client.end();
+  });
+}
+
+/** Streaming and detached commands ride the relay; everything else is one buffered exec request. */
+async function exec(sandbox: CocoonstackSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> {
+  const started = performance.now();
+  const resolved = resolve(sandbox.config);
+  const argv = ['bash', '-c', command];
+  if (options?.background || options?.onStdout || options?.onStderr) {
+    const result = await relay(
+      sandbox,
+      resolved,
+      {
+        op: 'exec',
+        argv,
+        ...(options.cwd ? { cwd: options.cwd } : {}),
+        ...(options.env ? { env: options.env } : {}),
+        ...(options.background ? { detach: true } : {}),
+      },
+      {
+        timeoutMs: options.timeout,
+        detach: options.background,
+        onStdout: options.onStdout,
+        onStderr: options.onStderr,
+      },
+    );
+    return { ...result, durationMs: performance.now() - started };
+  }
+  try {
+    const result = await request<ExecResponse>(
+      resolved,
+      sandbox.token,
+      'POST',
+      `/v1/sandboxes/${encodeURIComponent(sandbox.id)}/exec`,
+      {
+        argv,
+        ...(options?.cwd ? { cwd: options.cwd } : {}),
+        ...(options?.env ? { env: options.env } : {}),
+        ...(options?.timeout ? { timeout_seconds: Math.ceil(options.timeout / 1000) } : {}),
+      },
+      undefined,
+      options?.timeout ? options.timeout + COMMAND_HTTP_TIMEOUT_BUFFER_MS : resolved.requestTimeoutMs,
+    );
+    return {
+      exitCode: result.exit_code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      durationMs: performance.now() - started,
+    };
+  } catch (error: unknown) {
+    if (error instanceof CocoonstackApiError && error.status === 504) {
+      throw new Error(`Command timed out after ${options?.timeout} ms`);
+    }
+    throw error;
+  }
+}
+
+async function shell(runCommand: Exec, sandbox: CocoonstackSandbox, command: string, failure: string): Promise<string> {
+  const result = await runCommand(sandbox, command);
+  if (result.exitCode !== 0) {
+    throw new Error(`${failure}: ${result.stderr.trim() || `exit ${result.exitCode}`}`);
+  }
+  return result.stdout;
+}
+
+const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
+  name: PROVIDER,
+  methods: {
+    sandbox: {
+      create: async (config, options) => {
+        const resolved = resolve(config);
+        const template = options?.templateId ?? options?.image ?? resolved.template;
+        const size = sizeFor(resolved, options);
+        const claimed = await request<ClaimResponse>(
+          resolved,
+          resolved.apiKey,
+          'POST',
+          '/v1/claim',
+          { template, net: resolved.net, size, ttl_seconds: ttlFor(resolved, options) },
+          options?.signal,
+        );
+        if (claimed.redirect) {
+          throw new Error(
+            `sandboxd redirected the claim to ${claimed.redirect.join(', ')}; point baseUrl at a node that serves the pool.`,
+          );
+        }
+        claimTokens.set(claimed.id, claimed.token);
+        const sandbox: CocoonstackSandbox = {
+          id: claimed.id,
+          token: claimed.token,
+          template,
+          net: resolved.net,
+          size,
+          createdAt: new Date(),
+          deadline: new Date(claimed.deadline),
+          config,
+        };
+        return { sandbox, sandboxId: sandbox.id };
+      },
+
+      getById: async (config, sandboxId) => {
+        const row = (await index(resolve(config))).find((candidate) => candidate.id === sandboxId);
+        return row ? { sandbox: fromRow(config, row), sandboxId } : null;
+      },
+
+      list: async (config) =>
+        (await index(resolve(config))).map((row) => ({ sandbox: fromRow(config, row), sandboxId: row.id })),
+
+      destroy: async (config, sandboxId) => {
+        const resolved = resolve(config);
+        try {
+          await request<void>(
+            resolved,
+            claimTokens.get(sandboxId) ?? resolved.apiKey,
+            'POST',
+            `/v1/sandboxes/${encodeURIComponent(sandboxId)}/release`,
+            undefined,
+            undefined,
+            resolved.requestTimeoutMs,
+            'release',
+          );
+        } catch (error: unknown) {
+          if (!(error instanceof CocoonstackApiError && error.status === 404)) throw error;
+        } finally {
+          claimTokens.delete(sandboxId);
+        }
+      },
+
+      runCommand: exec,
+
+      streamCommand: exec,
+
+      getInfo: async (sandbox): Promise<SandboxInfo> => ({
+        id: sandbox.id,
+        provider: PROVIDER,
+        status: 'running',
+        createdAt: sandbox.createdAt,
+        timeout: Math.max(0, sandbox.deadline.getTime() - Date.now()),
+        metadata: {
+          template: sandbox.template,
+          net: sandbox.net,
+          size: sandbox.size,
+          deadline: sandbox.deadline.toISOString(),
+        },
+      }),
+
+      getUrl: async (sandbox, options): Promise<string> => {
+        const resolved = resolve(sandbox.config);
+        const preview = await request<{ url: string }>(
+          resolved,
+          resolved.apiKey,
+          'POST',
+          `/v1/sandboxes/${encodeURIComponent(sandbox.id)}/preview`,
+          { token: sandbox.token, port: options.port, ttl_seconds: 0 },
+        );
+        return preview.url;
+      },
+
+      filesystem: {
+        readFile: async (sandbox, path, runCommand): Promise<string> =>
+          shell(runCommand, sandbox, `cat "${escapeShellArg(path)}"`, `Failed to read ${path}`),
+
+        writeFile: async (sandbox, path, content, runCommand): Promise<void> => {
+          const encoded = Buffer.from(content, 'utf8').toString('base64');
+          const directory = path.slice(0, path.lastIndexOf('/')) || '/';
+          await shell(
+            runCommand,
+            sandbox,
+            `mkdir -p "${escapeShellArg(directory)}" && printf %s "${escapeShellArg(encoded)}" | base64 -d > "${escapeShellArg(path)}"`,
+            `Failed to write ${path}`,
+          );
+        },
+
+        mkdir: async (sandbox, path, runCommand): Promise<void> => {
+          await shell(runCommand, sandbox, `mkdir -p "${escapeShellArg(path)}"`, `Failed to create ${path}`);
+        },
+
+        readdir: async (sandbox, path, runCommand): Promise<FileEntry[]> => {
+          const listing = await shell(
+            runCommand,
+            sandbox,
+            `ls -Ap --time-style=+%s -l "${escapeShellArg(path)}"`,
+            `Failed to list ${path}`,
+          );
+          return listing
+            .split('\n')
+            .slice(1)
+            .flatMap((line) => {
+              const parts = line.trim().split(/\s+/);
+              if (parts.length < 7) return [];
+              const name = parts.slice(6).join(' ');
+              return [
+                {
+                  name: name.replace(/\/$/, ''),
+                  type: name.endsWith('/') ? ('directory' as const) : ('file' as const),
+                  size: Number.parseInt(parts[4], 10) || 0,
+                  modified: new Date(Number.parseInt(parts[5], 10) * 1000),
+                },
+              ];
+            });
+        },
+
+        exists: async (sandbox, path, runCommand): Promise<boolean> => {
+          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          return result.exitCode === 0;
+        },
+
+        remove: async (sandbox, path, runCommand): Promise<void> => {
+          await shell(runCommand, sandbox, `rm -rf "${escapeShellArg(path)}"`, `Failed to remove ${path}`);
+        },
+      },
+
+      getInstance: (sandbox) => sandbox,
+    },
+  },
+});
+
+/** Cocoon Stack provider; on a TLS endpoint the first call finds the HTTP/2 session already open. */
+export const cocoonstack: typeof provider = (config) => {
+  const baseUrl = config.baseUrl || env('COCOONSTACK_API_URL') || '';
+  if (baseUrl.startsWith('https://')) session(new URL(baseUrl).origin, 'main');
+  return provider(config);
+};
+
+export default cocoonstack;

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -445,6 +445,9 @@ function relay(
       const err = new StringDecoder('utf8');
       let stdout = '';
       let stderr = '';
+      let frames = 0;
+      let lastOut = 0;
+      let lastErr = 0;
       let pending = head.toString('utf8');
       const handle = (frame: Frame) => {
         switch (frame.type) {
@@ -455,12 +458,14 @@ function relay(
             }
             break;
           case 'stdout': {
+            lastOut = ++frames;
             const text = out.write(Buffer.from(frame.data ?? '', 'base64'));
             stdout += text;
             if (text) options.onStdout?.(text);
             break;
           }
           case 'stderr': {
+            lastErr = ++frames;
             const text = err.write(Buffer.from(frame.data ?? '', 'base64'));
             stderr += text;
             if (text) options.onStderr?.(text);
@@ -469,13 +474,15 @@ function relay(
           case 'exit': {
             const tailOut = out.end();
             const tailErr = err.end();
-            if (tailOut) {
-              stdout += tailOut;
-              options.onStdout?.(tailOut);
-            }
-            if (tailErr) {
-              stderr += tailErr;
-              options.onStderr?.(tailErr);
+            stdout += tailOut;
+            stderr += tailErr;
+            // each tail came from its stream's last frame, so replay them in that order
+            const tails: [number, string, ((text: string) => void) | undefined][] = [
+              [lastOut, tailOut, options.onStdout],
+              [lastErr, tailErr, options.onStderr],
+            ];
+            for (const [, text, notify] of tails.sort((a, b) => a[0] - b[0])) {
+              if (text) notify?.(text);
             }
             finish(() => fulfill({ exitCode: frame.code ?? 0, stdout, stderr }));
             socket.destroy();
@@ -682,21 +689,22 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
 
       filesystem: {
         readFile: async (sandbox, path, runCommand): Promise<string> =>
-          shell(runCommand, sandbox, `cat "${escapeShellArg(path)}"`, `Failed to read ${path}`),
+          shell(runCommand, sandbox, `cat "${shellPath(path)}"`, `Failed to read ${path}`),
 
         writeFile: async (sandbox, path, content, runCommand): Promise<void> => {
           const encoded = Buffer.from(content, 'utf8').toString('base64');
-          const directory = path.slice(0, path.lastIndexOf('/')) || '/';
+          const cut = path.lastIndexOf('/');
+          const directory = cut < 0 ? '.' : path.slice(0, cut) || '/';
           await shell(
             runCommand,
             sandbox,
-            `mkdir -p "${escapeShellArg(directory)}" && printf %s "${escapeShellArg(encoded)}" | base64 -d > "${escapeShellArg(path)}"`,
+            `mkdir -p "${shellPath(directory)}" && printf %s "${escapeShellArg(encoded)}" | base64 -d > "${shellPath(path)}"`,
             `Failed to write ${path}`,
           );
         },
 
         mkdir: async (sandbox, path, runCommand): Promise<void> => {
-          await shell(runCommand, sandbox, `mkdir -p "${escapeShellArg(path)}"`, `Failed to create ${path}`);
+          await shell(runCommand, sandbox, `mkdir -p "${shellPath(path)}"`, `Failed to create ${path}`);
         },
 
         readdir: async (sandbox, path, runCommand): Promise<FileEntry[]> => {
@@ -704,7 +712,7 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
           const listing = await shell(
             runCommand,
             sandbox,
-            `find "${escapeShellArg(path)}" -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\0'`,
+            `find "${shellPath(path)}" -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%T@\\t%f\\0'`,
             `Failed to list ${path}`,
           );
           return listing.split('\0').flatMap((record) => {
@@ -724,12 +732,12 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
         },
 
         exists: async (sandbox, path, runCommand): Promise<boolean> => {
-          const result = await runCommand(sandbox, `test -e "${escapeShellArg(path)}"`);
+          const result = await runCommand(sandbox, `test -e "${shellPath(path)}"`);
           return result.exitCode === 0;
         },
 
         remove: async (sandbox, path, runCommand): Promise<void> => {
-          await shell(runCommand, sandbox, `rm -rf "${escapeShellArg(path)}"`, `Failed to remove ${path}`);
+          await shell(runCommand, sandbox, `rm -rf "${shellPath(path)}"`, `Failed to remove ${path}`);
         },
       },
 
@@ -745,6 +753,11 @@ export const cocoonstack: typeof provider = (config) => {
 };
 
 export default cocoonstack;
+
+// a relative path starting with - or ( reads as an option or a find expression until it is anchored
+function shellPath(path: string): string {
+  return escapeShellArg(path.startsWith('/') ? path : `./${path}`);
+}
 
 // a malformed endpoint is reported by the first call, not by the warm-up
 function preconnect(baseUrl: string): void {

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -19,6 +19,7 @@ const DEFAULT_TTL_SECONDS = 300;
 const MAX_TTL_SECONDS = 86_400;
 const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 const COMMAND_HTTP_TIMEOUT_BUFFER_MS = 5_000;
+const MAX_RESPONSE_BYTES = 16 << 20;
 const SIZES = [
   { size: 'small', cpu: 1, memoryMb: 512 },
   { size: 'medium', cpu: 2, memoryMb: 1024 },
@@ -107,6 +108,11 @@ interface Frame {
   message?: string;
 }
 
+interface Claim {
+  token: string;
+  deadline: number;
+}
+
 interface RelayOptions {
   timeoutMs?: number;
   detach?: boolean;
@@ -118,8 +124,8 @@ type Exec = (sandbox: CocoonstackSandbox, command: string, options?: RunCommandO
 
 type Lane = 'main' | 'release';
 
-// sandboxd scopes a sandbox to its claim token; by-id calls look it up here.
-const claimTokens = new Map<string, string>();
+// sandboxd scopes a sandbox to its claim token; by-id calls look it up here, keyed per endpoint
+const claimTokens = new Map<string, Claim>();
 // one HTTP/2 session per origin and lane: a burst multiplexes over one TLS connection,
 // and releases ride their own session so a slow teardown never queues a claim or exec
 const sessions = new Map<string, http2.ClientHttp2Session>();
@@ -149,6 +155,29 @@ function resolve(config: CocoonstackConfig): Resolved {
     ttlSeconds: config.ttlSeconds ?? DEFAULT_TTL_SECONDS,
     requestTimeoutMs: config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
   };
+}
+
+function claimKey(resolved: Resolved, id: string): string {
+  return `${resolved.baseUrl} ${id}`;
+}
+
+function rememberClaim(resolved: Resolved, id: string, token: string, deadline: Date): void {
+  const now = Date.now();
+  for (const [key, claim] of claimTokens) {
+    if (claim.deadline < now) claimTokens.delete(key);
+  }
+  claimTokens.set(claimKey(resolved, id), { token, deadline: deadline.getTime() });
+}
+
+function retainedToken(resolved: Resolved, id: string): string | undefined {
+  const key = claimKey(resolved, id);
+  const claim = claimTokens.get(key);
+  if (!claim) return undefined;
+  if (claim.deadline < Date.now()) {
+    claimTokens.delete(key);
+    return undefined;
+  }
+  return claim.token;
 }
 
 function detail(body: string): string {
@@ -224,6 +253,10 @@ function h2Request(
     });
     stream.on('data', (chunk: string) => {
       text += chunk;
+      if (text.length > MAX_RESPONSE_BYTES) {
+        stream.close(http2.constants.NGHTTP2_CANCEL);
+        reject(new Error(`sandboxd response exceeds ${MAX_RESPONSE_BYTES >> 20} MiB`));
+      }
     });
     stream.on('end', () => {
       done();
@@ -265,6 +298,9 @@ function h1Request(
         response.setEncoding('utf8');
         response.on('data', (chunk: string) => {
           text += chunk;
+          if (text.length > MAX_RESPONSE_BYTES) {
+            client.destroy(new Error(`sandboxd response exceeds ${MAX_RESPONSE_BYTES >> 20} MiB`));
+          }
         });
         response.on('error', reject);
         response.on('end', () => fulfill({ status: response.statusCode ?? 0, text }));
@@ -333,10 +369,10 @@ function ttlFor(resolved: Resolved, options?: CreateSandboxOptions): number {
   return Math.min(MAX_TTL_SECONDS, Math.ceil(options.timeout / 1000));
 }
 
-function fromRow(config: CocoonstackConfig, row: SandboxRow): CocoonstackSandbox {
+function fromRow(config: CocoonstackConfig, row: SandboxRow, token: string): CocoonstackSandbox {
   return {
     id: row.id,
-    token: claimTokens.get(row.id) ?? '',
+    token,
     template: row.key.template,
     net: row.key.net,
     size: row.key.size,
@@ -482,7 +518,7 @@ async function exec(sandbox: CocoonstackSandbox, command: string, options?: RunC
         ...(options.background ? { detach: true } : {}),
       },
       {
-        timeoutMs: options.timeout,
+        timeoutMs: options.timeout ?? resolved.requestTimeoutMs,
         detach: options.background,
         onStdout: options.onStdout,
         onStderr: options.onStderr,
@@ -548,7 +584,8 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
             `sandboxd redirected the claim to ${claimed.redirect.join(', ')}; point baseUrl at a node that serves the pool.`,
           );
         }
-        claimTokens.set(claimed.id, claimed.token);
+        const deadline = new Date(claimed.deadline);
+        rememberClaim(resolved, claimed.id, claimed.token, deadline);
         const sandbox: CocoonstackSandbox = {
           id: claimed.id,
           token: claimed.token,
@@ -556,26 +593,34 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
           net: resolved.net,
           size,
           createdAt: new Date(),
-          deadline: new Date(claimed.deadline),
+          deadline,
           config,
         };
         return { sandbox, sandboxId: sandbox.id };
       },
 
       getById: async (config, sandboxId) => {
-        const row = (await index(resolve(config))).find((candidate) => candidate.id === sandboxId);
-        return row ? { sandbox: fromRow(config, row), sandboxId } : null;
+        const resolved = resolve(config);
+        const token = retainedToken(resolved, sandboxId);
+        if (token === undefined) return null;
+        const row = (await index(resolved)).find((candidate) => candidate.id === sandboxId);
+        return row ? { sandbox: fromRow(config, row, token), sandboxId } : null;
       },
 
-      list: async (config) =>
-        (await index(resolve(config))).map((row) => ({ sandbox: fromRow(config, row), sandboxId: row.id })),
+      list: async (config) => {
+        const resolved = resolve(config);
+        return (await index(resolved)).flatMap((row) => {
+          const token = retainedToken(resolved, row.id);
+          return token === undefined ? [] : [{ sandbox: fromRow(config, row, token), sandboxId: row.id }];
+        });
+      },
 
       destroy: async (config, sandboxId) => {
         const resolved = resolve(config);
         try {
           await request<void>(
             resolved,
-            claimTokens.get(sandboxId) ?? resolved.apiKey,
+            retainedToken(resolved, sandboxId) ?? resolved.apiKey,
             'POST',
             `/v1/sandboxes/${encodeURIComponent(sandboxId)}/release`,
             undefined,
@@ -585,9 +630,8 @@ const provider = defineProvider<CocoonstackSandbox, CocoonstackConfig>({
           );
         } catch (error: unknown) {
           if (!(error instanceof CocoonstackApiError && error.status === 404)) throw error;
-        } finally {
-          claimTokens.delete(sandboxId);
         }
+        claimTokens.delete(claimKey(resolved, sandboxId));
       },
 
       runCommand: exec,

--- a/packages/cocoonstack/src/index.ts
+++ b/packages/cocoonstack/src/index.ts
@@ -740,12 +740,11 @@ export default cocoonstack;
 
 // a malformed endpoint is reported by the first call, not by the warm-up
 function preconnect(baseUrl: string): void {
-  if (!baseUrl.startsWith('https://')) return;
-  let origin: string;
+  let url: URL;
   try {
-    origin = new URL(baseUrl).origin;
+    url = new URL(baseUrl);
   } catch {
     return;
   }
-  session(origin, 'main');
+  if (url.protocol === 'https:') session(url.origin, 'main');
 }

--- a/packages/cocoonstack/tsconfig.json
+++ b/packages/cocoonstack/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cocoonstack/tsup.config.ts
+++ b/packages/cocoonstack/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/cocoonstack/vitest.config.ts
+++ b/packages/cocoonstack/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,6 +667,40 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.5)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
 
+  packages/cocoonstack:
+    dependencies:
+      '@computesdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      computesdk:
+        specifier: workspace:*
+        version: link:../computesdk
+    devDependencies:
+      '@computesdk/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.41)(jsdom@23.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.43.1)
+
   packages/codesandbox:
     dependencies:
       '@codesandbox/sdk':


### PR DESCRIPTION
## Provider: `@computesdk/cocoonstack`

**What is it?** Cocoon Stack — self-hosted microVM sandboxes (Cloud Hypervisor) served from warm pools by `sandboxd`, the control plane of https://github.com/cocoonstack/sandbox. Sub-millisecond warm claims, size tiers from 1 vCPU/512 MB to 8 vCPU/16 GB, an audited egress allow-list, and an in-guest agent (silkd) for exec, files, sessions and port relays.

**Underlying SDK / API:** the sandboxd HTTP API (`POST /v1/claim`, `POST /v1/sandboxes/{id}/exec`, `POST /v1/sandboxes/{id}/release`, the `GET /v1/sandboxes/{id}/agent` upgrade relay for streaming/detached commands) — no extra runtime dependency; JSON calls ride one `node:http2` session per origin on TLS endpoints and `node:http` keep-alive otherwise.

**Credentials:** `COCOONSTACK_API_URL` (the sandboxd endpoint, self-hosted) and `COCOONSTACK_API_KEY` (a node or tenant token from the sandboxd config) — see the [deployment guide](https://github.com/cocoonstack/sandbox/blob/main/docs/deploy.md).

### Capabilities

| Capability | Supported? | Notes |
|---|---|---|
| `runCommand` (required) | ✅ | buffered exec over HTTP/2; `onStdout`/`onStderr` and `background` ride the agent relay (native streaming, `detach`) |
| Filesystem | ✅ | shell-backed (`cat`, `base64 -d`, `ls`, `test`, `rm`) |
| `getUrl` (port exposure) | ✅ | sandboxd signed preview URLs; 501 from the node when no preview listener is configured |
| `list` | ✅ | the token's sandbox index |
| Templates | ❌ | managed through sandboxd's own promote/checkpoint API; throws |
| Snapshots | ❌ | same; throws |

> Unsupported methods are defined but throw a clear "not supported" error — they are not omitted.

### Checklist

- [x] New `packages/cocoonstack/` package with `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, `README.md`, and `src/`
- [x] Core sandbox methods implemented: `create`, `getById`, `destroy`, `runCommand`, `getInfo`
- [x] Config validated early with a helpful error; env-var fallback supported
- [x] Shell interpolation uses `escapeShellArg` wrapped in double quotes
- [x] Tests via `runProviderTestSuite` (unit pass; integration gated on credentials) plus 21 provider tests against an in-process fake sandboxd (real HTTP server + upgrade relay)
- [x] `pnpm build` passes
- [x] `pnpm --filter @computesdk/cocoonstack run typecheck` passes
- [x] `pnpm --filter @computesdk/cocoonstack run lint` passes
- [x] Root `README.md` "Supported Providers" table updated (and install list)
- [x] Docs page added at `docs/providers/cocoonstack.md`, linked from `docs/SUMMARY.md`
- [x] Changeset added (`patch`)

### Notes for reviewers

- sandboxd scopes a sandbox to the token minted at claim time, so `destroy` and `runCommand` on a sandbox obtained through `getById`/`list` work for sandboxes this process created (an in-process token registry); other sandboxes need the node token. Documented in the README.
- `size` picks a tier by name; otherwise `vcpus`/`cpus`/`cpu` and `memoryMb`/`memoryMiB`/`memMiB`/`memory` map to the smallest covering tier. `timeout` on create becomes the claim lease (capped at 24 h).
- A clustered node may answer a claim with a redirect to a peer; the provider refuses it rather than following cluster-internal addresses.
- The HTTP/2 path has no unit test (the fake is HTTP/1.1); it was verified against a live node behind Caddy with 100-concurrency runs of the TTI and Dax benchmarks from this repo (100/100 and 7/7).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->