### PR TITLE
Fix Beam deferred command completion

### DIFF
--- a/packages/beam/package.json
+++ b/packages/beam/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@beamcloud/beam-js": "^1.0.17",
+    "@beamcloud/beam-js": "^1.0.18",
     "computesdk": "workspace:*",
     "@computesdk/provider": "workspace:*"
   },

--- a/packages/beam/src/__tests__/index.test.ts
+++ b/packages/beam/src/__tests__/index.test.ts
@@ -88,4 +88,39 @@ describe('lazy sandbox readiness', () => {
 
     expect(connect).not.toHaveBeenCalled();
   });
+
+  test('reads command output after the process finishes', async () => {
+    const instance = mockSandbox();
+    const process = await instance.exec(['true']);
+    let finished = false;
+    vi.mocked(process.wait).mockImplementation(async () => {
+      finished = true;
+      process.exitCode = 0;
+      return 0;
+    });
+    vi.mocked(process.stdout.read).mockImplementation(async () => {
+      expect(finished).toBe(true);
+      return 'complete output\n';
+    });
+    vi.mocked(instance.exec).mockResolvedValue(process);
+
+    const sandbox = await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create();
+    await expect(sandbox.runCommand('sleep 1; echo complete output')).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: 'complete output\n',
+    });
+    expect(process.wait).toHaveBeenCalledOnce();
+  });
+
+  test('reuses the sandbox builder across equivalent provider instances', async () => {
+    mockSandbox();
+    const options = { name: 'computesdk-benchmarks', runtime: 'node' };
+
+    await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create(options);
+    await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create(options);
+
+    const create = vi.mocked(Sandbox.prototype.create);
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.instances[0]).toBe(create.mock.instances[1]);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
   packages/beam:
     dependencies:
       '@beamcloud/beam-js':
-        specifier: ^1.0.17
-        version: 1.0.17(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
+        specifier: ^1.0.18
+        version: 1.0.18(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)
       '@computesdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -2925,8 +2925,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.17':
-    resolution: {integrity: sha512-LcgLeUDYZajTOktXXwRiWH6waE7ikWdaM5PjVv0bctjEOxwwFuUEtEc2iyj3SYAXaCJaXDiWs1LSB5frIkzBhQ==}
+  '@beamcloud/beam-js@1.0.18':
+    resolution: {integrity: sha512-G6rAd3PD/jfLvDO+WFoR+Rf7AuzbJ3rgEtTPiK+z0p4CDsTli6vxGA0zy/f8EqZ7i4OeCPlqmlp9sOeVmGE73Q==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -10256,7 +10256,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.17(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.18(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)':
     dependencies:
       axios: 1.18.1
       commander: 12.1.0


### PR DESCRIPTION
## Summary
- require @beamcloud/beam-js 1.0.18 so deferred sandbox commands are polled to completion
- cover complete command output and cross-provider sandbox builder reuse

## Validation
- `pnpm build`
- `pnpm --filter @computesdk/beam test` (19/19)
- `pnpm --filter @computesdk/beam typecheck`
- production DAX validation: 7/7 phases, exit 0
- in-cluster warm burst validation: 25/25, 160 ms median TTI, 473 ms p95

No changeset is included.