### PR TITLE
chore(beam): add changeset for beam-js 1.0.18 deferred command fix

### DIFF
--- a/.changeset/beam-js-1-0-18.md
+++ b/.changeset/beam-js-1-0-18.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/beam": patch
+---
+
+Update `@beamcloud/beam-js` to 1.0.18 so deferred sandbox commands complete and their output is read after the process finishes.


### PR DESCRIPTION
## Summary
#779 bumped `@beamcloud/beam-js` to 1.0.18 (fixing deferred sandbox commands) without a changeset, so `@computesdk/beam` would not be released. Adds a `patch` changeset for it.

Link to Devin session: https://app.devin.ai/sessions/a619796083d34a3483b4aa2ae24cad18
Open in Devin Desktop: https://app.devin.ai/desktop/session/a619796083d34a3483b4aa2ae24cad18?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->