### PR TITLE
fix(cloud-run): stream writeFile payload via stdin to avoid spawn E2BIG

### DIFF
--- a/.changeset/cloud-run-chunk-writefile.md
+++ b/.changeset/cloud-run-chunk-writefile.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/cloud-run": patch
+---
+
+Chunk `filesystem.writeFile` payloads (adapter and gateway) through a staging file so large writes no longer fail with `spawn E2BIG` from an oversized `/bin/sh -c` argument.

--- a/.changeset/cloud-run-chunk-writefile.md
+++ b/.changeset/cloud-run-chunk-writefile.md
@@ -2,4 +2,4 @@
 "@computesdk/cloud-run": patch
 ---
 
-Chunk `filesystem.writeFile` payloads (adapter and gateway) through a staging file so large writes no longer fail with `spawn E2BIG` from an oversized `/bin/sh -c` argument.
+Pipe `filesystem.writeFile` content to the sandbox CLI via stdin (adapter and gateway) so large writes no longer fail with `spawn E2BIG` from an oversized `/bin/sh -c` argument.

--- a/packages/cloud-run/src/__tests__/write-file.test.ts
+++ b/packages/cloud-run/src/__tests__/write-file.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { buildWriteFileCommands } from '../index'
+
+const MAX_ARG_STRLEN = 128 * 1024
+
+describe('buildWriteFileCommands', () => {
+  it('keeps every command under the Linux single-argument limit for a 100 KiB file', () => {
+    const content = 'x'.repeat(100 * 1024)
+    const { commands, cleanup } = buildWriteFileCommands('/tmp/bench/file.txt', content)
+
+    for (const command of commands) expect(command.length).toBeLessThan(MAX_ARG_STRLEN)
+    expect(commands.length).toBeGreaterThan(3)
+    expect(commands[0]).toMatch(/^mkdir -p "\$\(dirname "\/tmp\/bench\/file\.txt"\)" && : > "\/tmp\/bench\/file\.txt\.computesdk-tmp\.[0-9a-f]{8}"$/)
+    expect(commands.at(-1)).toMatch(/^cat < ".*\.computesdk-tmp\.[0-9a-f]{8}" > "\/tmp\/bench\/file\.txt" && rm -f ".*\.computesdk-tmp\.[0-9a-f]{8}"$/)
+    expect(cleanup).toMatch(/^rm -f "\/tmp\/bench\/file\.txt\.computesdk-tmp\.[0-9a-f]{8}"$/)
+  })
+
+  it('reassembles the original content from the chunked base64 payloads', () => {
+    const content = 'héllo wörld '.repeat(20_000)
+    const { commands } = buildWriteFileCommands('/tmp/a.txt', content)
+    const b64 = commands
+      .slice(1, -1)
+      .map(command => /printf '%s' '([^']*)'/.exec(command)?.[1] ?? '')
+      .join('')
+    expect(Buffer.from(b64, 'base64').toString('utf8')).toBe(content)
+  })
+
+  it('uses a distinct staging file per call', () => {
+    const a = buildWriteFileCommands('/tmp/a.txt', 'a')
+    const b = buildWriteFileCommands('/tmp/a.txt', 'b')
+    expect(a.cleanup).not.toBe(b.cleanup)
+  })
+})

--- a/packages/cloud-run/src/__tests__/write-file.test.ts
+++ b/packages/cloud-run/src/__tests__/write-file.test.ts
@@ -1,33 +1,49 @@
-import { describe, expect, it } from 'vitest'
-import { buildWriteFileCommands } from '../index'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { cloudRun, writeFileCommand } from '../index'
 
-const MAX_ARG_STRLEN = 128 * 1024
+// Stand-in for /usr/local/gcp/bin/sandbox: drops everything up to `--`, then runs
+// the command locally so stdin/argv handling can be exercised without Cloud Run.
+const FAKE_SANDBOX = `#!/bin/sh
+while [ "$1" != "--" ]; do shift; done
+shift
+exec "$@"
+`
 
-describe('buildWriteFileCommands', () => {
-  it('keeps every command under the Linux single-argument limit for a 100 KiB file', () => {
+describe('cloudRun filesystem.writeFile (local CLI mode)', () => {
+  let dir: string
+  let binary: string
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'cloud-run-fs-'))
+    binary = join(dir, 'sandbox')
+    await writeFile(binary, FAKE_SANDBOX)
+    await chmod(binary, 0o755)
+  })
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('pipes the payload through stdin so argv stays small', () => {
+    const command = writeFileCommand('/tmp/bench/file.txt')
+    expect(command).toBe('mkdir -p "$(dirname "/tmp/bench/file.txt")" && base64 -d > "/tmp/bench/file.txt"')
+  })
+
+  it('writes a 100 KiB file and a nested path without spawn E2BIG', async () => {
+    const compute = cloudRun({ sandboxBinary: binary })
+    const sandbox = await compute.sandbox.create()
     const content = 'x'.repeat(100 * 1024)
-    const { commands, cleanup } = buildWriteFileCommands('/tmp/bench/file.txt', content)
+    const target = join(dir, 'nested', 'deep', 'file.txt')
 
-    for (const command of commands) expect(command.length).toBeLessThan(MAX_ARG_STRLEN)
-    expect(commands.length).toBeGreaterThan(3)
-    expect(commands[0]).toMatch(/^mkdir -p "\$\(dirname "\/tmp\/bench\/file\.txt"\)" && : > "\/tmp\/bench\/file\.txt\.computesdk-tmp\.[0-9a-f]{8}"$/)
-    expect(commands.at(-1)).toMatch(/^cat < ".*\.computesdk-tmp\.[0-9a-f]{8}" > "\/tmp\/bench\/file\.txt" && rm -f ".*\.computesdk-tmp\.[0-9a-f]{8}"$/)
-    expect(cleanup).toMatch(/^rm -f "\/tmp\/bench\/file\.txt\.computesdk-tmp\.[0-9a-f]{8}"$/)
-  })
+    await sandbox.filesystem.writeFile(target, content)
+    expect(await readFile(target, 'utf8')).toBe(content)
 
-  it('reassembles the original content from the chunked base64 payloads', () => {
-    const content = 'héllo wörld '.repeat(20_000)
-    const { commands } = buildWriteFileCommands('/tmp/a.txt', content)
-    const b64 = commands
-      .slice(1, -1)
-      .map(command => /printf '%s' '([^']*)'/.exec(command)?.[1] ?? '')
-      .join('')
-    expect(Buffer.from(b64, 'base64').toString('utf8')).toBe(content)
-  })
-
-  it('uses a distinct staging file per call', () => {
-    const a = buildWriteFileCommands('/tmp/a.txt', 'a')
-    const b = buildWriteFileCommands('/tmp/a.txt', 'b')
-    expect(a.cleanup).not.toBe(b.cleanup)
+    const unicode = 'héllo wörld\n'.repeat(1000)
+    await sandbox.filesystem.writeFile(target, unicode)
+    expect(await readFile(target, 'utf8')).toBe(unicode)
+    expect(await sandbox.filesystem.readFile(target)).toBe(unicode)
   })
 })

--- a/packages/cloud-run/src/gateway.ts
+++ b/packages/cloud-run/src/gateway.ts
@@ -12,6 +12,8 @@ import { randomUUID } from 'node:crypto'
 const SANDBOX_BINARY = process.env.CLOUD_RUN_SANDBOX_BINARY ?? '/usr/local/gcp/bin/sandbox'
 const SANDBOX_SECRET = process.env.SANDBOX_SECRET ?? process.env.CLOUD_RUN_SANDBOX_SECRET
 const DEFAULT_TIMEOUT_MS = 300_000
+/** Base64 chars per write command; keeps each `/bin/sh -c` argument under Linux's 128 KiB MAX_ARG_STRLEN. */
+const WRITE_CHUNK_CHARS = 64_000
 
 type Json = Record<string, any>
 
@@ -163,8 +165,19 @@ async function handle(pathname: string, body: Json): Promise<unknown> {
     if (body.content === undefined) throw new Error('Missing required field: content')
     const path = shellEscape(String(body.path))
     const b64 = Buffer.from(String(body.content), 'utf8').toString('base64')
-    const result = await fsCommand(sandboxId, `mkdir -p "$(dirname "${path}")" && printf '%s' '${b64}' | base64 -d > "${path}"`, body)
-    if (result.exitCode !== 0) throw new Error(result.stderr || `Failed to write: ${body.path}`)
+    const staging = `${path}.computesdk-tmp.${randomUUID().slice(0, 8)}`
+    const commands = [`mkdir -p "$(dirname "${path}")" && : > "${staging}"`]
+    for (let i = 0; i < b64.length; i += WRITE_CHUNK_CHARS) {
+      commands.push(`printf '%s' '${b64.slice(i, i + WRITE_CHUNK_CHARS)}' | base64 -d >> "${staging}"`)
+    }
+    commands.push(`cat < "${staging}" > "${path}" && rm -f "${staging}"`)
+    for (const command of commands) {
+      const result = await fsCommand(sandboxId, command, body)
+      if (result.exitCode !== 0) {
+        await fsCommand(sandboxId, `rm -f "${staging}"`, body).catch(() => {})
+        throw new Error(result.stderr || `Failed to write: ${body.path}`)
+      }
+    }
     return { success: true }
   }
 

--- a/packages/cloud-run/src/gateway.ts
+++ b/packages/cloud-run/src/gateway.ts
@@ -12,8 +12,6 @@ import { randomUUID } from 'node:crypto'
 const SANDBOX_BINARY = process.env.CLOUD_RUN_SANDBOX_BINARY ?? '/usr/local/gcp/bin/sandbox'
 const SANDBOX_SECRET = process.env.SANDBOX_SECRET ?? process.env.CLOUD_RUN_SANDBOX_SECRET
 const DEFAULT_TIMEOUT_MS = 300_000
-/** Base64 chars per write command; keeps each `/bin/sh -c` argument under Linux's 128 KiB MAX_ARG_STRLEN. */
-const WRITE_CHUNK_CHARS = 64_000
 
 type Json = Record<string, any>
 
@@ -48,13 +46,15 @@ async function readBody(req: IncomingMessage): Promise<Json> {
   return JSON.parse(Buffer.concat(chunks).toString('utf8'))
 }
 
-async function runSandbox(args: string[], timeout = DEFAULT_TIMEOUT_MS): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function runSandbox(args: string[], timeout = DEFAULT_TIMEOUT_MS, stdin?: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeout)
   return new Promise((resolve, reject) => {
-    const child = spawn(SANDBOX_BINARY, args, { stdio: ['ignore', 'pipe', 'pipe'], signal: controller.signal })
+    const child = spawn(SANDBOX_BINARY, args, { stdio: ['pipe', 'pipe', 'pipe'], signal: controller.signal })
     let stdout = ''
     let stderr = ''
+    child.stdin.on('error', () => {})
+    child.stdin.end(stdin)
     child.stdout.on('data', chunk => { stdout += chunk.toString('utf8') })
     child.stderr.on('data', chunk => { stderr += chunk.toString('utf8') })
     child.on('error', error => {
@@ -97,24 +97,24 @@ function pushRunArgs(args: string[], body: Json, forceWrite = false): void {
   args.push(...((body.runArgs ?? []) as string[]))
 }
 
-async function doCommand(command: string, body: Json = {}) {
+async function doCommand(command: string, body: Json = {}, stdin?: string) {
   const args = ['do']
   pushRunArgs(args, body, true)
   args.push('--', '/bin/sh', '-c', command)
-  return runSandbox(args, body.timeout)
+  return runSandbox(args, body.timeout, stdin)
 }
 
-async function execCommand(sandboxId: string, command: string, body: Json = {}) {
+async function execCommand(sandboxId: string, command: string, body: Json = {}, stdin?: string) {
   const args = ['exec', sandboxId]
   pushExecArgs(args, body)
   args.push('--', '/bin/sh', '-c', command)
-  return runSandbox(args, body.timeout)
+  return runSandbox(args, body.timeout, stdin)
 }
 
-async function fsCommand(sandboxId: string, command: string, body: Json = {}) {
+async function fsCommand(sandboxId: string, command: string, body: Json = {}, stdin?: string) {
   return body.executionMode === 'stateful'
-    ? execCommand(sandboxId, command, body)
-    : doCommand(command, body)
+    ? execCommand(sandboxId, command, body, stdin)
+    : doCommand(command, body, stdin)
 }
 
 async function handle(pathname: string, body: Json): Promise<unknown> {
@@ -165,19 +165,8 @@ async function handle(pathname: string, body: Json): Promise<unknown> {
     if (body.content === undefined) throw new Error('Missing required field: content')
     const path = shellEscape(String(body.path))
     const b64 = Buffer.from(String(body.content), 'utf8').toString('base64')
-    const staging = `${path}.computesdk-tmp.${randomUUID().slice(0, 8)}`
-    const commands = [`mkdir -p "$(dirname "${path}")" && : > "${staging}"`]
-    for (let i = 0; i < b64.length; i += WRITE_CHUNK_CHARS) {
-      commands.push(`printf '%s' '${b64.slice(i, i + WRITE_CHUNK_CHARS)}' | base64 -d >> "${staging}"`)
-    }
-    commands.push(`cat < "${staging}" > "${path}" && rm -f "${staging}"`)
-    for (const command of commands) {
-      const result = await fsCommand(sandboxId, command, body)
-      if (result.exitCode !== 0) {
-        await fsCommand(sandboxId, `rm -f "${staging}"`, body).catch(() => {})
-        throw new Error(result.stderr || `Failed to write: ${body.path}`)
-      }
-    }
+    const result = await fsCommand(sandboxId, `mkdir -p "$(dirname "${path}")" && base64 -d > "${path}"`, body, b64)
+    if (result.exitCode !== 0) throw new Error(result.stderr || `Failed to write: ${body.path}`)
     return { success: true }
   }
 

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -22,6 +22,8 @@ import type {
 const PROVIDER = 'cloud-run' as const
 const DEFAULT_SANDBOX_BINARY = '/usr/local/gcp/bin/sandbox'
 const DEFAULT_TIMEOUT_MS = 300_000
+/** Base64 chars per write command; keeps each `/bin/sh -c` argument under Linux's 128 KiB MAX_ARG_STRLEN. */
+const WRITE_CHUNK_CHARS = 64_000
 
 export interface CloudRunMount {
   type?: 'bind'
@@ -291,6 +293,21 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
 
 type FsRunCommand = (sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
 
+/**
+ * Shell commands that write `content` to `escapedPath` in bounded chunks via a
+ * staging file, so no single command argument exceeds the OS argv limit.
+ */
+export function buildWriteFileCommands(escapedPath: string, content: string): { commands: string[]; cleanup: string } {
+  const b64 = Buffer.from(content, 'utf8').toString('base64')
+  const staging = `${escapedPath}.computesdk-tmp.${randomUUID().slice(0, 8)}`
+  const commands: string[] = [`mkdir -p "$(dirname "${escapedPath}")" && : > "${staging}"`]
+  for (let i = 0; i < b64.length; i += WRITE_CHUNK_CHARS) {
+    commands.push(`printf '%s' '${b64.slice(i, i + WRITE_CHUNK_CHARS)}' | base64 -d >> "${staging}"`)
+  }
+  commands.push(`cat < "${staging}" > "${escapedPath}" && rm -f "${staging}"`)
+  return { commands, cleanup: `rm -f "${staging}"` }
+}
+
 export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
   name: PROVIDER,
   methods: {
@@ -403,10 +420,14 @@ export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
             await gatewayRequest(sandbox.config, '/v1/sandbox/writeFile', sandboxRequestBody(sandbox.config, { sandboxId: sandbox.id, path, content }))
             return
           }
-          const escapedPath = escapeShellArg(path)
-          const b64 = Buffer.from(content, 'utf8').toString('base64')
-          const r = await runCommand(sandbox, `mkdir -p "$(dirname "${escapedPath}")" && printf '%s' '${b64}' | base64 -d > "${escapedPath}"`)
-          if (r.exitCode !== 0) throw new Error(r.stderr || `Failed to write: ${path}`)
+          const { commands, cleanup } = buildWriteFileCommands(escapeShellArg(path), content)
+          for (const command of commands) {
+            const r = await runCommand(sandbox, command)
+            if (r.exitCode !== 0) {
+              await runCommand(sandbox, cleanup).catch(() => {})
+              throw new Error(r.stderr || `Failed to write: ${path}`)
+            }
+          }
         },
         mkdir: async (sandbox: CloudRunSandbox, path: string, runCommand: FsRunCommand): Promise<void> => {
           if (sandbox.remote) {

--- a/packages/cloud-run/src/index.ts
+++ b/packages/cloud-run/src/index.ts
@@ -22,8 +22,6 @@ import type {
 const PROVIDER = 'cloud-run' as const
 const DEFAULT_SANDBOX_BINARY = '/usr/local/gcp/bin/sandbox'
 const DEFAULT_TIMEOUT_MS = 300_000
-/** Base64 chars per write command; keeps each `/bin/sh -c` argument under Linux's 128 KiB MAX_ARG_STRLEN. */
-const WRITE_CHUNK_CHARS = 64_000
 
 export interface CloudRunMount {
   type?: 'bind'
@@ -201,18 +199,21 @@ function buildBaseArgs(config: CloudRunConfig): string[] {
 async function runSandboxCli(
   config: CloudRunConfig,
   args: string[],
-  options?: { timeout?: number; onStdout?: (data: string) => void; onStderr?: (data: string) => void }
+  options?: { timeout?: number; stdin?: string; onStdout?: (data: string) => void; onStderr?: (data: string) => void }
 ): Promise<SpawnResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), options?.timeout ?? DEFAULT_TIMEOUT_MS)
 
   return new Promise<SpawnResult>((resolve, reject) => {
     const child = spawn(getBinary(config), args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['pipe', 'pipe', 'pipe'],
       signal: controller.signal,
     })
     let stdout = ''
     let stderr = ''
+
+    child.stdin.on('error', () => {})
+    child.stdin.end(options?.stdin)
 
     child.stdout.on('data', (chunk: Buffer) => {
       const data = chunk.toString('utf8')
@@ -250,7 +251,7 @@ function withShellOptions(command: string, options?: RunCommandOptions): string 
   return fullCommand
 }
 
-async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions): Promise<CommandResult> {
+async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions, stdin?: string): Promise<CommandResult> {
   const start = performance.now()
   if (sandbox.remote) {
     try {
@@ -285,6 +286,7 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
   args.push('--', '/bin/sh', '-c', withShellOptions(command, options))
   const result = await runSandboxCli(sandbox.config, args, {
     timeout: options?.timeout,
+    stdin,
     onStdout: options?.onStdout,
     onStderr: options?.onStderr,
   })
@@ -293,19 +295,9 @@ async function execInSandbox(sandbox: CloudRunSandbox, command: string, options?
 
 type FsRunCommand = (sandbox: CloudRunSandbox, command: string, options?: RunCommandOptions) => Promise<CommandResult>
 
-/**
- * Shell commands that write `content` to `escapedPath` in bounded chunks via a
- * staging file, so no single command argument exceeds the OS argv limit.
- */
-export function buildWriteFileCommands(escapedPath: string, content: string): { commands: string[]; cleanup: string } {
-  const b64 = Buffer.from(content, 'utf8').toString('base64')
-  const staging = `${escapedPath}.computesdk-tmp.${randomUUID().slice(0, 8)}`
-  const commands: string[] = [`mkdir -p "$(dirname "${escapedPath}")" && : > "${staging}"`]
-  for (let i = 0; i < b64.length; i += WRITE_CHUNK_CHARS) {
-    commands.push(`printf '%s' '${b64.slice(i, i + WRITE_CHUNK_CHARS)}' | base64 -d >> "${staging}"`)
-  }
-  commands.push(`cat < "${staging}" > "${escapedPath}" && rm -f "${staging}"`)
-  return { commands, cleanup: `rm -f "${staging}"` }
+/** Shell command that decodes base64 from stdin into `escapedPath`; the payload never enters argv. */
+export function writeFileCommand(escapedPath: string): string {
+  return `mkdir -p "$(dirname "${escapedPath}")" && base64 -d > "${escapedPath}"`
 }
 
 export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
@@ -420,14 +412,8 @@ export const cloudRun = defineProvider<CloudRunSandbox, CloudRunConfig>({
             await gatewayRequest(sandbox.config, '/v1/sandbox/writeFile', sandboxRequestBody(sandbox.config, { sandboxId: sandbox.id, path, content }))
             return
           }
-          const { commands, cleanup } = buildWriteFileCommands(escapeShellArg(path), content)
-          for (const command of commands) {
-            const r = await runCommand(sandbox, command)
-            if (r.exitCode !== 0) {
-              await runCommand(sandbox, cleanup).catch(() => {})
-              throw new Error(r.stderr || `Failed to write: ${path}`)
-            }
-          }
+          const r = await execInSandbox(sandbox, writeFileCommand(escapeShellArg(path)), undefined, Buffer.from(content, 'utf8').toString('base64'))
+          if (r.exitCode !== 0) throw new Error(r.stderr || `Failed to write: ${path}`)
         },
         mkdir: async (sandbox: CloudRunSandbox, path: string, runCommand: FsRunCommand): Promise<void> => {
           if (sandbox.remote) {


### PR DESCRIPTION
## Summary

The `sandbox-tmp-filesystem` benchmark fails on Cloud Run with `spawn E2BIG`. Both the gateway (`/v1/sandbox/writeFile`) and the local-CLI adapter base64-encoded the whole file into a single `/bin/sh -c '... printf "%s" "<b64>" | base64 -d > path'` argument passed to `spawn(sandboxBinary, args)`. A 100 KiB file becomes ~137 KB in one argv entry, over Linux's 128 KiB `MAX_ARG_STRLEN`, so `spawn` fails before the `sandbox` binary ever runs.

Fix: keep the command tiny and feed the base64 payload to the `sandbox` process over stdin, in one invocation:

```
spawn(sandbox, [..., '--', '/bin/sh', '-c', 'mkdir -p "$(dirname "<path>")" && base64 -d > "<path>"'], { stdio: ['pipe', ...] })
child.stdin.end(b64)
```

`runSandboxCli` / gateway `runSandbox` gain an optional `stdin` parameter (stdin is now always a pipe, closed immediately when no payload is given). Applied in `packages/cloud-run/src/gateway.ts` (what the benchmark hits in remote mode — the deployed gateway needs a redeploy to pick this up) and `packages/cloud-run/src/index.ts` (local CLI mode). No staging file, so no cross-`sandbox do` persistence or extra directory-permission requirements.

Unit test drives the local adapter through a fake `sandbox` binary (drops args up to `--` and `exec`s the rest) and verifies a 100 KiB write into a nested path plus a UTF-8 round trip. Not verified against a live Cloud Run gateway here — it relies on the `sandbox` CLI forwarding stdin to `do`/`exec` (its `--stdin` flag suggests it does). `pnpm --filter @computesdk/cloud-run typecheck|lint|test|build` all pass.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->