### PR TITLE
fix(opencomputer): defer native SDK initialization until provider use

### DIFF
--- a/.changeset/lazy-opencomputer-sdk.md
+++ b/.changeset/lazy-opencomputer-sdk.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/opencomputer": patch
+---
+
+Load the OpenComputer SDK on first provider use. Importing an unused provider no longer changes the global HTTP dispatcher or starts background connections. Concurrent operations share one SDK initialization.

--- a/packages/opencomputer/src/__tests__/index.test.ts
+++ b/packages/opencomputer/src/__tests__/index.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { opencomputer } from '../index';
 
-// vi.hoisted: the SDK import now starts at module load, so the mock factory
-// can run before this file's own top-level consts are initialized.
+// SDK mocks are available before provider module evaluation.
 const { createMock, connectMock, createFromCheckpointMock } = vi.hoisted(() => ({
   createMock: vi.fn(),
   connectMock: vi.fn(),

--- a/packages/opencomputer/src/__tests__/lazy-sdk.test.ts
+++ b/packages/opencomputer/src/__tests__/lazy-sdk.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.doUnmock('@opencomputer/sdk');
+  vi.resetModules();
+});
+
+it('loads the SDK only on provider use and shares initialization across concurrent creates', async () => {
+  vi.resetModules();
+  let initialized = 0;
+  const create = vi.fn().mockResolvedValue({ sandboxId: 'sb_lazy' });
+  vi.doMock('@opencomputer/sdk', () => {
+    initialized++;
+    return { Sandbox: { create } };
+  });
+
+  const { opencomputer } = await import('../index');
+  await vi.dynamicImportSettled();
+  expect(initialized).toBe(0);
+
+  const provider = opencomputer({ apiKey: 'test-key' });
+  expect(initialized).toBe(0);
+  const sandboxes = await Promise.all([
+    provider.sandbox.create(),
+    provider.sandbox.create(),
+  ]);
+
+  expect(initialized).toBe(1);
+  expect(create).toHaveBeenCalledTimes(2);
+  expect(sandboxes.map(sandbox => sandbox.sandboxId)).toEqual(['sb_lazy', 'sb_lazy']);
+});
+
+it('returns an SDK import failure to each concurrent caller', async () => {
+  vi.resetModules();
+  let initialized = 0;
+  vi.doMock('@opencomputer/sdk', () => {
+    initialized++;
+    throw new Error('SDK load failed');
+  });
+
+  const { opencomputer } = await import('../index');
+  const provider = opencomputer({ apiKey: 'test-key' });
+  const outcomes = await Promise.allSettled([
+    provider.sandbox.create(),
+    provider.sandbox.create(),
+  ]);
+
+  expect(initialized).toBe(1);
+  for (const outcome of outcomes) {
+    expect(outcome.status).toBe('rejected');
+    if (outcome.status === 'rejected') {
+      expect(outcome.reason.cause?.message).toBe('SDK load failed');
+    }
+  }
+});

--- a/packages/opencomputer/src/index.ts
+++ b/packages/opencomputer/src/index.ts
@@ -106,20 +106,12 @@ interface OpenComputerSandboxStatic {
   createFromCheckpoint(checkpointId: string, opts?: Pick<OpenComputerSandboxOpts, 'apiKey' | 'apiUrl' | 'timeout' | 'envs' | 'secretStore'>): Promise<OpenComputerNativeSandbox>;
 }
 
-// `@opencomputer/sdk` initialises at import. Starting it here rather than in
-// loadSandbox() means that happens before the first create, not during it.
-//
-// Dynamic, not static: the SDK is ESM-only with top-level await, so a static
-// import compiles to require() in the CJS build and fails to load.
-const _sdkPromise: Promise<OpenComputerSandboxStatic> = import('@opencomputer/sdk')
-  .then((mod) => (mod as { Sandbox: OpenComputerSandboxStatic }).Sandbox);
-
-// Nothing has awaited this yet, so an early failure would surface as an
-// unhandled rejection. The real error still reaches loadSandbox()'s caller.
-void _sdkPromise.catch(() => {});
+let sdkPromise: Promise<OpenComputerSandboxStatic> | undefined;
 
 async function loadSandbox(): Promise<OpenComputerSandboxStatic> {
-  return _sdkPromise;
+  sdkPromise ??= import('@opencomputer/sdk')
+    .then((mod) => (mod as { Sandbox: OpenComputerSandboxStatic }).Sandbox);
+  return sdkPromise;
 }
 
 export interface OpenComputerConfig {


### PR DESCRIPTION
Importing `@computesdk/opencomputer` currently starts `@opencomputer/sdk` even when another provider is selected. With the pinned SDK, this changes the global HTTP dispatcher and starts 48 background health requests. In the ComputeSDK Arker burst benchmark, that work overlaps the measured first connection.

Initialize the cached SDK promise in `loadSandbox()`, following the existing microsandbox pattern. OpenComputer operations still share one initialization, and import failures still reach their callers. Add a patch changeset and regression coverage for unused imports, concurrent creates, and import failures.

Validation:

- Full workspace build passed; OpenComputer build, typecheck, and all 12 tests passed. The new unused-import test fails on the original code and passes with the fix.
- Built original ESM/CJS JavaScript matches published 1.0.4 byte for byte. The fixed runtime diff only changes the lazy import.
- Real native-SDK fixtures for both ESM and CJS: zero unused-provider requests, unchanged dispatcher until use, then one initialization and two native create requests. No live OpenComputer account was used.
- Same east-region G4 environment, cSDK 4.1.4, unchanged 100-way Arker burst workload, no prewarm-disable flags: all 300 original and 300 fixed traced iterations passed. Median timer-to-stream-ready fell from 153.77 ms to 21.83 ms; median fork time fell from 250.41 ms to 137.50 ms.
- A further 100/100 fixed iterations passed with the original benchmark task and all timing instrumentation removed.
- The unmodified DAX workload also passed with instrumentation removed: 1/1 run, all 7 phases, 56.96 seconds, on the existing G4 Ubuntu full VM.

These measurements use a locally built adapter package, not a published release. They demonstrate the connection fix; they are not a claim that server-side run latency is fixed. The three bursts share one cold connection each, so the 300 request measurements are not 300 independent cold connections.
