### PR TITLE
fix(beam): use native sandbox.fs for readFile/writeFile

### DIFF
--- a/.changeset/beam-native-fs-readwrite.md
+++ b/.changeset/beam-native-fs-readwrite.md
@@ -1,0 +1,5 @@
+---
+"@computesdk/beam": patch
+---
+
+Route `filesystem.writeFile`/`readFile` through Beam's native `sandbox.fs.writeText`/`readText` instead of embedding the base64 payload in a shell command, which failed with `fork/exec /usr/bin/sh: argument list too long` for files over ~100 KiB.

--- a/packages/beam/src/__tests__/index.test.ts
+++ b/packages/beam/src/__tests__/index.test.ts
@@ -41,6 +41,8 @@ function mockSandbox() {
     exposePort: vi.fn().mockResolvedValue('https://sandbox.example'),
     fs: {
       listFiles: vi.fn().mockResolvedValue([]),
+      writeText: vi.fn().mockResolvedValue(undefined),
+      readText: vi.fn().mockResolvedValue(''),
     },
   } as unknown as SandboxInstance;
   vi.spyOn(Sandbox.prototype, 'create').mockResolvedValue(instance);
@@ -110,6 +112,30 @@ describe('lazy sandbox readiness', () => {
       stdout: 'complete output\n',
     });
     expect(process.wait).toHaveBeenCalledOnce();
+  });
+
+  test('writes and reads files through the native fs API instead of shell arguments', async () => {
+    const instance = mockSandbox();
+    vi.spyOn(Sandbox, 'connect').mockResolvedValue(instance);
+    const content = 'x'.repeat(100 * 1024);
+    vi.mocked(instance.fs.readText).mockResolvedValue(content);
+
+    const sandbox = await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create();
+    await sandbox.filesystem.writeFile('/tmp/bench/file-0.txt', content);
+    await expect(sandbox.filesystem.readFile('/tmp/bench/file-0.txt')).resolves.toBe(content);
+
+    expect(instance.fs.writeText).toHaveBeenCalledWith('/tmp/bench/file-0.txt', content);
+    expect(instance.fs.readText).toHaveBeenCalledWith('/tmp/bench/file-0.txt');
+    expect(instance.exec).not.toHaveBeenCalled();
+  });
+
+  test('wraps native fs errors with the file path', async () => {
+    const instance = mockSandbox();
+    vi.spyOn(Sandbox, 'connect').mockResolvedValue(instance);
+    vi.mocked(instance.fs.readText).mockRejectedValue(new Error('no such file'));
+
+    const sandbox = await beam({ token: 'token', workspaceId: 'workspace' }).sandbox.create();
+    await expect(sandbox.filesystem.readFile('/missing.txt')).rejects.toThrow('Failed to read file /missing.txt: no such file');
   });
 
   test('reuses the sandbox builder across equivalent provider instances', async () => {

--- a/packages/beam/src/index.ts
+++ b/packages/beam/src/index.ts
@@ -265,15 +265,21 @@ export const beam = defineProvider<SandboxInstance, BeamConfig>({
       },
 
       filesystem: {
-        readFile: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<string> => {
-          const result = await runCommand(sandbox, `cat ${shellEscape(path)}`);
-          if (result.exitCode !== 0) throw new Error(`Failed to read file ${path}: ${result.stderr}`);
-          return result.stdout;
+        readFile: async (sandbox: SandboxInstance, path: string, _runCommand: RunCommandFn): Promise<string> => {
+          await ensureSandboxReady(sandbox);
+          try {
+            return await sandbox.fs.readText(path);
+          } catch (error) {
+            throw new Error(`Failed to read file ${path}: ${error instanceof Error ? error.message : String(error)}`);
+          }
         },
-        writeFile: async (sandbox: SandboxInstance, path: string, content: string, runCommand: RunCommandFn): Promise<void> => {
-          const b64 = Buffer.from(content).toString('base64');
-          const result = await runCommand(sandbox, `echo '${b64}' | base64 -d > ${shellEscape(path)}`);
-          if (result.exitCode !== 0) throw new Error(`Failed to write file ${path}: ${result.stderr}`);
+        writeFile: async (sandbox: SandboxInstance, path: string, content: string, _runCommand: RunCommandFn): Promise<void> => {
+          await ensureSandboxReady(sandbox);
+          try {
+            await sandbox.fs.writeText(path, content);
+          } catch (error) {
+            throw new Error(`Failed to write file ${path}: ${error instanceof Error ? error.message : String(error)}`);
+          }
         },
         mkdir: async (sandbox: SandboxInstance, path: string, runCommand: RunCommandFn): Promise<void> => {
           const result = await runCommand(sandbox, `mkdir -p ${shellEscape(path)}`);


### PR DESCRIPTION
## Summary

`@computesdk/beam`'s `filesystem.writeFile` embedded the whole base64 payload in a shell command:

```ts
runCommand(sandbox, `echo '${b64}' | base64 -d > ${path}`)
```

For files around 100 KiB the base64 string exceeds the per-argument limit, and `sandbox.exec(['sh','-c', ...])` fails with `fork/exec /usr/bin/sh: argument list too long`.

`@beamcloud/beam-js` already exposes a native file API (`sandbox.fs.writeText` / `readText`, which POST the content to the gateway `files/upload` endpoint — no shell involved). This PR routes `writeFile` and `readFile` through it, gated by the same `ensureSandboxReady` used by `readdir`:

```diff
- readFile:  runCommand(`cat ${path}`)
+ readFile:  sandbox.fs.readText(path)
- writeFile: runCommand(`echo '<b64>' | base64 -d > ${path}`)
+ writeFile: sandbox.fs.writeText(path, content)
```

Errors are wrapped as `Failed to read/write file <path>: <message>` as before. `mkdir`/`exists`/`remove` still use shell commands (small, fixed-size).

Adds unit tests (100 KiB round-trip without `exec`, error wrapping) and a patch changeset.


Link to Devin session: https://app.devin.ai/sessions/3fd75dbeb04840ae8b62f6ac520e3ccb
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fd75dbeb04840ae8b62f6ac520e3ccb?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/computesdk/pull/783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->