### PR TITLE
fix(vercel): use @vercel/sandbox `sandbox.fs` for directory operations

### DIFF
--- a/.changeset/vercel-fs-methods.md
+++ b/.changeset/vercel-fs-methods.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/vercel": patch
+---
+
+Route mkdir/readdir/exists/remove through `sandbox.fs`. `mkdir` now creates parent directories (the raw `Sandbox.mkDir` API is non-recursive and failed with "error creating directory: No such file or directory" for nested paths), and `readdir`/`exists`/`remove` are implemented instead of throwing "not supported".

--- a/packages/vercel/src/__tests__/filesystem-unit.test.ts
+++ b/packages/vercel/src/__tests__/filesystem-unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { vercel } from '../index';
+
+const fs = vi.hoisted(() => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readdir: vi.fn(),
+  exists: vi.fn(),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@vercel/sandbox', () => {
+  const mockSandboxInstance = {
+    name: 'mock-sandbox-id',
+    fs,
+    mkDir: vi.fn().mockRejectedValue(new Error('Status code 400 is not ok: error creating directory: No such file or directory')),
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    Sandbox: {
+      create: vi.fn().mockResolvedValue(mockSandboxInstance),
+      get: vi.fn().mockResolvedValue(mockSandboxInstance),
+    },
+    Snapshot: { get: vi.fn() },
+  };
+});
+
+describe('Vercel filesystem via sandbox.fs', () => {
+  const provider = vercel({ token: 't', teamId: 'team', projectId: 'proj' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mkdir creates parent directories recursively instead of using the non-recursive mkDir API', async () => {
+    const sandbox = await provider.sandbox.create();
+    await sandbox.filesystem.mkdir('/tmp/bench/fs-123');
+    expect(fs.mkdir).toHaveBeenCalledWith('/tmp/bench/fs-123', { recursive: true });
+  });
+
+  it('readdir maps dirents to FileEntry', async () => {
+    fs.readdir.mockResolvedValue([
+      { name: 'a.txt', isDirectory: () => false },
+      { name: 'sub', isDirectory: () => true },
+    ]);
+    const sandbox = await provider.sandbox.create();
+    expect(await sandbox.filesystem.readdir('/tmp/bench')).toEqual([
+      { name: 'a.txt', type: 'file' },
+      { name: 'sub', type: 'directory' },
+    ]);
+    expect(fs.readdir).toHaveBeenCalledWith('/tmp/bench', { withFileTypes: true });
+  });
+
+  it('exists delegates to fs.exists', async () => {
+    fs.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const sandbox = await provider.sandbox.create();
+    expect(await sandbox.filesystem.exists('/tmp/bench')).toBe(true);
+    expect(await sandbox.filesystem.exists('/nope')).toBe(false);
+  });
+
+  it('remove is recursive and tolerates missing paths', async () => {
+    const sandbox = await provider.sandbox.create();
+    await sandbox.filesystem.remove('/tmp/bench');
+    expect(fs.rm).toHaveBeenCalledWith('/tmp/bench', { recursive: true, force: true });
+  });
+});

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -208,15 +208,21 @@ export const vercel = defineProvider<VercelSandbox, VercelConfig, any, VercelSna
         writeFile: async (sandbox: VercelSandbox, path: string, content: string): Promise<void> => {
           await sandbox.writeFiles([{ path, content: Buffer.from(content) }]);
         },
-        mkdir: async (sandbox: VercelSandbox, path: string): Promise<void> => { await sandbox.mkDir(path); },
-        readdir: async (_sandbox: VercelSandbox, _path: string): Promise<FileEntry[]> => {
-          throw new Error('Vercel sandbox does not support readdir.');
+        mkdir: async (sandbox: VercelSandbox, path: string): Promise<void> => {
+          await sandbox.fs.mkdir(path, { recursive: true });
         },
-        exists: async (_sandbox: VercelSandbox, _path: string): Promise<boolean> => {
-          throw new Error('Vercel sandbox does not support exists.');
+        readdir: async (sandbox: VercelSandbox, path: string): Promise<FileEntry[]> => {
+          const entries = await sandbox.fs.readdir(path, { withFileTypes: true });
+          return entries.map((entry) => ({
+            name: entry.name,
+            type: entry.isDirectory() ? 'directory' : 'file',
+          }));
         },
-        remove: async (_sandbox: VercelSandbox, _path: string): Promise<void> => {
-          throw new Error('Vercel sandbox does not support remove.');
+        exists: async (sandbox: VercelSandbox, path: string): Promise<boolean> => {
+          return sandbox.fs.exists(path);
+        },
+        remove: async (sandbox: VercelSandbox, path: string): Promise<void> => {
+          await sandbox.fs.rm(path, { recursive: true, force: true });
         }
       },
 


### PR DESCRIPTION
## Summary

`@vercel/sandbox@3.x` ships a `node:fs/promises`-style filesystem API on `sandbox.fs` (`mkdir`, `readdir`, `stat`, `exists`, `rm`, …), executed inside the sandbox. `@computesdk/vercel` predates it: `mkdir` called the low-level `Sandbox.mkDir(path)` REST endpoint, which is non-recursive and rejects any path whose parent doesn't exist (`Status code 400 is not ok: error creating directory: No such file or directory`), and `readdir`/`exists`/`remove` simply threw "not supported".

This updates the provider's `filesystem` methods to the current `sandbox.fs` API so they match ComputeSDK's semantics (`mkdir` = `mkdir -p`, `remove` = `rm -rf`) and fill in the missing operations:

```diff
- mkdir:   sandbox.mkDir(path)                         // non-recursive REST call
+ mkdir:   sandbox.fs.mkdir(path, { recursive: true })
- readdir: throw 'not supported'
+ readdir: sandbox.fs.readdir(path, { withFileTypes: true }) → { name, type: 'file' | 'directory' }
- exists:  throw 'not supported'
+ exists:  sandbox.fs.exists(path)
- remove:  throw 'not supported'
+ remove:  sandbox.fs.rm(path, { recursive: true, force: true })   // missing path is a no-op
```

`readFile`/`writeFile` are unchanged (they already use the native `readFile`/`writeFiles` APIs).

Adds `packages/vercel/src/__tests__/filesystem-unit.test.ts` (mocked `@vercel/sandbox`) covering the four mappings, plus a patch changeset. The `vercel` provider/computesdk integration CI jobs on this PR exercise the change against a live sandbox.

Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->